### PR TITLE
added `getWeeklySchedule(week, year, seasonType)` to NFL service

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ Gets the College Football scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.cfb.getScoreboard(year = 2019, month = 11, day = 16, group=80)
+const result = await sdv.cfb.getScoreboard(
+year = 2019, month = 11, day = 16, group=80
+)
 ```
 <a name="cfb.getConferences"></a>
 
@@ -302,7 +304,8 @@ Gets the list of all College Football conferences and their identification info 
 
 **Example**  
 ```js
-const yr = 2021;const result = await sdv.cfb.getConferences(year = yr, group = 80);
+const yr = 2021;
+const result = await sdv.cfb.getConferences(year = yr, group = 80);
 ```
 <a name="cfb.getStandings"></a>
 
@@ -319,7 +322,8 @@ Gets the team standings for College Football.
 
 **Example**  
 ```js
-const yr = 2020;const result = await sdv.cfb.getStandings(year = yr);
+const yr = 2020;
+const result = await sdv.cfb.getStandings(year = yr);
 ```
 <a name="cfb.getTeamList"></a>
 
@@ -351,7 +355,8 @@ Gets the team info for a specific College Football team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.cfb.getTeamInfo(teamId);
+const teamId = 52;
+const result = await sdv.cfb.getTeamInfo(teamId);
 ```
 <a name="cfb.getTeamPlayers"></a>
 
@@ -366,7 +371,8 @@ Gets the team roster information for a specific College Football team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.cfb.getTeamPlayers(teamId);
+const teamId = 52;
+const result = await sdv.cfb.getTeamPlayers(teamId);
 ```
 
 Operations for Men's College Basketball.
@@ -469,7 +475,9 @@ Gets the Men's College Basketball rankings data for a specified year and week if
 
 **Example**  
 ```js
-const result = await sdv.mbb.getRankings(year = 2020, week = 15)
+const result = await sdv.mbb.getRankings(
+year = 2020, week = 15
+)
 ```
 <a name="mbb.getPlayerRankings"></a>
 
@@ -541,7 +549,9 @@ Gets the Men's College Basketball schedule data for a specified date if availabl
 
 **Example**  
 ```js
-const result = await sdv.mbb.getSchedule(year = 2021, month = 02, day = 15, group=50)
+const result = await sdv.mbb.getSchedule(
+year = 2021, month = 02, day = 15, group=50
+)
 ```
 <a name="mbb.getScoreboard"></a>
 
@@ -562,7 +572,9 @@ Gets the Men's College Basketball scoreboard data for a specified date if availa
 
 **Example**  
 ```js
-const result = await sdv.mbb.getScoreboard(year = 2021, month = 02, day = 15, group=50)
+const result = await sdv.mbb.getScoreboard(
+year = 2021, month = 02, day = 15, group=50
+)
 ```
 <a name="mbb.getConferences"></a>
 
@@ -579,7 +591,8 @@ Gets the Men's College Basketball Conferences.
 
 **Example**  
 ```js
-const yr = 2021;const result = await sdv.mbb.getConferences(year = yr, group = 50);
+const yr = 2021;
+const result = await sdv.mbb.getConferences(year = yr, group = 50);
 ```
 <a name="mbb.getStandings"></a>
 
@@ -596,7 +609,8 @@ Gets the team standings for Men's College Basketball.
 
 **Example**  
 ```js
-const yr = 2020;const result = await sdv.mbb.getStandings(year = yr);
+const yr = 2020;
+const result = await sdv.mbb.getStandings(year = yr);
 ```
 <a name="mbb.getTeamList"></a>
 
@@ -628,7 +642,8 @@ Gets the team info for a specific College Basketball team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.mbb.getTeamInfo(teamId);
+const teamId = 52;
+const result = await sdv.mbb.getTeamInfo(teamId);
 ```
 <a name="mbb.getTeamPlayers"></a>
 
