### PR TITLE
ci(release): harden npm-publish workflow + LF-pin generated output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Source + config are always checked out as LF (overriding core.autocrlf on
+# Windows) so the codegen drift gate (`npm run codegen:check`) is deterministic
+# across platforms — the generator in tools/codegen always emits LF.
+*.ts   text eol=lf
+*.js   text eol=lf
+*.mjs  text eol=lf
+*.json text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,7 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+# Publishes the package to npm when a GitHub release is created (or on manual
+# dispatch). The build job validates the package on every supported Node before
+# the publish job runs (publish `needs: build`).
+# https://docs.github.com/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
 
@@ -8,32 +10,41 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20]
+        node-version: [20.x, 22.x]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm install && npm ci
+      - run: npm ci
+      - run: npm run codegen:check
+      - run: npm run typecheck
+      - run: npm run build
 
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance (OIDC)
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
-          node-version: 18
+          node-version: 20
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
-      - run: npm install && npm ci
-      - run: npm publish
+      - run: npm ci
+      - run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Release-prep for **v3.0.0**. Two small, surgical changes so the npm publish path is correct and the codegen drift gate is cross-platform deterministic.

### `npm-publish.yml`
- **Node matrix `[14, 16, 18, 20]` → `[20.x, 22.x]`.** The package floor is Node `>=20.18.1` (cheerio 1.2 → undici 7), so the old matrix would fail the publish gate on every legacy Node it tried.
- **SHA-pin** `actions/checkout` + `actions/setup-node` to v5 (immutable refs, matching `ci.yml`'s pinning convention).
- **`npm install && npm ci` → `npm ci`.** The `&&` chain was redundant/contradictory; `npm ci` alone is the reproducible install.
- **Add the no-network gates CI runs** (`codegen:check`, `typecheck`, `build`) to the build job so a stale or broken package can't reach npm.
- **Provenance:** publish with `npm publish --provenance --access public` + a job-scoped `id-token: write`, so the release carries Sigstore build provenance. Top-level least-privilege `permissions: contents: read`.

### `.gitattributes`
- Force **LF** on `*.ts/*.js/*.mjs/*.json/*.yml/*.yaml` so `npm run codegen:check` is deterministic on Windows. The generator always emits LF; `core.autocrlf` would otherwise make the committed-vs-regenerated comparison false-fail in a Windows working tree. (Scoped to source/config only — docs/markdown untouched to avoid churn.)

## Validation
- `npm run codegen:check` ✅ (116 wrappers × 29 leagues, up to date)
- `npm run typecheck` ✅
- `npm run build` ✅
- `npm test` → 148 passing; the 3 failures are pre-existing **legacy NCAA live-network** tests (dead ESPN game id → 404), which `ci.yml` does not run.

After merge: cut the `v3.0.0` GitHub release to trigger `npm-publish.yml`.