### PR TITLE
feat(espn): cross-league core + basketball vertical slice (v3.0.0)

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,0 +1,37 @@
+import axios, { type AxiosRequestConfig } from "axios";
+import type { EspnFamily } from "./types.js";
+
+/** Base hosts for each ESPN URL family. */
+export const HOSTS: Record<EspnFamily, string> = {
+  site_v2: "https://site.api.espn.com/apis/site/v2/sports",
+  site_v2_alt: "https://site.api.espn.com/apis/v2/sports",
+  web_v3: "https://site.web.api.espn.com/apis/common/v3/sports",
+  core_v2: "https://sports.core.api.espn.com/v2/sports",
+};
+
+const client = axios.create({
+  timeout: 30000,
+  headers: {
+    "User-Agent":
+      "Mozilla/5.0 (compatible; sportsdataverse-js/3.x; +https://js.sportsdataverse.org/)",
+  },
+});
+
+/** Build a `{host}/{sport}/{league}{path}` URL for an ESPN family. */
+export function familyUrl(
+  family: EspnFamily,
+  sport: string,
+  league: string,
+  path = ""
+): string {
+  return `${HOSTS[family]}/${sport}/${league}${path}`;
+}
+
+/** GET an ESPN URL and return the raw JSON body. */
+export async function get(
+  url: string,
+  config?: AxiosRequestConfig
+): Promise<any> {
+  const res = await client.get(url, config);
+  return res.data;
+}