@@ -644,7 +659,8 @@ Gets the team roster information for a specific Men's College Basketball team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.mbb.getTeamPlayers(teamId);
+const teamId = 52;
+const result = await sdv.mbb.getTeamPlayers(teamId);
 ```
 
 Operations for MLB.
@@ -743,7 +759,9 @@ Gets the MLB schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.mlb.getSchedule(year = 2016, month = 04, day = 15)
+const result = await sdv.mlb.getSchedule(
+year = 2016, month = 04, day = 15
+)
 ```
 <a name="mlb.getScoreboard"></a>
 
@@ -762,7 +780,9 @@ Gets the MLB scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.mlb.getScoreboard(year = 2019, month = 11, day = 16)
+const result = await sdv.mlb.getScoreboard(
+year = 2019, month = 11, day = 16
+)
 ```
 <a name="mlb.getStandings"></a>
 
@@ -779,7 +799,8 @@ Gets the team standings for the MLB.
 
 **Example**  
 ```js
-const yr = 2016;const result = await sdv.mlb.getStandings(year = yr);
+const yr = 2016;
+const result = await sdv.mlb.getStandings(year = yr);
 ```
 <a name="mlb.getTeamList"></a>
 
@@ -806,7 +827,8 @@ Gets the team info for a specific MLB team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.mlb.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.mlb.getTeamInfo(teamId);
 ```
 <a name="mlb.getTeamPlayers"></a>
 
@@ -822,7 +844,8 @@ Gets the team roster information for a specific MLB team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.mlb.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.mlb.getTeamPlayers(teamId);
 ```
 
 Operations for NBA.
@@ -921,7 +944,9 @@ Gets the NBA schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nba.getSchedule(year = 2016, month = 04, day = 15)
+const result = await sdv.nba.getSchedule(
+year = 2016, month = 04, day = 15
+)
 ```
 <a name="nba.getScoreboard"></a>
 
@@ -940,7 +965,9 @@ Gets the NBA scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nba.getScoreboard(year = 2019, month = 11, day = 16)
+const result = await sdv.nba.getScoreboard(
+year = 2019, month = 11, day = 16
+)
 ```
 <a name="nba.getStandings"></a>
 
@@ -957,7 +984,8 @@ Gets the team standings for the NBA.
 
 **Example**  
 ```js
-const yr = 2016;const result = await sdv.nba.getStandings(year = yr);
+const yr = 2016;
+const result = await sdv.nba.getStandings(year = yr);
 ```
 <a name="nba.getTeamList"></a>
 
@@ -984,7 +1012,8 @@ Gets the team info for a specific NBA team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nba.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.nba.getTeamInfo(teamId);
 ```
 <a name="nba.getTeamPlayers"></a>
 
@@ -1000,7 +1029,8 @@ Gets the team roster information for a specific NBA team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nba.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.nba.getTeamPlayers(teamId);
 ```
 
 Operations for NCAA Sports.
@@ -1025,7 +1055,8 @@ Operations for NCAA Sports.
 <a name="ncaa.getRedirectUrl"></a>
 
 ### ncaa.getRedirectUrl(url) ⇒
-Gets the gameId for older games whose url redirects to the current url pattern using thegame url fragment (relative to [https://ncaa.com](https://ncaa.com)) pulled from ncaaScoreboard
+Gets the gameId for older games whose url redirects to the current url pattern using the
+game url fragment (relative to [https://ncaa.com](https://ncaa.com)) pulled from ncaaScoreboard
 
 **Kind**: static method of [<code>ncaa</code>](#ncaa)  
 **Returns**: json  
@@ -1036,7 +1067,11 @@ Gets the gameId for older games whose url redirects to the current url pattern u
 
 **Example**  
 ```js
-const result = await sdv.ncaaScoreboard.getNcaaScoreboard(sport = 'basketball-men', division = 'd3', year = 2019, month = 02, day = 15)const urlGame = result["games"][16]["game"]["url"]const gameId = await sdv.ncaa.getRedirectUrl(url=urlGame);
+const result = await sdv.ncaaScoreboard.getNcaaScoreboard(
+sport = 'basketball-men', division = 'd3', year = 2019, month = 02, day = 15
+)
+const urlGame = result["games"][16]["game"]["url"]
+const gameId = await sdv.ncaa.getRedirectUrl(url=urlGame);
 ```
 <a name="ncaa.getInfo"></a>
 
@@ -1136,7 +1171,9 @@ Gets the scoreboard data for a specified date and team sport if available.
 
 **Example**  
 ```js
