### PR TITLE
feat(espn): camelCase param aliases + per-league live smoke

### DIFF
--- a/src/core/espn.ts
+++ b/src/core/espn.ts
@@ -43,7 +43,8 @@ function buildPath(
   params: Record<string, any>
 ): string {
   // Only league-parameterized leagues (soccer/cricket) honour a `league` override.
-  const league = cfg.leagueParam && params.league ? params.league : cfg.league;
+  const override = cfg.leagueParam ? lookup(params, "league") : undefined;
+  const league = override != null ? override : cfg.league;
   const byName = new Map(def.pathParams.map((p) => [p.name, p]));
 
   // Resolve a path token: explicit param -> `defaultFrom` param -> `default`
@@ -91,14 +92,30 @@ function buildPath(
   return path;
 }
 
+/**
+ * Build the full request (URL + query) for a wrapper without fetching. Exported
+ * so the param resolution (camelCase aliases, defaults, path substitution) is
+ * unit-testable without network.
+ */
+export function resolveRequest(
+  def: WrapperDef,
+  cfg: LeagueConfig,
+  params: Record<string, any> = {}
+): { url: string; query?: Record<string, any> } {
+  return {
+    url: `${HOSTS[def.family]}${buildPath(def, cfg, params)}`,
+    query: cleanQuery(def, params),
+  };
+}
+
 /** Resolve a wrapper for a league and fetch the raw ESPN JSON. */
 export function callWrapper(
   def: WrapperDef,
   cfg: LeagueConfig,
   params: Record<string, any> = {}
 ): Promise<any> {
-  const path = buildPath(def, cfg, params);
-  return get(`${HOSTS[def.family]}${path}`, { params: cleanQuery(def, params) });
+  const { url, query } = resolveRequest(def, cfg, params);
+  return get(url, { params: query });
 }
 
 /** All wrappers grouped by scope (built from the generated table). */

--- a/src/core/espn.ts
+++ b/src/core/espn.ts
@@ -2,6 +2,24 @@ import { HOSTS, get } from "./client.js";
 import type { LeagueConfig, Scope, WrapperDef } from "./types.js";
 import { WRAPPERS } from "../generated/wrappers.js";
 
+/** snake_case -> camelCase (e.g. `event_id` -> `eventId`). */
+function toCamel(s: string): string {
+  return s.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
+}
+
+/**
+ * Look a param up by its canonical (snake_case) name OR a camelCase alias, so
+ * callers can pass either `{ event_id }` or `{ eventId }`.
+ */
+function lookup(params: Record<string, any>, name: string): any {
+  if (params[name] !== undefined && params[name] !== null) return params[name];
+  const camel = toCamel(name);
+  if (camel !== name && params[camel] !== undefined && params[camel] !== null) {
+    return params[camel];
+  }
+  return undefined;
+}
+
 /** Drop undefined/null query values so we don't send `?dates=undefined`. */
 function cleanQuery(
   def: WrapperDef,
@@ -9,7 +27,7 @@ function cleanQuery(
 ): Record<string, any> | undefined {
   const out: Record<string, any> = {};
   for (const qp of def.queryParams) {
-    const v = params[qp.name] ?? qp.default;
+    const v = lookup(params, qp.name) ?? qp.default;
     if (v !== undefined && v !== null) out[qp.queryKey] = v;
   }
   return Object.keys(out).length ? out : undefined;
@@ -28,12 +46,15 @@ function buildPath(
   const league = cfg.leagueParam && params.league ? params.league : cfg.league;
   const byName = new Map(def.pathParams.map((p) => [p.name, p]));
 
-  // Resolve a path token: explicit param -> `defaultFrom` param -> `default`.
+  // Resolve a path token: explicit param -> `defaultFrom` param -> `default`
+  // (each lookup accepts the snake_case name or a camelCase alias).
   const resolve = (name: string): any => {
-    if (params[name] !== undefined && params[name] !== null) return params[name];
+    const v = lookup(params, name);
+    if (v !== undefined && v !== null) return v;
     const pp = byName.get(name);
-    if (pp?.defaultFrom != null && params[pp.defaultFrom] != null) {
-      return params[pp.defaultFrom];
+    if (pp?.defaultFrom != null) {
+      const from = lookup(params, pp.defaultFrom);
+      if (from !== undefined && from !== null) return from;
     }
     return pp?.default;
   };

--- a/test/espn-core.test.js
+++ b/test/espn-core.test.js
@@ -1,5 +1,7 @@
 import should from 'should';
 import sdv, { makeLeagueModule, LEAGUES, WRAPPERS } from '../dist/index.js';
+// deep import (not part of the public API) — exercises request building w/o network
+import { resolveRequest } from '../dist/core/espn.js';
 
 // Structural (no-network) tests for the generated cross-league ESPN surface.
 describe('ESPN cross-league core (generated from YAML)', () => {
@@ -48,5 +50,41 @@ describe('ESPN cross-league core (generated from YAML)', () => {
         families.has('site_v2').should.be.true();
         families.has('core_v2').should.be.true();
         families.has('site_v2_alt').should.be.true();
+    });
+
+    it('resolves params by snake_case or camelCase alias (+ default_from)', () => {
+        const def = {
+            short: 'event_competition',
+            family: 'core_v2',
+            scope: 'universal',
+            path: '/{sport}/leagues/{league}/events/{event_id}/competitions/{cid}',
+            pathParams: [{ name: 'event_id' }, { name: 'cid', defaultFrom: 'event_id' }],
+            queryParams: [{ name: 'season_type', queryKey: 'seasontype' }],
+        };
+        const cfg = { prefix: 'nfl', sport: 'football', league: 'nfl', scopes: ['universal'] };
+
+        const snake = resolveRequest(def, cfg, { event_id: 5, season_type: 2 });
+        const camel = resolveRequest(def, cfg, { eventId: 5, seasonType: 2 });
+
+        // both spellings produce the identical request
+        snake.url.should.equal(camel.url);
+        JSON.stringify(snake.query).should.equal(JSON.stringify(camel.query));
+        // cid defaulted from event_id; query key mapped to ESPN's `seasontype`
+        snake.url.should.endWith('/events/5/competitions/5');
+        snake.query.seasontype.should.equal(2);
+    });
+
+    it('only honours a league override for leagueParam leagues', () => {
+        const def = {
+            short: 'scoreboard', family: 'site_v2', scope: 'universal',
+            path: '/{sport}/{league}/scoreboard', pathParams: [], queryParams: [],
+        };
+        const pro = { prefix: 'nba', sport: 'basketball', league: 'nba', scopes: ['universal'] };
+        const soccer = { prefix: 'soccer', sport: 'soccer', league: 'eng.1', scopes: ['universal'], leagueParam: true };
+
+        // pro league ignores the override
+        resolveRequest(def, pro, { league: 'mens-college-basketball' }).url.should.endWith('/basketball/nba/scoreboard');
+        // leagueParam league honours it
+        resolveRequest(def, soccer, { league: 'esp.1' }).url.should.endWith('/soccer/esp.1/scoreboard');
     });
 });

--- a/test/espn-live.test.js
+++ b/test/espn-live.test.js
@@ -7,7 +7,7 @@ import sdv, { LEAGUES } from '../dist/index.js';
 // dead at ESPN.
 //
 //   SDV_LIVE=1 npm test
-const run = process.env.SDV_LIVE ? describe : describe.skip;
+const run = ['1', 'true', 'yes'].includes(process.env.SDV_LIVE) ? describe : describe.skip;
 
 run('ESPN live smoke (all leagues)', function () {
     this.timeout(30000);

--- a/test/espn-live.test.js
+++ b/test/espn-live.test.js
@@ -1,0 +1,29 @@
+import should from 'should';
+import sdv, { LEAGUES } from '../dist/index.js';
+
+// Live smoke across every league in the generated matrix. Gated: only runs when
+// SDV_LIVE=1 (it hits ~29 real ESPN endpoints — slow + network-dependent), so it
+// never blocks the default CI. Use it to catch a league/endpoint that has gone
+// dead at ESPN.
+//
+//   SDV_LIVE=1 npm test
+const run = process.env.SDV_LIVE ? describe : describe.skip;
+
+run('ESPN live smoke (all leagues)', function () {
+    this.timeout(30000);
+
+    for (const cfg of LEAGUES) {
+        // `cricket` is a league_param catch-all whose default slug (`eng.1`) is a
+        // placeholder pending ESPN series-slug discovery — its scoreboard 404s.
+        // Use it with a real `{ league }`; skip the default-slug smoke here.
+        const test = cfg.prefix === 'cricket' ? it.skip : it;
+        test(`espn_${cfg.prefix}_scoreboard returns data`, async () => {
+            const fn = sdv[cfg.prefix][`espn_${cfg.prefix}_scoreboard`];
+            (typeof fn).should.equal('function');
+            const data = await fn({});
+            should(data).be.an.Object();
+            // every ESPN scoreboard payload carries a leagues block
+            should(data).have.property('leagues');
+        });
+    }
+});

--- a/test/espn-live.test.js
+++ b/test/espn-live.test.js
@@ -18,7 +18,9 @@ run('ESPN live smoke (all leagues)', function () {
         // Use it with a real `{ league }`; skip the default-slug smoke here.
         const test = cfg.prefix === 'cricket' ? it.skip : it;
         test(`espn_${cfg.prefix}_scoreboard returns data`, async () => {
-            const fn = sdv[cfg.prefix][`espn_${cfg.prefix}_scoreboard`];
+            const ns = sdv[cfg.prefix];
+            should(ns).be.an.Object();
+            const fn = ns[`espn_${cfg.prefix}_scoreboard`];
             (typeof fn).should.equal('function');
             const data = await fn({});
             should(data).be.an.Object();


### PR DESCRIPTION
Phase 6 polish (v3.0.0).

- **camelCase param aliases** — the core now resolves params by snake_case name *or* a camelCase alias, so call sites can be idiomatic: `espn_nfl_event_competition({ eventId })` or `({ event_id })`. Applies to query params, path params, and `defaultFrom`.
- **Gated per-league live smoke** (`test/espn-live.test.js`, `SDV_LIVE=1`) — calls `scoreboard` on every league in the generated matrix. **28/29 verified live** (incl. all 13 soccer leagues). `cricket` is skipped: its league_param default slug `eng.1` is a placeholder pending ESPN series-slug discovery (404s) — use it with a real `{ league }`.

Structural tests + build/typecheck/codegen-drift all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Improved internal handling of ESPN API query parameters to support alternative naming conventions without affecting existing functionality

* **Tests**
  * Added comprehensive smoke test suite for ESPN live scoreboard functionality across all supported sports leagues, verifying data integrity and proper payload structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->