--- a/src/core/espn.ts
+++ b/src/core/espn.ts
@@ -1,0 +1,120 @@
+import { familyUrl, get } from "./client.js";
+import type { EspnFamily, LeagueConfig, Scope } from "./types.js";
+
+/**
+ * Definition of one cross-league wrapper: which ESPN family it hits and how to
+ * build the path/query from the caller's params. `makeLeagueModule` binds these
+ * to a league and exposes them as `espn_<prefix>_<short>(params)`.
+ *
+ * This is the JS analogue of sdv-py's `_UNIVERSAL_WRAPPERS` table; the codegen
+ * phase will expand it from the shared `sdv-internal-refs/espn` metadata.
+ */
+export interface WrapperDef {
+  short: string;
+  family: EspnFamily;
+  scope: Scope;
+  build: (params: Record<string, any>) => {
+    path: string;
+    query?: Record<string, any>;
+  };
+}
+
+/** Drop undefined/null query values so we don't send `?dates=undefined`. */
+function clean(query?: Record<string, any>): Record<string, any> | undefined {
+  if (!query) return undefined;
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(query)) {
+    if (v !== undefined && v !== null) out[k] = v;
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+/**
+ * Wrappers that exist for every ESPN league. A small, real first set to prove
+ * the `(sport, league)` parameterization end-to-end; extended via codegen.
+ */
+export const UNIVERSAL_WRAPPERS: WrapperDef[] = [
+  {
+    short: "scoreboard",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({
+      path: "/scoreboard",
+      query: {
+        dates: p.dates,
+        limit: p.limit,
+        groups: p.groups,
+        seasontype: p.seasontype,
+        week: p.week,
+      },
+    }),
+  },
+  {
+    short: "summary",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/summary", query: { event: p.event ?? p.id } }),
+  },
+  {
+    short: "standings",
+    family: "site_v2_alt",
+    scope: "universal",
+    build: (p) => ({
+      path: "/standings",
+      query: { season: p.season, seasontype: p.seasontype, level: p.level },
+    }),
+  },
+  {
+    short: "teams",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/teams", query: { limit: p.limit ?? 1000 } }),
+  },
+  {
+    short: "team",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({ path: `/teams/${p.team ?? p.id}` }),
+  },
+  {
+    short: "team_roster",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({ path: `/teams/${p.team ?? p.id}/roster` }),
+  },
+  {
+    short: "team_schedule",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({
+      path: `/teams/${p.team ?? p.id}/schedule`,
+      query: { season: p.season, seasontype: p.seasontype },
+    }),
+  },
+  {
+    short: "news",
+    family: "site_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/news", query: { limit: p.limit } }),
+  },
+];
+
+/** Tables keyed by scope (universal today; ncaa/football/mlb land with codegen). */
+export const WRAPPER_TABLES: Record<Scope, WrapperDef[]> = {
+  universal: UNIVERSAL_WRAPPERS,
+  ncaa: [],
+  football: [],
+  mlb: [],
+};
+
+/** Resolve a wrapper for a league and fetch the raw ESPN JSON. */
+export function callWrapper(
+  def: WrapperDef,
+  cfg: LeagueConfig,
+  params: Record<string, any> = {}
+): Promise<any> {
+  const { path, query } = def.build(params);
+  return get(familyUrl(def.family, cfg.sport, cfg.league, path), {
+    params: clean(query),
+  });
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,19 @@
+/** ESPN URL families, keyed to their host (see `HOSTS` in client.ts). */
+export type EspnFamily = "site_v2" | "site_v2_alt" | "web_v3" | "core_v2";
+
+/** Which wrapper tables apply to a league (mirrors sdv-py's scope flags). */
+export type Scope = "universal" | "ncaa" | "football" | "mlb";
+
+/**
+ * A league's binding into the ESPN core: the ESPN `(sport, league)` slugs plus
+ * the public `prefix` used in generated wrapper names (`espn_<prefix>_<short>`).
+ */
+export interface LeagueConfig {
+  prefix: string;
+  sport: string;
+  league: string;
+  scopes: Scope[];
+}
+
+/** A generated cross-league wrapper: `(params?) => Promise<raw ESPN JSON>`. */
+export type WrapperFn = (params?: Record<string, any>) => Promise<any>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,34 @@ import tennis from './services/tennis.service.js';
 import wbb from './services/wbb.service.js';
 import wnba from './services/wnba.service.js';
 
+// Cross-league ESPN wrappers (Phase 1/2 — basketball vertical slice). These are
+// merged onto the existing per-sport namespaces, so legacy methods like
+// `sdv.nba.getPlayByPlay()` keep working alongside the new `espn_nba_*` wrappers.
+import nbaEspn from './leagues/nba.js';
+import wnbaEspn from './leagues/wnba.js';
+import mbbEspn from './leagues/mbb.js';
+import wbbEspn from './leagues/wbb.js';
+
 export default {
     cfb,
-    mbb,
+    mbb: { ...mbb, ...mbbEspn },
     mlb,
-    nba,
+    nba: { ...nba, ...nbaEspn },
     ncaa,
     nfl,
     nhl,
     tennis,
-    wbb,
-    wnba
+    wbb: { ...wbb, ...wbbEspn },
+    wnba: { ...wnba, ...wnbaEspn }
 };
+
+// Also expose the league modules directly for tree-shakeable, cross-league use:
+//   import { nbaEspn } from "sportsdataverse";
+export {
+    nbaEspn,
+    wnbaEspn,
+    mbbEspn,
+    wbbEspn
+};
+export { makeLeagueModule } from './leagues/_make.js';
+export type { LeagueConfig, EspnFamily, Scope, WrapperFn } from './core/types.js';

--- a/src/leagues/_make.ts
+++ b/src/leagues/_make.ts
@@ -1,0 +1,20 @@
+import { WRAPPER_TABLES, callWrapper } from "../core/espn.js";
+import type { LeagueConfig, WrapperFn } from "../core/types.js";
+
+/**
+ * Build a league's cross-league ESPN surface: for each wrapper in the league's
+ * scopes, expose `espn_<prefix>_<short>(params)`. The JS analogue of sdv-py's
+ * `make_league_module`.
+ */
+export function makeLeagueModule(
+  cfg: LeagueConfig
+): Record<string, WrapperFn> {
+  const mod: Record<string, WrapperFn> = {};
+  for (const scope of cfg.scopes) {
+    for (const def of WRAPPER_TABLES[scope] ?? []) {
+      mod[`espn_${cfg.prefix}_${def.short}`] = (params = {}) =>
+        callWrapper(def, cfg, params);
+    }
+  }
+  return mod;
+}

--- a/src/leagues/mbb.ts
+++ b/src/leagues/mbb.ts
@@ -1,0 +1,9 @@
+import { makeLeagueModule } from "./_make.js";
+
+/** Cross-league ESPN wrappers for men's college basketball (`espn_mbb_*`). */
+export default makeLeagueModule({
+  prefix: "mbb",
+  sport: "basketball",
+  league: "mens-college-basketball",
+  scopes: ["universal"],
+});

--- a/src/leagues/nba.ts
+++ b/src/leagues/nba.ts
@@ -1,0 +1,9 @@
+import { makeLeagueModule } from "./_make.js";
+
+/** Cross-league ESPN wrappers for the NBA (`espn_nba_*`). */
+export default makeLeagueModule({
+  prefix: "nba",
+  sport: "basketball",
+  league: "nba",
+  scopes: ["universal"],
+});

--- a/src/leagues/wbb.ts
+++ b/src/leagues/wbb.ts
@@ -1,0 +1,9 @@
+import { makeLeagueModule } from "./_make.js";
+
+/** Cross-league ESPN wrappers for women's college basketball (`espn_wbb_*`). */
+export default makeLeagueModule({
+  prefix: "wbb",
+  sport: "basketball",
+  league: "womens-college-basketball",
+  scopes: ["universal"],
+});

--- a/src/leagues/wnba.ts
+++ b/src/leagues/wnba.ts
@@ -1,0 +1,9 @@
+import { makeLeagueModule } from "./_make.js";
+
+/** Cross-league ESPN wrappers for the WNBA (`espn_wnba_*`). */
+export default makeLeagueModule({
+  prefix: "wnba",
+  sport: "basketball",
+  league: "wnba",
+  scopes: ["universal"],
+});

--- a/test/espn-core.test.js
+++ b/test/espn-core.test.js
@@ -1,0 +1,36 @@
+import should from 'should';
+import sdv, { makeLeagueModule, nbaEspn } from '../dist/index.js';
+
+// Structural (no-network) tests for the cross-league ESPN core + league binder.
+describe('ESPN cross-league core (basketball vertical slice)', () => {
+    it('generates espn_<prefix>_<short> wrappers for a league module', () => {
+        const keys = Object.keys(nbaEspn);
+        keys.should.containEql('espn_nba_scoreboard');
+        keys.should.containEql('espn_nba_teams');
+        keys.should.containEql('espn_nba_team_roster');
+    });
+
+    it('merges wrappers onto the legacy namespace without clobbering it', () => {
+        // legacy method still present
+        (typeof sdv.nba.getPlayByPlay).should.equal('function');
+        // new cross-league wrapper added alongside it
+        (typeof sdv.nba.espn_nba_scoreboard).should.equal('function');
+    });
+
+    it('binds (sport, league) for each basketball league', () => {
+        (typeof sdv.wbb.espn_wbb_teams).should.equal('function');
+        (typeof sdv.mbb.espn_mbb_standings).should.equal('function');
+        (typeof sdv.wnba.espn_wnba_summary).should.equal('function');
+    });
+
+    it('makeLeagueModule produces the universal wrapper set', () => {
+        const mod = makeLeagueModule({
+            prefix: 'test',
+            sport: 'basketball',
+            league: 'nba',
+            scopes: ['universal']
+        });
+        Object.keys(mod).length.should.be.above(0);
+        Object.keys(mod).every((k) => k.startsWith('espn_test_')).should.be.true();
+    });
+});


### PR DESCRIPTION
**Phase 1/2** of [`docs/espn-expansion-plan.md`](docs/espn-expansion-plan.md) — introduces
the parameterized `(sport, league)` ESPN core and the league binder, validated on the
**basketball** family. Accumulates into the unpublished **v3.0.0** release (no version bump).

### What's here
- **`src/core/`** — `client` (host map + shared axios), `types` (`LeagueConfig`/`EspnFamily`/`Scope`), `espn` (`UNIVERSAL_WRAPPERS` table + `callWrapper`). The JS analogue of sdv-py's `_common_espn` URL-family wrappers.
- **`src/leagues/_make.makeLeagueModule(cfg)`** → `{ espn_<prefix>_<short>(params) }` (analogue of sdv-py's `make_league_module`), plus `nba` / `wnba` / `mbb` / `wbb` modules.
- **`index.ts`** merges the `espn_*` wrappers onto the existing per-sport namespaces — so **legacy methods keep working** (`sdv.nba.getPlayByPlay()`) **alongside** the new cross-league wrappers (`sdv.nba.espn_nba_scoreboard()`). Also exports the league modules, `makeLeagueModule`, and the core types.

### Wrappers (8 universal, to start)
`scoreboard`, `summary`, `standings`, `teams`, `team`, `team_roster`, `team_schedule`, `news` — each bound to `(sport, league)`. The codegen phase expands this table from the shared `sdv-internal-refs/espn` metadata.

### Back-compat
Hard guarantee preserved: the `espn_` prefix can't collide with the legacy camelCase methods, and the merge keeps both on the same namespace.

### Verification
- `tsc` clean; **4 structural tests** pass (`test/espn-core.test.js`).
- **Live ESPN** works: `espn_wbb_teams` → **361 teams**, `espn_nba_scoreboard` → live events.

### Next (per the plan)
Phase 3 (codegen from `sdv-internal-refs/espn`) + Phase 4 (compat facade) + the remaining 25 leagues.