-const result = await sdv.ncaa.getScoreboard(sport = 'basketball-men', division = 'd3', year = 2019, month = 02, day = 15)
+const result = await sdv.ncaa.getScoreboard(
+sport = 'basketball-men', division = 'd3', year = 2019, month = 02, day = 15
+)
 ```
 <a name="ncaa.getSports"></a>
 
@@ -1257,6 +1294,7 @@ Operations for NFL.
     * [.getSummary(id)](#nfl.getSummary) ⇒
     * [.getPicks(id)](#nfl.getPicks) ⇒
     * [.getSchedule(year, month, day)](#nfl.getSchedule) ⇒
+    * [.getWeeklySchedule(week, year, seasonType)](#nfl.getWeeklySchedule) ⇒
     * [.getScoreboard(year, month, day, limit)](#nfl.getScoreboard) ⇒
     * [.getStandings(year, group)](#nfl.getStandings) ⇒
     * [.getTeamList()](#nfl.getTeamList)
@@ -1343,7 +1381,29 @@ Gets the NFL schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nfl.getSchedule(year = 2019, month = 11, day = 17)
+const result = await sdv.nfl.getSchedule(
+year = 2019, month = 11, day = 17
+)
+```
+<a name="nfl.getWeeklySchedule"></a>
+
+### nfl.getWeeklySchedule(week, year, seasonType) ⇒
+Gets the NFL Weekly Schedule data for a specified season type.
+
+**Kind**: static method of [<code>nfl</code>](#nfl)  
+**Returns**: json  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| week | <code>\*</code> | Week (1-17) Default is 1 |
+| year | <code>\*</code> | Year (YYYY) Default is current year |
+| seasonType | <code>\*</code> | Season Type (1 = Preseason, 2 = Regular Season, 3 = Postseason) Default is 2 |
+
+**Example**  
+```js
+const result = await sdv.nfl.getWeeklySchedule(
+week = 1, year = 2023, seasonType = 2
+)
 ```
 <a name="nfl.getScoreboard"></a>
 
@@ -1362,7 +1422,9 @@ Gets the NFL scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nfl.getScoreboard(year = 2019, month = 11, day = 17)
+const result = await sdv.nfl.getScoreboard(
+year = 2019, month = 11, day = 17
+)
 ```
 <a name="nfl.getStandings"></a>
 
@@ -1379,7 +1441,8 @@ Gets the team standings for the NFL.
 
 **Example**  
 ```js
-const yr = 2021;const result = await sdv.nfl.getStandings(year = yr);
+const yr = 2021;
+const result = await sdv.nfl.getStandings(year = yr);
 ```
 <a name="nfl.getTeamList"></a>
 
@@ -1405,7 +1468,8 @@ Gets the team info for a specific NFL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nfl.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.nfl.getTeamInfo(teamId);
 ```
 <a name="nfl.getTeamPlayers"></a>
 
@@ -1421,7 +1485,8 @@ Gets the team roster information for a specific NFL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nfl.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.nfl.getTeamPlayers(teamId);
 ```
 
 Operations for NHL.
@@ -1520,7 +1585,9 @@ Gets the NHL schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nhl.getSchedule(year = 2019, month = 11, day = 17)
+const result = await sdv.nhl.getSchedule(
+year = 2019, month = 11, day = 17
+)
 ```
 <a name="nhl.getScoreboard"></a>
 
@@ -1539,7 +1606,9 @@ Gets the NHL scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nhl.getScoreboard(year = 2019, month = 11, day = 16)
+const result = await sdv.nhl.getScoreboard(
+year = 2019, month = 11, day = 16
+)
 ```
 <a name="nhl.getStandings"></a>
 
@@ -1556,7 +1625,8 @@ Gets the team standings for the NHL.
 
 **Example**  
 ```js
-const yr = 2016;const result = await sdv.nhl.getStandings(year = yr);
+const yr = 2016;
+const result = await sdv.nhl.getStandings(year = yr);
 ```
 <a name="nhl.getTeamList"></a>
 
@@ -1582,7 +1652,8 @@ Gets the team info for a specific NHL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nhl.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.nhl.getTeamInfo(teamId);
 ```
 <a name="nhl.getTeamPlayers"></a>
 
@@ -1598,9 +1669,11 @@ Gets the team roster information for a specific NHL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nhl.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.nhl.getTeamPlayers(teamId);
 ```
 
+ERROR, Cannot find namespace.
 Operations for WBB.
 
 **Kind**: global namespace  
@@ -1681,7 +1754,9 @@ Gets the WBB rankings data for a specified year and week if available.
 
 **Example**  
 ```js
-const result = await sdv.wbb.getRankings(year = 2021, week = 4)
+const result = await sdv.wbb.getRankings(
+year = 2021, week = 4
+)
 ```
 <a name="wbb.getSchedule"></a>
 
@@ -1702,7 +1777,9 @@ Gets the Women's College Basketball schedule data for a specified date if availa
 
 **Example**  
 ```js
-const result = await sdv.wbb.getSchedule(year = 2021, month = 02, day = 15, group=50)
+const result = await sdv.wbb.getSchedule(
+year = 2021, month = 02, day = 15, group=50
+)
 ```
 <a name="wbb.getScoreboard"></a>
 
@@ -1723,7 +1800,9 @@ Gets the Women's College Basketball scoreboard data for a specified date if avai
 
 **Example**  
 ```js
-const result = await sdv.wbb.getScoreboard(year = 2019, month = 02, day = 15, group=50)
+const result = await sdv.wbb.getScoreboard(
+year = 2019, month = 02, day = 15, group=50
+)
 ```
 <a name="wbb.getConferences"></a>
 
@@ -1740,7 +1819,8 @@ Gets the list of all Women's College Basketball conferences and their identifica
 
 **Example**  
 ```js
-const yr = 2021;const result = await sdv.wbb.getConferences(year = yr, group = 50);
+const yr = 2021;
+const result = await sdv.wbb.getConferences(year = yr, group = 50);
 ```
 <a name="wbb.getStandings"></a>
 
@@ -1757,7 +1837,8 @@ Gets the team standings for Women's College Basketball.
 
 **Example**  
 ```js
-const yr = 2020;const result = await sdv.wbb.getStandings(year = yr);
+const yr = 2020;
+const result = await sdv.wbb.getStandings(year = yr);
 ```
 <a name="wbb.getTeamList"></a>
 
@@ -1773,7 +1854,8 @@ Gets the list of all Women's College Basketball teams their identification info 
 
 **Example**  
 ```js
-get list of teamsconst result = await sdv.wbb.getTeamList(group=50);
+get list of teams
+const result = await sdv.wbb.getTeamList(group=50);
 ```
 <a name="wbb.getTeamInfo"></a>
 
@@ -1789,7 +1871,8 @@ Gets the team info for a specific WBB team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.wbb.getTeamInfo(teamId);
+const teamId = 52;
+const result = await sdv.wbb.getTeamInfo(teamId);
 ```
 <a name="wbb.getTeamPlayers"></a>
 
@@ -1805,7 +1888,8 @@ Gets the team roster information for a specific WBB team.
 
 **Example**  
 ```js
-const teamId = 52;const result = await sdv.wbb.getTeamPlayers(teamId);
+const teamId = 52;
+const result = await sdv.wbb.getTeamPlayers(teamId);
 ```
 
 Operations for WNBA.
@@ -1887,7 +1971,9 @@ Gets the WNBA schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.wnba.getSchedule(year = 2019, month = 07, day = 15)
+const result = await sdv.wnba.getSchedule(
+year = 2019, month = 07, day = 15
+)
 ```
 <a name="wnba.getScoreboard"></a>
 
@@ -1906,7 +1992,9 @@ Gets the WNBA scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.wnba.getScoreboard(year = 2019, month = 07, day = 15)
+const result = await sdv.wnba.getScoreboard(
+year = 2019, month = 07, day = 15
+)
 ```
 <a name="wnba.getStandings"></a>
 
@@ -1923,7 +2011,8 @@ Gets the team standings for the WNBA.
 
 **Example**  
 ```js
-const yr = 2016;const result = await sdv.wnba.getStandings(year = yr);
+const yr = 2016;
+const result = await sdv.wnba.getStandings(year = yr);
 ```
 <a name="wnba.getTeamList"></a>
 
@@ -1950,7 +2039,8 @@ Gets the team info for a specific WNBA team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.wnba.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.wnba.getTeamInfo(teamId);
 ```
 <a name="wnba.getTeamPlayers"></a>
 
@@ -1966,7 +2056,8 @@ Gets the team roster information for a specific WNBA team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.wnba.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.wnba.getTeamPlayers(teamId);
 ```
 
 * * *

--- a/app/services/nfl.service.js
+++ b/app/services/nfl.service.js
@@ -162,6 +162,36 @@ module.exports = {
         });
         return res.data.content.schedule;
     },
