### PR TITLE
feat(espn): widen wrapper table (web_v3/core_v2 + NCAA scope)

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -17,14 +17,18 @@ const client = axios.create({
   },
 });
 
-/** Build a `{host}/{sport}/{league}{path}` URL for an ESPN family. */
+/**
+ * Build an ESPN URL for a family. The Core API (`core_v2`) nests the league
+ * under `/leagues/{league}`; the Site/Web families use `/{league}` directly.
+ */
 export function familyUrl(
   family: EspnFamily,
   sport: string,
   league: string,
   path = ""
 ): string {
-  return `${HOSTS[family]}/${sport}/${league}${path}`;
+  const leagueSeg = family === "core_v2" ? `leagues/${league}` : league;
+  return `${HOSTS[family]}/${sport}/${leagueSeg}${path}`;
 }
 
 /** GET an ESPN URL and return the raw JSON body. */

--- a/src/core/espn.ts
+++ b/src/core/espn.ts
@@ -97,12 +97,70 @@ export const UNIVERSAL_WRAPPERS: WrapperDef[] = [
     scope: "universal",
     build: (p) => ({ path: "/news", query: { limit: p.limit } }),
   },
+  {
+    short: "athletes",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({
+      path: "/athletes",
+      query: { limit: p.limit ?? 50, page: p.page },
+    }),
+  },
+  {
+    short: "athlete",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: `/athletes/${p.athlete ?? p.id}` }),
+  },
+  {
+    short: "seasons",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/seasons", query: { limit: p.limit } }),
+  },
+  {
+    short: "season",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: `/seasons/${p.season}` }),
+  },
+  {
+    short: "franchises",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/franchises", query: { limit: p.limit ?? 100 } }),
+  },
+  {
+    short: "venues",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/venues", query: { limit: p.limit ?? 100 } }),
+  },
+  {
+    short: "positions",
+    family: "core_v2",
+    scope: "universal",
+    build: (p) => ({ path: "/positions", query: { limit: p.limit ?? 100 } }),
+  },
 ];
 
-/** Tables keyed by scope (universal today; ncaa/football/mlb land with codegen). */
+/** Wrappers that only make sense for NCAA leagues (polls, etc.). */
+export const NCAA_WRAPPERS: WrapperDef[] = [
+  {
+    short: "rankings",
+    family: "site_v2",
+    scope: "ncaa",
+    build: (p) => ({
+      path: "/rankings",
+      query: { week: p.week, seasontype: p.seasontype },
+    }),
+  },
+];
+
+/** Tables keyed by scope (football/mlb land with codegen). */
 export const WRAPPER_TABLES: Record<Scope, WrapperDef[]> = {
   universal: UNIVERSAL_WRAPPERS,
-  ncaa: [],
+  ncaa: NCAA_WRAPPERS,
   football: [],
   mlb: [],
 };

--- a/src/leagues/mbb.ts
+++ b/src/leagues/mbb.ts
@@ -5,5 +5,5 @@ export default makeLeagueModule({
   prefix: "mbb",
   sport: "basketball",
   league: "mens-college-basketball",
-  scopes: ["universal"],
+  scopes: ["universal", "ncaa"],
 });

--- a/src/leagues/wbb.ts
+++ b/src/leagues/wbb.ts
@@ -5,5 +5,5 @@ export default makeLeagueModule({
   prefix: "wbb",
   sport: "basketball",
   league: "womens-college-basketball",
-  scopes: ["universal"],
+  scopes: ["universal", "ncaa"],
 });

--- a/test/espn-core.test.js
+++ b/test/espn-core.test.js
@@ -33,4 +33,19 @@ describe('ESPN cross-league core (basketball vertical slice)', () => {
         Object.keys(mod).length.should.be.above(0);
         Object.keys(mod).every((k) => k.startsWith('espn_test_')).should.be.true();
     });
+
+    it('exposes core_v2 wrappers (seasons / franchises / athletes / venues)', () => {
+        (typeof sdv.nba.espn_nba_seasons).should.equal('function');
+        (typeof sdv.nba.espn_nba_franchises).should.equal('function');
+        (typeof sdv.nba.espn_nba_athletes).should.equal('function');
+        (typeof sdv.nba.espn_nba_venues).should.equal('function');
+    });
+
+    it('applies scope tables: ncaa `rankings` on college leagues only', () => {
+        // mbb/wbb carry the ncaa scope -> rankings
+        (typeof sdv.mbb.espn_mbb_rankings).should.equal('function');
+        (typeof sdv.wbb.espn_wbb_rankings).should.equal('function');
+        // nba is universal-only -> no rankings wrapper
+        (typeof sdv.nba.espn_nba_rankings).should.equal('undefined');
+    });
 });


### PR DESCRIPTION
Widens the cross-league core (Phase 2.5, v3.0.0) beyond the initial 8 wrappers.

- **core_v2 family** support — `familyUrl` nests `/leagues/{league}` for the Core API `$ref` graph.
- **+7 universal wrappers** (15 total): `athletes`, `athlete`, `seasons`, `season`, `franchises`, `venues`, `positions` (core_v2).
- **NCAA scope table** — `rankings` (site_v2); mbb/wbb now carry `[universal, ncaa]`, so `espn_mbb_rankings`/`espn_wbb_rankings` exist but `espn_nba_rankings` (universal-only) does not. **Scope filtering verified.**

Live-verified: core_v2 wrappers return paginated items; `espn_mbb_rankings` returns AP + Coaches polls. 6 structural tests pass.

Next: **Phase 3 codegen** to generate the full table + all 29 leagues from `sdv-internal-refs/espn`.