+
+
+        /**
+     * Gets the NFL Weekly Schedule data for a specified season type.
+     * @memberOf nfl
+     * @async
+     * @function
+     * @param {*} week - Week (1-17) Default is 1
+     * @param {*} year - Year (YYYY) Default is current year
+     * @param {*} seasonType -  Season Type (1 = Preseason, 2 = Regular Season, 3 = Postseason) Default is 2
+     * @returns json
+     * @example
+     * const result = await sdv.nfl.getWeeklySchedule(
+     * week = 1, year = 2023, seasonType = 2
+     * )
+     */
+    getWeeklySchedule: async function ({ week = 1, year = null, seasonType = 2 }) {
+        if(!year) year = new Date().getFullYear();
+       const baseUrl = `http://cdn.espn.com/core/nfl/schedule/_/week/${week}/year/${year}/seasontype/${seasonType}`;
+            const params = {
+            xhr: 1,
+            render: false,
+            device: 'desktop',
+            userab: 18
+        };
+        const res = await axios.get(baseUrl, {
+            params
+        });
+        return res.data.content.schedule;
+    },
     /**
      * Gets the NFL scoreboard data for a specified date if available.
      * @memberOf nfl

--- a/docs/docs/nfl.md
+++ b/docs/docs/nfl.md
@@ -11,6 +11,7 @@ Operations for NFL.
     * [.getSummary(id)](#nfl.getSummary) ⇒
     * [.getPicks(id)](#nfl.getPicks) ⇒
     * [.getSchedule(year, month, day)](#nfl.getSchedule) ⇒
+    * [.getWeeklySchedule(week, year, seasonType)](#nfl.getWeeklySchedule) ⇒
     * [.getScoreboard(year, month, day, limit)](#nfl.getScoreboard) ⇒
     * [.getStandings(year, group)](#nfl.getStandings) ⇒
     * [.getTeamList()](#nfl.getTeamList)
@@ -97,7 +98,29 @@ Gets the NFL schedule data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nfl.getSchedule(year = 2019, month = 11, day = 17)
+const result = await sdv.nfl.getSchedule(
+year = 2019, month = 11, day = 17
+)
+```
+<a name="nfl.getWeeklySchedule"></a>
+
+### nfl.getWeeklySchedule(week, year, seasonType) ⇒
+Gets the NFL Weekly Schedule data for a specified season type.
+
+**Kind**: static method of [<code>nfl</code>](#nfl)  
+**Returns**: json  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| week | <code>\*</code> | Week (1-17) Default is 1 |
+| year | <code>\*</code> | Year (YYYY) Default is current year |
+| seasonType | <code>\*</code> | Season Type (1 = Preseason, 2 = Regular Season, 3 = Postseason) Default is 2 |
+
+**Example**  
+```js
+const result = await sdv.nfl.getWeeklySchedule(
+week = 1, year = 2023, seasonType = 2
+)
 ```
 <a name="nfl.getScoreboard"></a>
 
@@ -116,7 +139,9 @@ Gets the NFL scoreboard data for a specified date if available.
 
 **Example**  
 ```js
-const result = await sdv.nfl.getScoreboard(year = 2019, month = 11, day = 17)
+const result = await sdv.nfl.getScoreboard(
+year = 2019, month = 11, day = 17
+)
 ```
 <a name="nfl.getStandings"></a>
 
@@ -133,7 +158,8 @@ Gets the team standings for the NFL.
 
 **Example**  
 ```js
-const yr = 2021;const result = await sdv.nfl.getStandings(year = yr);
+const yr = 2021;
+const result = await sdv.nfl.getStandings(year = yr);
 ```
 <a name="nfl.getTeamList"></a>
 
@@ -159,7 +185,8 @@ Gets the team info for a specific NFL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nfl.getTeamInfo(teamId);
+const teamId = 16;
+const result = await sdv.nfl.getTeamInfo(teamId);
 ```
 <a name="nfl.getTeamPlayers"></a>
 
@@ -175,5 +202,6 @@ Gets the team roster information for a specific NFL team.
 
 **Example**  
 ```js
-const teamId = 16;const result = await sdv.nfl.getTeamPlayers(teamId);
+const teamId = 16;
+const result = await sdv.nfl.getTeamPlayers(teamId);
 ```

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -1,5 +1,6 @@
 # ChangeLog
-
+## **V1.2.5**
+- NFL getWeeklySchedule function added by @unmonk
 ## **V1.2.4**
 - MLB functionality added by @unmonk (very grateful for the contribution!)
 ## **V1.2.0-2**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportsdataverse",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Node.js client which retrieves sports data from the ESPN API as well as from the NCAA website, with support for NBA, NFL, NHL, MLB, WNBA, men's and women's college basketball, and college football.",
   "main": "server.js",
   "directories": {

--- a/test/nfl.test.js
+++ b/test/nfl.test.js
@@ -101,6 +101,46 @@ describe('NFL Scoreboard', () => {
     });
 });
 
+describe('NFL Weekly Schedule', () => {
+
+    it('should populate schedule data for the first week of regular season for the current year', async () => {
+        const data = await app.nfl.getWeeklySchedule({})
+        should(data).exist;
+        should(data).be.json;
+        should(data).not.be.empty;
+
+    });
+
+    it('should populate schedule data for the given week and year and seasonType', async () => {
+        const data = await app.nfl.getWeeklySchedule({
+            week: 2,
+            year: 2023,
+            seasonType: 2
+        })
+        should(data).exist;
+        should(data).be.json;
+        should(data).not.be.empty;
+    });
+
+        it('should populate schedule data for the given week and year and default seasonType to Regular Season', async () => {
+        const data = await app.nfl.getWeeklySchedule({
+            week: 2,
+            year: 2023,
+        })
+        const data2 = await app.nfl.getWeeklySchedule({
+            week: 2,
+            year: 2023,
+            seasonType: 2
+        })
+        should(data).exist;
+        should(data).be.json;
+        should(data).not.be.empty;
+        should(data).eql(data2);
+    });
+
+  
+});
+
 describe('NFL Standings', () => {
 
     it('should populate standings for the given year', async () => {


### PR DESCRIPTION
My brother asked for a pickem league, the current nfl.getSchedule fetches by year, month, day. Which could work, but wasnt the easiest solution for me. 

 `getWeeklySchedule(week, year, seasonType)` is just utilizing some different params on that same cdn ```http://cdn.espn.com/core/nfl/schedule/_/week/${week}/year/${year}/seasontype/${seasonType}`;```
 
 Defaults to 1st week of regular season, of current year, if no parameters are provided.
 
 Related tests created.
 Ran `md-nfl` and `readme` 
 