### PR TITLE
feat(espn)!: camelCase canonical wrapper names + snake_case aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,43 +32,44 @@ TypeScript declarations.
 ## Usage
 
 Every league is a namespace on the default export. The cross-league ESPN endpoints
-follow one naming rule — **`espn_<league>_<endpoint>`**:
+follow one naming rule — **`espn<League><Endpoint>`** (camelCase). Every method also
+has a snake_case alias (`espn_nba_scoreboard`) for parity with the Python / R packages:
 
 ```js
 import sdv from "sportsdataverse";
 
 // Today's NBA scoreboard
-const board = await sdv.nba.espn_nba_scoreboard({});
+const board = await sdv.nba.espnNbaScoreboard({});
 
 // A single game summary (box score + plays + win probability + ...)
-const game = await sdv.nba.espn_nba_summary({ event_id: 401584793 });
+const game = await sdv.nba.espnNbaSummary({ event_id: 401584793 });
 
 // A team's roster
-const roster = await sdv.nfl.espn_nfl_team_roster({ team_id: 12 });
+const roster = await sdv.nfl.espnNflTeamRoster({ team_id: 12 });
 ```
 
 The same methods exist on **every** league, so switching sports is a one-token change:
 
 ```js
-await sdv.nfl.espn_nfl_scoreboard({ week: 1, season_type: 2 });
-await sdv.nhl.espn_nhl_scoreboard({});
-await sdv.cfb.espn_cfb_rankings({});                 // NCAA-scoped endpoint
-await sdv.wnba.espn_wnba_standings({ season: 2024 });
+await sdv.nfl.espnNflScoreboard({ week: 1, season_type: 2 });
+await sdv.nhl.espnNhlScoreboard({});
+await sdv.cfb.espnCfbRankings({});                 // NCAA-scoped endpoint
+await sdv.wnba.espnWnbaStandings({ season: 2024 });
 ```
 
 Multi-league sports (soccer, cricket) take an extra `league` slug:
 
 ```js
-await sdv.soccer.espn_soccer_scoreboard({ league: "eng.1" });  // Premier League
-await sdv.soccer.espn_soccer_scoreboard({ league: "esp.1" });  // La Liga
+await sdv.soccer.espnSoccerScoreboard({ league: "eng.1" });  // Premier League
+await sdv.soccer.espnSoccerScoreboard({ league: "esp.1" });  // La Liga
 ```
 
 Parameters accept **snake_case or camelCase**, and every pre-3.0 convenience method
 is preserved alongside the generated wrappers:
 
 ```js
-await sdv.nfl.espn_nfl_team_schedule({ team_id: 12, season: 2024 });
-await sdv.nfl.espn_nfl_team_schedule({ teamId: 12, season: 2024 });  // identical
+await sdv.nfl.espnNflTeamSchedule({ team_id: 12, season: 2024 });
+await sdv.nfl.espnNflTeamSchedule({ teamId: 12, season: 2024 });  // identical
 
 const pbp = await sdv.nba.getPlayByPlay(401584793);  // legacy method, still works
 ```
@@ -80,7 +81,7 @@ import sdv, { LEAGUES, WRAPPERS } from "sportsdataverse";
 
 LEAGUES.map((l) => l.prefix);           // ['nba','nfl',...,'soccer','cricket','ufl',...]
 WRAPPERS.length;                         // 116 endpoint definitions
-Object.keys(sdv.nba).filter((k) => k.startsWith("espn_nba_"));  // every NBA wrapper
+Object.keys(sdv.nba).filter((k) => k.startsWith("espnNba"));  // every NBA wrapper
 ```
 
 Endpoints are grouped into **scopes** — `universal` (every league), `ncaa` (college),

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -41,38 +41,40 @@ import sdv from 'sportsdataverse';
 ## Quick start
 
 Every league is a namespace on the default export. The cross-league ESPN
-endpoints follow one naming rule — **`espn_<league>_<endpoint>`**:
+endpoints follow one naming rule — **`espn<League><Endpoint>`** (camelCase). Every
+method also has a snake_case alias (`espn_nba_scoreboard`) for parity with the
+Python / R packages:
 
 ```js
 import sdv from 'sportsdataverse';
 
 // Today's NBA scoreboard
-const board = await sdv.nba.espn_nba_scoreboard({});
+const board = await sdv.nba.espnNbaScoreboard({});
 
 // A single game summary (box score + plays + win probability + ...)
-const game = await sdv.nba.espn_nba_summary({ event_id: 401584793 });
+const game = await sdv.nba.espnNbaSummary({ event_id: 401584793 });
 
 // A team's roster
-const roster = await sdv.nfl.espn_nfl_team_roster({ team_id: 12 });
+const roster = await sdv.nfl.espnNflTeamRoster({ team_id: 12 });
 ```
 
 The same methods exist on **every** league, so switching sports is a one-token
 change:
 
 ```js
-await sdv.nfl.espn_nfl_scoreboard({ week: 1, season_type: 2 });
-await sdv.nhl.espn_nhl_scoreboard({});
-await sdv.cfb.espn_cfb_rankings({});          // NCAA-scoped endpoint
-await sdv.wnba.espn_wnba_standings({ season: 2024 });
+await sdv.nfl.espnNflScoreboard({ week: 1, season_type: 2 });
+await sdv.nhl.espnNhlScoreboard({});
+await sdv.cfb.espnCfbRankings({});          // NCAA-scoped endpoint
+await sdv.wnba.espnWnbaStandings({ season: 2024 });
 ```
 
 Multi-league sports (soccer, cricket) take an extra `league` slug:
 
 ```js
 // English Premier League scoreboard
-await sdv.soccer.espn_soccer_scoreboard({ league: 'eng.1' });
+await sdv.soccer.espnSoccerScoreboard({ league: 'eng.1' });
 // La Liga, same call
-await sdv.soccer.espn_soccer_scoreboard({ league: 'esp.1' });
+await sdv.soccer.espnSoccerScoreboard({ league: 'esp.1' });
 ```
 
 ### Parameters: snake_case **or** camelCase
@@ -81,8 +83,8 @@ Every wrapper accepts either spelling, so it reads naturally from JS or matches
 the Python/R sister packages:
 
 ```js
-await sdv.nfl.espn_nfl_team_schedule({ team_id: 12, season: 2024 });
-await sdv.nfl.espn_nfl_team_schedule({ teamId: 12, season: 2024 });  // identical
+await sdv.nfl.espnNflTeamSchedule({ team_id: 12, season: 2024 });
+await sdv.nfl.espnNflTeamSchedule({ teamId: 12, season: 2024 });  // identical
 ```
 
 ### Legacy methods still work
@@ -116,13 +118,13 @@ import sdv, { LEAGUES, WRAPPERS } from 'sportsdataverse';
 
 LEAGUES.map((l) => l.prefix);            // ['nba','nfl','nhl',...,'soccer','cricket','ufl',...]
 WRAPPERS.length;                          // 116 endpoint definitions
-Object.keys(sdv.nba).filter((k) => k.startsWith('espn_nba_'));  // every NBA wrapper
+Object.keys(sdv.nba).filter((k) => k.startsWith('espnNba'));  // every NBA wrapper
 ```
 
 ## Where to next
 
 - **[Tutorials](./tutorials/quickstart)** — guided, copy-pasteable walkthroughs.
-- **[Reference](./reference/)** — every `espn_<league>_<endpoint>` wrapper, by league.
+- **[Reference](./reference/)** — every `espn<League><Endpoint>` wrapper, by league.
 - **[Playground](/playground)** — run live ESPN calls in your browser.
 - **[API (TypeDoc)](./api/)** — the full typed module surface.
 

--- a/docs/docs/reference/bundesliga.md
+++ b/docs/docs/reference/bundesliga.md
@@ -14,125 +14,125 @@ sidebar_position: 19
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.bundesliga.espn_bundesliga_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.bundesliga.espnBundesliga<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_bundesliga_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.bundesliga.espn_bundesliga_scoreboard({});
+await sdv.bundesliga.espnBundesligaScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_bundesliga_athlete_awards` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_bio` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_career_stats` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_bundesliga_athlete_contracts` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_core` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_eventlog` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_gamelog` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_bundesliga_athlete_info` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_injuries` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_news` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_notes` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_overview` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_records` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_seasons` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_splits` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_bundesliga_athlete_statisticslog` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_bundesliga_athlete_stats` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_bundesliga_athlete_vs_athlete` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_bundesliga_athletes_index` | `core_v2` `/soccer/leagues/ger.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_bundesliga_award` | `core_v2` `/soccer/leagues/ger.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_bundesliga_awards` | `core_v2` `/soccer/leagues/ger.1/awards` | — | — |
-| `espn_bundesliga_calendar` | `site_v2` `/soccer/ger.1/calendar` | — | — |
-| `espn_bundesliga_coach` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_bundesliga_coach_record` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_bundesliga_coach_season` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_bundesliga_conferences` | `site_v2` `/soccer/ger.1/groups` | — | — |
-| `espn_bundesliga_draft` | `site_v2` `/soccer/ger.1/draft` | — | — |
-| `espn_bundesliga_event` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}` | `event_id`\* | — |
-| `espn_bundesliga_event_broadcasts` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_competition` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor_leaders` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor_linescores` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor_record` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor_roster` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitor_statistics` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_bundesliga_event_competitors` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_leaders` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_odds` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_official_detail` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_bundesliga_event_officials` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_play` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_bundesliga_event_play_personnel` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_bundesliga_event_plays` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_bundesliga_event_powerindex` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_predictor` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_probabilities` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_bundesliga_event_propbets` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_scoringplays` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_situation` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_event_status` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_bundesliga_events` | `core_v2` `/soccer/leagues/ger.1/events` | — | `dates`, `limit` |
-| `espn_bundesliga_franchise` | `core_v2` `/soccer/leagues/ger.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_bundesliga_franchises` | `core_v2` `/soccer/leagues/ger.1/franchises` | — | `limit` |
-| `espn_bundesliga_injuries` | `site_v2` `/soccer/ger.1/injuries` | — | — |
-| `espn_bundesliga_leaders` | `web_v3` `/soccer/ger.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_bundesliga_leaders_core` | `core_v2` `/soccer/leagues/ger.1/leaders` | — | — |
-| `espn_bundesliga_league_notes` | `core_v2` `/soccer/leagues/ger.1/notes` | — | — |
-| `espn_bundesliga_league_root` | `core_v2` `/soccer/leagues/ger.1` | — | — |
-| `espn_bundesliga_news` | `site_v2` `/soccer/ger.1/news` | — | `limit` |
-| `espn_bundesliga_position` | `core_v2` `/soccer/leagues/ger.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_bundesliga_positions` | `core_v2` `/soccer/leagues/ger.1/positions` | — | — |
-| `espn_bundesliga_scoreboard` | `site_v2` `/soccer/ger.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_bundesliga_season_athletes` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_bundesliga_season_awards` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_bundesliga_season_coaches` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_bundesliga_season_draft` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_bundesliga_season_draft_round_picks` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_bundesliga_season_freeagents` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_bundesliga_season_futures` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_bundesliga_season_group` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_bundesliga_season_group_children` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_bundesliga_season_group_teams` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_bundesliga_season_groups` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_bundesliga_season_info` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}` | `season`\* | — |
-| `espn_bundesliga_season_pointer` | `core_v2` `/soccer/leagues/ger.1/season` | — | — |
-| `espn_bundesliga_season_powerindex` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_bundesliga_season_powerindex_leaders` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_bundesliga_season_team` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_bundesliga_season_teams` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_bundesliga_season_type` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_bundesliga_season_type_corrections` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_bundesliga_season_type_leaders` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_bundesliga_season_types` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types` | `season`\* | — |
-| `espn_bundesliga_season_week` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_bundesliga_season_week_events` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_bundesliga_season_weeks` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_bundesliga_seasons` | `core_v2` `/soccer/leagues/ger.1/seasons` | — | `limit` |
-| `espn_bundesliga_standings` | `site_v2_alt` `/soccer/ger.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_bundesliga_standings_core` | `core_v2` `/soccer/leagues/ger.1/standings` | — | — |
-| `espn_bundesliga_statistics_league` | `site_v2` `/soccer/ger.1/statistics` | — | — |
-| `espn_bundesliga_summary` | `site_v2` `/soccer/ger.1/summary` | — | `event_id` → `event` |
-| `espn_bundesliga_talentpicks` | `core_v2` `/soccer/leagues/ger.1/talentpicks` | — | — |
-| `espn_bundesliga_team` | `site_v2` `/soccer/ger.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_bundesliga_team_core` | `core_v2` `/soccer/leagues/ger.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_bundesliga_team_depthcharts` | `site_v2` `/soccer/ger.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_bundesliga_team_history` | `site_v2` `/soccer/ger.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_bundesliga_team_injuries` | `site_v2` `/soccer/ger.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_bundesliga_team_leaders` | `site_v2` `/soccer/ger.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_bundesliga_team_news` | `site_v2` `/soccer/ger.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_bundesliga_team_record` | `site_v2` `/soccer/ger.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_bundesliga_team_roster` | `site_v2` `/soccer/ger.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_bundesliga_team_schedule` | `site_v2` `/soccer/ger.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_bundesliga_team_transactions` | `site_v2` `/soccer/ger.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_bundesliga_teams_core` | `core_v2` `/soccer/leagues/ger.1/teams` | — | `limit` |
-| `espn_bundesliga_teams_site` | `site_v2` `/soccer/ger.1/teams` | — | `limit` |
-| `espn_bundesliga_tournaments` | `core_v2` `/soccer/leagues/ger.1/tournaments` | — | — |
-| `espn_bundesliga_transactions` | `site_v2` `/soccer/ger.1/transactions` | — | — |
-| `espn_bundesliga_venue` | `core_v2` `/soccer/leagues/ger.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_bundesliga_venues` | `core_v2` `/soccer/leagues/ger.1/venues` | — | `limit` |
+| `espnBundesligaAthleteAwards` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnBundesligaAthleteBio` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnBundesligaAthleteCareerStats` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnBundesligaAthleteContracts` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnBundesligaAthleteCore` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnBundesligaAthleteEventlog` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnBundesligaAthleteGamelog` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnBundesligaAthleteInfo` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnBundesligaAthleteInjuries` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnBundesligaAthleteNews` | `site_v2` `/soccer/ger.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnBundesligaAthleteNotes` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnBundesligaAthleteOverview` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnBundesligaAthleteRecords` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnBundesligaAthleteSeasons` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnBundesligaAthleteSplits` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnBundesligaAthleteStatisticslog` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnBundesligaAthleteStats` | `web_v3` `/soccer/ger.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnBundesligaAthleteVsAthlete` | `core_v2` `/soccer/leagues/ger.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnBundesligaAthletesIndex` | `core_v2` `/soccer/leagues/ger.1/athletes` | — | `active`, `limit`, `page` |
+| `espnBundesligaAward` | `core_v2` `/soccer/leagues/ger.1/awards/{award_id}` | `award_id`\* | — |
+| `espnBundesligaAwards` | `core_v2` `/soccer/leagues/ger.1/awards` | — | — |
+| `espnBundesligaCalendar` | `site_v2` `/soccer/ger.1/calendar` | — | — |
+| `espnBundesligaCoach` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnBundesligaCoachRecord` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnBundesligaCoachSeason` | `core_v2` `/soccer/leagues/ger.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnBundesligaConferences` | `site_v2` `/soccer/ger.1/groups` | — | — |
+| `espnBundesligaDraft` | `site_v2` `/soccer/ger.1/draft` | — | — |
+| `espnBundesligaEvent` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}` | `event_id`\* | — |
+| `espnBundesligaEventBroadcasts` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventCompetition` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitor` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitorLeaders` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitorLinescores` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitorRecord` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitorRoster` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitorStatistics` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnBundesligaEventCompetitors` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventLeaders` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventOdds` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventOfficialDetail` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnBundesligaEventOfficials` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventPlay` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnBundesligaEventPlayPersonnel` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnBundesligaEventPlays` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnBundesligaEventPowerindex` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventPredictor` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventProbabilities` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnBundesligaEventPropbets` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventScoringplays` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventSituation` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnBundesligaEventStatus` | `core_v2` `/soccer/leagues/ger.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnBundesligaEvents` | `core_v2` `/soccer/leagues/ger.1/events` | — | `dates`, `limit` |
+| `espnBundesligaFranchise` | `core_v2` `/soccer/leagues/ger.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnBundesligaFranchises` | `core_v2` `/soccer/leagues/ger.1/franchises` | — | `limit` |
+| `espnBundesligaInjuries` | `site_v2` `/soccer/ger.1/injuries` | — | — |
+| `espnBundesligaLeaders` | `web_v3` `/soccer/ger.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnBundesligaLeadersCore` | `core_v2` `/soccer/leagues/ger.1/leaders` | — | — |
+| `espnBundesligaLeagueNotes` | `core_v2` `/soccer/leagues/ger.1/notes` | — | — |
+| `espnBundesligaLeagueRoot` | `core_v2` `/soccer/leagues/ger.1` | — | — |
+| `espnBundesligaNews` | `site_v2` `/soccer/ger.1/news` | — | `limit` |
+| `espnBundesligaPosition` | `core_v2` `/soccer/leagues/ger.1/positions/{position_id}` | `position_id`\* | — |
+| `espnBundesligaPositions` | `core_v2` `/soccer/leagues/ger.1/positions` | — | — |
+| `espnBundesligaScoreboard` | `site_v2` `/soccer/ger.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnBundesligaSeasonAthletes` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnBundesligaSeasonAwards` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/awards` | `season`\* | — |
+| `espnBundesligaSeasonCoaches` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnBundesligaSeasonDraft` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/draft` | `season`\* | — |
+| `espnBundesligaSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnBundesligaSeasonFreeagents` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnBundesligaSeasonFutures` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/futures` | `season`\* | — |
+| `espnBundesligaSeasonGroup` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnBundesligaSeasonGroupChildren` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnBundesligaSeasonGroupTeams` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnBundesligaSeasonGroups` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnBundesligaSeasonInfo` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}` | `season`\* | — |
+| `espnBundesligaSeasonPointer` | `core_v2` `/soccer/leagues/ger.1/season` | — | — |
+| `espnBundesligaSeasonPowerindex` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnBundesligaSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnBundesligaSeasonTeam` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnBundesligaSeasonTeams` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnBundesligaSeasonType` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnBundesligaSeasonTypeCorrections` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnBundesligaSeasonTypeLeaders` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnBundesligaSeasonTypes` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types` | `season`\* | — |
+| `espnBundesligaSeasonWeek` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnBundesligaSeasonWeekEvents` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnBundesligaSeasonWeeks` | `core_v2` `/soccer/leagues/ger.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnBundesligaSeasons` | `core_v2` `/soccer/leagues/ger.1/seasons` | — | `limit` |
+| `espnBundesligaStandings` | `site_v2_alt` `/soccer/ger.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnBundesligaStandingsCore` | `core_v2` `/soccer/leagues/ger.1/standings` | — | — |
+| `espnBundesligaStatisticsLeague` | `site_v2` `/soccer/ger.1/statistics` | — | — |
+| `espnBundesligaSummary` | `site_v2` `/soccer/ger.1/summary` | — | `event_id` → `event` |
+| `espnBundesligaTalentpicks` | `core_v2` `/soccer/leagues/ger.1/talentpicks` | — | — |
+| `espnBundesligaTeam` | `site_v2` `/soccer/ger.1/teams/{team_id}` | `team_id`\* | — |
+| `espnBundesligaTeamCore` | `core_v2` `/soccer/leagues/ger.1/teams/{team_id}` | `team_id`\* | — |
+| `espnBundesligaTeamDepthcharts` | `site_v2` `/soccer/ger.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnBundesligaTeamHistory` | `site_v2` `/soccer/ger.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnBundesligaTeamInjuries` | `site_v2` `/soccer/ger.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnBundesligaTeamLeaders` | `site_v2` `/soccer/ger.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnBundesligaTeamNews` | `site_v2` `/soccer/ger.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnBundesligaTeamRecord` | `site_v2` `/soccer/ger.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnBundesligaTeamRoster` | `site_v2` `/soccer/ger.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnBundesligaTeamSchedule` | `site_v2` `/soccer/ger.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnBundesligaTeamTransactions` | `site_v2` `/soccer/ger.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnBundesligaTeamsCore` | `core_v2` `/soccer/leagues/ger.1/teams` | — | `limit` |
+| `espnBundesligaTeamsSite` | `site_v2` `/soccer/ger.1/teams` | — | `limit` |
+| `espnBundesligaTournaments` | `core_v2` `/soccer/leagues/ger.1/tournaments` | — | — |
+| `espnBundesligaTransactions` | `site_v2` `/soccer/ger.1/transactions` | — | — |
+| `espnBundesligaVenue` | `core_v2` `/soccer/leagues/ger.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnBundesligaVenues` | `core_v2` `/soccer/leagues/ger.1/venues` | — | `limit` |

--- a/docs/docs/reference/cfb.md
+++ b/docs/docs/reference/cfb.md
@@ -14,140 +14,140 @@ sidebar_position: 5
 - **scopes:** `universal`, `ncaa`, `football`
 - **wrappers:** 115
 
-Every endpoint is called as `sdv.cfb.espn_cfb_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.cfb.espnCfb<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_cfb_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.cfb.espn_cfb_scoreboard({});
+await sdv.cfb.espnCfbScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_cfb_athlete_awards` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_cfb_athlete_bio` | `site_v2` `/football/college-football/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_cfb_athlete_career_stats` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_cfb_athlete_contracts` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_cfb_athlete_core` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cfb_athlete_eventlog` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_cfb_athlete_gamelog` | `web_v3` `/football/college-football/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_cfb_athlete_info` | `site_v2` `/football/college-football/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cfb_athlete_injuries` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_cfb_athlete_news` | `site_v2` `/football/college-football/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_cfb_athlete_notes` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_cfb_athlete_overview` | `web_v3` `/football/college-football/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_cfb_athlete_records` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_cfb_athlete_seasons` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_cfb_athlete_splits` | `web_v3` `/football/college-football/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_cfb_athlete_statisticslog` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_cfb_athlete_stats` | `web_v3` `/football/college-football/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_cfb_athlete_vs_athlete` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_cfb_athletes_index` | `core_v2` `/football/leagues/college-football/athletes` | — | `active`, `limit`, `page` |
-| `espn_cfb_award` | `core_v2` `/football/leagues/college-football/awards/{award_id}` | `award_id`\* | — |
-| `espn_cfb_awards` | `core_v2` `/football/leagues/college-football/awards` | — | — |
-| `espn_cfb_calendar` | `site_v2` `/football/college-football/calendar` | — | — |
-| `espn_cfb_coach` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_cfb_coach_record` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_cfb_coach_season` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_cfb_conferences` | `site_v2` `/football/college-football/groups` | — | — |
-| `espn_cfb_draft` | `site_v2` `/football/college-football/draft` | — | — |
-| `espn_cfb_event` | `core_v2` `/football/leagues/college-football/events/{event_id}` | `event_id`\* | — |
-| `espn_cfb_event_broadcasts` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_competition` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_competitor` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitor_leaders` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitor_linescores` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitor_record` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitor_roster` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitor_statistics` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfb_event_competitors` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_leaders` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_odds` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_official_detail` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_cfb_event_officials` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_play` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cfb_event_play_personnel` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cfb_event_plays` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_cfb_event_powerindex` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_predictor` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_probabilities` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_cfb_event_propbets` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_scoringplays` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_situation` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_cfb_event_status` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_cfb_events` | `core_v2` `/football/leagues/college-football/events` | — | `dates`, `limit` |
-| `espn_cfb_franchise` | `core_v2` `/football/leagues/college-football/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_cfb_franchises` | `core_v2` `/football/leagues/college-football/franchises` | — | `limit` |
-| `espn_cfb_injuries` | `site_v2` `/football/college-football/injuries` | — | — |
-| `espn_cfb_leaders` | `web_v3` `/football/college-football/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_cfb_leaders_core` | `core_v2` `/football/leagues/college-football/leaders` | — | — |
-| `espn_cfb_league_notes` | `core_v2` `/football/leagues/college-football/notes` | — | — |
-| `espn_cfb_league_root` | `core_v2` `/football/leagues/college-football` | — | — |
-| `espn_cfb_news` | `site_v2` `/football/college-football/news` | — | `limit` |
-| `espn_cfb_position` | `core_v2` `/football/leagues/college-football/positions/{position_id}` | `position_id`\* | — |
-| `espn_cfb_positions` | `core_v2` `/football/leagues/college-football/positions` | — | — |
-| `espn_cfb_scoreboard` | `site_v2` `/football/college-football/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_cfb_season_athletes` | `core_v2` `/football/leagues/college-football/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_cfb_season_awards` | `core_v2` `/football/leagues/college-football/seasons/{season}/awards` | `season`\* | — |
-| `espn_cfb_season_coaches` | `core_v2` `/football/leagues/college-football/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_cfb_season_draft` | `core_v2` `/football/leagues/college-football/seasons/{season}/draft` | `season`\* | — |
-| `espn_cfb_season_draft_round_picks` | `core_v2` `/football/leagues/college-football/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_cfb_season_freeagents` | `core_v2` `/football/leagues/college-football/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_cfb_season_futures` | `core_v2` `/football/leagues/college-football/seasons/{season}/futures` | `season`\* | — |
-| `espn_cfb_season_group` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cfb_season_group_children` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cfb_season_group_teams` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_cfb_season_groups` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_cfb_season_info` | `core_v2` `/football/leagues/college-football/seasons/{season}` | `season`\* | — |
-| `espn_cfb_season_pointer` | `core_v2` `/football/leagues/college-football/season` | — | — |
-| `espn_cfb_season_powerindex` | `core_v2` `/football/leagues/college-football/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_cfb_season_powerindex_leaders` | `core_v2` `/football/leagues/college-football/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_cfb_season_team` | `core_v2` `/football/leagues/college-football/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_cfb_season_teams` | `core_v2` `/football/leagues/college-football/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_cfb_season_type` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_cfb_season_type_corrections` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_cfb_season_type_leaders` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_cfb_season_types` | `core_v2` `/football/leagues/college-football/seasons/{season}/types` | `season`\* | — |
-| `espn_cfb_season_week` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_cfb_season_week_events` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_cfb_season_weeks` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_cfb_seasons` | `core_v2` `/football/leagues/college-football/seasons` | — | `limit` |
-| `espn_cfb_standings` | `site_v2_alt` `/football/college-football/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_cfb_standings_core` | `core_v2` `/football/leagues/college-football/standings` | — | — |
-| `espn_cfb_statistics_league` | `site_v2` `/football/college-football/statistics` | — | — |
-| `espn_cfb_summary` | `site_v2` `/football/college-football/summary` | — | `event_id` → `event` |
-| `espn_cfb_talentpicks` | `core_v2` `/football/leagues/college-football/talentpicks` | — | — |
-| `espn_cfb_team` | `site_v2` `/football/college-football/teams/{team_id}` | `team_id`\* | — |
-| `espn_cfb_team_core` | `core_v2` `/football/leagues/college-football/teams/{team_id}` | `team_id`\* | — |
-| `espn_cfb_team_depthcharts` | `site_v2` `/football/college-football/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_cfb_team_history` | `site_v2` `/football/college-football/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_cfb_team_injuries` | `site_v2` `/football/college-football/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_cfb_team_leaders` | `site_v2` `/football/college-football/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_cfb_team_news` | `site_v2` `/football/college-football/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_cfb_team_record` | `site_v2` `/football/college-football/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_cfb_team_roster` | `site_v2` `/football/college-football/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_cfb_team_schedule` | `site_v2` `/football/college-football/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_cfb_team_transactions` | `site_v2` `/football/college-football/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_cfb_teams_core` | `core_v2` `/football/leagues/college-football/teams` | — | `limit` |
-| `espn_cfb_teams_site` | `site_v2` `/football/college-football/teams` | — | `limit` |
-| `espn_cfb_tournaments` | `core_v2` `/football/leagues/college-football/tournaments` | — | — |
-| `espn_cfb_transactions` | `site_v2` `/football/college-football/transactions` | — | — |
-| `espn_cfb_venue` | `core_v2` `/football/leagues/college-football/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_cfb_venues` | `core_v2` `/football/leagues/college-football/venues` | — | `limit` |
+| `espnCfbAthleteAwards` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnCfbAthleteBio` | `site_v2` `/football/college-football/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnCfbAthleteCareerStats` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnCfbAthleteContracts` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnCfbAthleteCore` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCfbAthleteEventlog` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnCfbAthleteGamelog` | `web_v3` `/football/college-football/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnCfbAthleteInfo` | `site_v2` `/football/college-football/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCfbAthleteInjuries` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnCfbAthleteNews` | `site_v2` `/football/college-football/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnCfbAthleteNotes` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnCfbAthleteOverview` | `web_v3` `/football/college-football/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnCfbAthleteRecords` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnCfbAthleteSeasons` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnCfbAthleteSplits` | `web_v3` `/football/college-football/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnCfbAthleteStatisticslog` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnCfbAthleteStats` | `web_v3` `/football/college-football/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnCfbAthleteVsAthlete` | `core_v2` `/football/leagues/college-football/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnCfbAthletesIndex` | `core_v2` `/football/leagues/college-football/athletes` | — | `active`, `limit`, `page` |
+| `espnCfbAward` | `core_v2` `/football/leagues/college-football/awards/{award_id}` | `award_id`\* | — |
+| `espnCfbAwards` | `core_v2` `/football/leagues/college-football/awards` | — | — |
+| `espnCfbCalendar` | `site_v2` `/football/college-football/calendar` | — | — |
+| `espnCfbCoach` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnCfbCoachRecord` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnCfbCoachSeason` | `core_v2` `/football/leagues/college-football/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnCfbConferences` | `site_v2` `/football/college-football/groups` | — | — |
+| `espnCfbDraft` | `site_v2` `/football/college-football/draft` | — | — |
+| `espnCfbEvent` | `core_v2` `/football/leagues/college-football/events/{event_id}` | `event_id`\* | — |
+| `espnCfbEventBroadcasts` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnCfbEventCompetition` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnCfbEventCompetitor` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitorLeaders` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitorLinescores` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitorRecord` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitorRoster` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitorStatistics` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCfbEventCompetitors` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnCfbEventLeaders` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnCfbEventOdds` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnCfbEventOfficialDetail` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnCfbEventOfficials` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnCfbEventPlay` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCfbEventPlayPersonnel` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCfbEventPlays` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnCfbEventPowerindex` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnCfbEventPredictor` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnCfbEventProbabilities` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnCfbEventPropbets` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnCfbEventScoringplays` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnCfbEventSituation` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnCfbEventStatus` | `core_v2` `/football/leagues/college-football/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnCfbEvents` | `core_v2` `/football/leagues/college-football/events` | — | `dates`, `limit` |
+| `espnCfbFranchise` | `core_v2` `/football/leagues/college-football/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnCfbFranchises` | `core_v2` `/football/leagues/college-football/franchises` | — | `limit` |
+| `espnCfbInjuries` | `site_v2` `/football/college-football/injuries` | — | — |
+| `espnCfbLeaders` | `web_v3` `/football/college-football/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnCfbLeadersCore` | `core_v2` `/football/leagues/college-football/leaders` | — | — |
+| `espnCfbLeagueNotes` | `core_v2` `/football/leagues/college-football/notes` | — | — |
+| `espnCfbLeagueRoot` | `core_v2` `/football/leagues/college-football` | — | — |
+| `espnCfbNews` | `site_v2` `/football/college-football/news` | — | `limit` |
+| `espnCfbPosition` | `core_v2` `/football/leagues/college-football/positions/{position_id}` | `position_id`\* | — |
+| `espnCfbPositions` | `core_v2` `/football/leagues/college-football/positions` | — | — |
+| `espnCfbScoreboard` | `site_v2` `/football/college-football/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnCfbSeasonAthletes` | `core_v2` `/football/leagues/college-football/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnCfbSeasonAwards` | `core_v2` `/football/leagues/college-football/seasons/{season}/awards` | `season`\* | — |
+| `espnCfbSeasonCoaches` | `core_v2` `/football/leagues/college-football/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnCfbSeasonDraft` | `core_v2` `/football/leagues/college-football/seasons/{season}/draft` | `season`\* | — |
+| `espnCfbSeasonDraftRoundPicks` | `core_v2` `/football/leagues/college-football/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnCfbSeasonFreeagents` | `core_v2` `/football/leagues/college-football/seasons/{season}/freeagents` | `season`\* | — |
+| `espnCfbSeasonFutures` | `core_v2` `/football/leagues/college-football/seasons/{season}/futures` | `season`\* | — |
+| `espnCfbSeasonGroup` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCfbSeasonGroupChildren` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCfbSeasonGroupTeams` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnCfbSeasonGroups` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnCfbSeasonInfo` | `core_v2` `/football/leagues/college-football/seasons/{season}` | `season`\* | — |
+| `espnCfbSeasonPointer` | `core_v2` `/football/leagues/college-football/season` | — | — |
+| `espnCfbSeasonPowerindex` | `core_v2` `/football/leagues/college-football/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnCfbSeasonPowerindexLeaders` | `core_v2` `/football/leagues/college-football/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnCfbSeasonTeam` | `core_v2` `/football/leagues/college-football/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnCfbSeasonTeams` | `core_v2` `/football/leagues/college-football/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnCfbSeasonType` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnCfbSeasonTypeCorrections` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnCfbSeasonTypeLeaders` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnCfbSeasonTypes` | `core_v2` `/football/leagues/college-football/seasons/{season}/types` | `season`\* | — |
+| `espnCfbSeasonWeek` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCfbSeasonWeekEvents` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnCfbSeasonWeeks` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnCfbSeasons` | `core_v2` `/football/leagues/college-football/seasons` | — | `limit` |
+| `espnCfbStandings` | `site_v2_alt` `/football/college-football/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnCfbStandingsCore` | `core_v2` `/football/leagues/college-football/standings` | — | — |
+| `espnCfbStatisticsLeague` | `site_v2` `/football/college-football/statistics` | — | — |
+| `espnCfbSummary` | `site_v2` `/football/college-football/summary` | — | `event_id` → `event` |
+| `espnCfbTalentpicks` | `core_v2` `/football/leagues/college-football/talentpicks` | — | — |
+| `espnCfbTeam` | `site_v2` `/football/college-football/teams/{team_id}` | `team_id`\* | — |
+| `espnCfbTeamCore` | `core_v2` `/football/leagues/college-football/teams/{team_id}` | `team_id`\* | — |
+| `espnCfbTeamDepthcharts` | `site_v2` `/football/college-football/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnCfbTeamHistory` | `site_v2` `/football/college-football/teams/{team_id}/history` | `team_id`\* | — |
+| `espnCfbTeamInjuries` | `site_v2` `/football/college-football/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnCfbTeamLeaders` | `site_v2` `/football/college-football/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnCfbTeamNews` | `site_v2` `/football/college-football/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnCfbTeamRecord` | `site_v2` `/football/college-football/teams/{team_id}/record` | `team_id`\* | — |
+| `espnCfbTeamRoster` | `site_v2` `/football/college-football/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnCfbTeamSchedule` | `site_v2` `/football/college-football/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnCfbTeamTransactions` | `site_v2` `/football/college-football/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnCfbTeamsCore` | `core_v2` `/football/leagues/college-football/teams` | — | `limit` |
+| `espnCfbTeamsSite` | `site_v2` `/football/college-football/teams` | — | `limit` |
+| `espnCfbTournaments` | `core_v2` `/football/leagues/college-football/tournaments` | — | — |
+| `espnCfbTransactions` | `site_v2` `/football/college-football/transactions` | — | — |
+| `espnCfbVenue` | `core_v2` `/football/leagues/college-football/venues/{venue_id}` | `venue_id`\* | — |
+| `espnCfbVenues` | `core_v2` `/football/leagues/college-football/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_cfb_rankings` | `site_v2` `/football/college-football/rankings` | — | — |
-| `espn_cfb_season_recruits` | `core_v2` `/football/leagues/college-football/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_cfb_season_week_rankings` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCfbRankings` | `site_v2` `/football/college-football/rankings` | — | — |
+| `espnCfbSeasonRecruits` | `core_v2` `/football/leagues/college-football/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnCfbSeasonWeekRankings` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
 
 ## Football endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_cfb_season_qbr` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}[/groups/{group_id}]/qbr/{split}` | `season`\*, `season_type`, `group_id`, `split` | — |
-| `espn_cfb_season_qbr_week` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/qbr/{split}` | `season`\*, `week`\*, `season_type`, `split` | — |
+| `espnCfbSeasonQbr` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}[/groups/{group_id}]/qbr/{split}` | `season`\*, `season_type`, `group_id`, `split` | — |
+| `espnCfbSeasonQbrWeek` | `core_v2` `/football/leagues/college-football/seasons/{season}/types/{season_type}/weeks/{week}/qbr/{split}` | `season`\*, `week`\*, `season_type`, `split` | — |

--- a/docs/docs/reference/cfl.md
+++ b/docs/docs/reference/cfl.md
@@ -14,125 +14,125 @@ sidebar_position: 15
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.cfl.espn_cfl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.cfl.espnCfl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_cfl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.cfl.espn_cfl_scoreboard({});
+await sdv.cfl.espnCflScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_cfl_athlete_awards` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_cfl_athlete_bio` | `site_v2` `/football/cfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_cfl_athlete_career_stats` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_cfl_athlete_contracts` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_cfl_athlete_core` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cfl_athlete_eventlog` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_cfl_athlete_gamelog` | `web_v3` `/football/cfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_cfl_athlete_info` | `site_v2` `/football/cfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cfl_athlete_injuries` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_cfl_athlete_news` | `site_v2` `/football/cfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_cfl_athlete_notes` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_cfl_athlete_overview` | `web_v3` `/football/cfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_cfl_athlete_records` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_cfl_athlete_seasons` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_cfl_athlete_splits` | `web_v3` `/football/cfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_cfl_athlete_statisticslog` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_cfl_athlete_stats` | `web_v3` `/football/cfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_cfl_athlete_vs_athlete` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_cfl_athletes_index` | `core_v2` `/football/leagues/cfl/athletes` | — | `active`, `limit`, `page` |
-| `espn_cfl_award` | `core_v2` `/football/leagues/cfl/awards/{award_id}` | `award_id`\* | — |
-| `espn_cfl_awards` | `core_v2` `/football/leagues/cfl/awards` | — | — |
-| `espn_cfl_calendar` | `site_v2` `/football/cfl/calendar` | — | — |
-| `espn_cfl_coach` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_cfl_coach_record` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_cfl_coach_season` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_cfl_conferences` | `site_v2` `/football/cfl/groups` | — | — |
-| `espn_cfl_draft` | `site_v2` `/football/cfl/draft` | — | — |
-| `espn_cfl_event` | `core_v2` `/football/leagues/cfl/events/{event_id}` | `event_id`\* | — |
-| `espn_cfl_event_broadcasts` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_competition` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_competitor` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitor_leaders` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitor_linescores` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitor_record` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitor_roster` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitor_statistics` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cfl_event_competitors` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_leaders` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_odds` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_official_detail` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_cfl_event_officials` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_play` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cfl_event_play_personnel` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cfl_event_plays` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_cfl_event_powerindex` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_predictor` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_probabilities` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_cfl_event_propbets` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_scoringplays` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_situation` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_cfl_event_status` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_cfl_events` | `core_v2` `/football/leagues/cfl/events` | — | `dates`, `limit` |
-| `espn_cfl_franchise` | `core_v2` `/football/leagues/cfl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_cfl_franchises` | `core_v2` `/football/leagues/cfl/franchises` | — | `limit` |
-| `espn_cfl_injuries` | `site_v2` `/football/cfl/injuries` | — | — |
-| `espn_cfl_leaders` | `web_v3` `/football/cfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_cfl_leaders_core` | `core_v2` `/football/leagues/cfl/leaders` | — | — |
-| `espn_cfl_league_notes` | `core_v2` `/football/leagues/cfl/notes` | — | — |
-| `espn_cfl_league_root` | `core_v2` `/football/leagues/cfl` | — | — |
-| `espn_cfl_news` | `site_v2` `/football/cfl/news` | — | `limit` |
-| `espn_cfl_position` | `core_v2` `/football/leagues/cfl/positions/{position_id}` | `position_id`\* | — |
-| `espn_cfl_positions` | `core_v2` `/football/leagues/cfl/positions` | — | — |
-| `espn_cfl_scoreboard` | `site_v2` `/football/cfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_cfl_season_athletes` | `core_v2` `/football/leagues/cfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_cfl_season_awards` | `core_v2` `/football/leagues/cfl/seasons/{season}/awards` | `season`\* | — |
-| `espn_cfl_season_coaches` | `core_v2` `/football/leagues/cfl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_cfl_season_draft` | `core_v2` `/football/leagues/cfl/seasons/{season}/draft` | `season`\* | — |
-| `espn_cfl_season_draft_round_picks` | `core_v2` `/football/leagues/cfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_cfl_season_freeagents` | `core_v2` `/football/leagues/cfl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_cfl_season_futures` | `core_v2` `/football/leagues/cfl/seasons/{season}/futures` | `season`\* | — |
-| `espn_cfl_season_group` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cfl_season_group_children` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cfl_season_group_teams` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_cfl_season_groups` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_cfl_season_info` | `core_v2` `/football/leagues/cfl/seasons/{season}` | `season`\* | — |
-| `espn_cfl_season_pointer` | `core_v2` `/football/leagues/cfl/season` | — | — |
-| `espn_cfl_season_powerindex` | `core_v2` `/football/leagues/cfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_cfl_season_powerindex_leaders` | `core_v2` `/football/leagues/cfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_cfl_season_team` | `core_v2` `/football/leagues/cfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_cfl_season_teams` | `core_v2` `/football/leagues/cfl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_cfl_season_type` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_cfl_season_type_corrections` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_cfl_season_type_leaders` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_cfl_season_types` | `core_v2` `/football/leagues/cfl/seasons/{season}/types` | `season`\* | — |
-| `espn_cfl_season_week` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_cfl_season_week_events` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_cfl_season_weeks` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_cfl_seasons` | `core_v2` `/football/leagues/cfl/seasons` | — | `limit` |
-| `espn_cfl_standings` | `site_v2_alt` `/football/cfl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_cfl_standings_core` | `core_v2` `/football/leagues/cfl/standings` | — | — |
-| `espn_cfl_statistics_league` | `site_v2` `/football/cfl/statistics` | — | — |
-| `espn_cfl_summary` | `site_v2` `/football/cfl/summary` | — | `event_id` → `event` |
-| `espn_cfl_talentpicks` | `core_v2` `/football/leagues/cfl/talentpicks` | — | — |
-| `espn_cfl_team` | `site_v2` `/football/cfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_cfl_team_core` | `core_v2` `/football/leagues/cfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_cfl_team_depthcharts` | `site_v2` `/football/cfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_cfl_team_history` | `site_v2` `/football/cfl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_cfl_team_injuries` | `site_v2` `/football/cfl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_cfl_team_leaders` | `site_v2` `/football/cfl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_cfl_team_news` | `site_v2` `/football/cfl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_cfl_team_record` | `site_v2` `/football/cfl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_cfl_team_roster` | `site_v2` `/football/cfl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_cfl_team_schedule` | `site_v2` `/football/cfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_cfl_team_transactions` | `site_v2` `/football/cfl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_cfl_teams_core` | `core_v2` `/football/leagues/cfl/teams` | — | `limit` |
-| `espn_cfl_teams_site` | `site_v2` `/football/cfl/teams` | — | `limit` |
-| `espn_cfl_tournaments` | `core_v2` `/football/leagues/cfl/tournaments` | — | — |
-| `espn_cfl_transactions` | `site_v2` `/football/cfl/transactions` | — | — |
-| `espn_cfl_venue` | `core_v2` `/football/leagues/cfl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_cfl_venues` | `core_v2` `/football/leagues/cfl/venues` | — | `limit` |
+| `espnCflAthleteAwards` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnCflAthleteBio` | `site_v2` `/football/cfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnCflAthleteCareerStats` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnCflAthleteContracts` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnCflAthleteCore` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCflAthleteEventlog` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnCflAthleteGamelog` | `web_v3` `/football/cfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnCflAthleteInfo` | `site_v2` `/football/cfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCflAthleteInjuries` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnCflAthleteNews` | `site_v2` `/football/cfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnCflAthleteNotes` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnCflAthleteOverview` | `web_v3` `/football/cfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnCflAthleteRecords` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnCflAthleteSeasons` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnCflAthleteSplits` | `web_v3` `/football/cfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnCflAthleteStatisticslog` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnCflAthleteStats` | `web_v3` `/football/cfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnCflAthleteVsAthlete` | `core_v2` `/football/leagues/cfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnCflAthletesIndex` | `core_v2` `/football/leagues/cfl/athletes` | — | `active`, `limit`, `page` |
+| `espnCflAward` | `core_v2` `/football/leagues/cfl/awards/{award_id}` | `award_id`\* | — |
+| `espnCflAwards` | `core_v2` `/football/leagues/cfl/awards` | — | — |
+| `espnCflCalendar` | `site_v2` `/football/cfl/calendar` | — | — |
+| `espnCflCoach` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnCflCoachRecord` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnCflCoachSeason` | `core_v2` `/football/leagues/cfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnCflConferences` | `site_v2` `/football/cfl/groups` | — | — |
+| `espnCflDraft` | `site_v2` `/football/cfl/draft` | — | — |
+| `espnCflEvent` | `core_v2` `/football/leagues/cfl/events/{event_id}` | `event_id`\* | — |
+| `espnCflEventBroadcasts` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnCflEventCompetition` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnCflEventCompetitor` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitorLeaders` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitorLinescores` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitorRecord` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitorRoster` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitorStatistics` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCflEventCompetitors` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnCflEventLeaders` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnCflEventOdds` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnCflEventOfficialDetail` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnCflEventOfficials` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnCflEventPlay` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCflEventPlayPersonnel` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCflEventPlays` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnCflEventPowerindex` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnCflEventPredictor` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnCflEventProbabilities` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnCflEventPropbets` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnCflEventScoringplays` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnCflEventSituation` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnCflEventStatus` | `core_v2` `/football/leagues/cfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnCflEvents` | `core_v2` `/football/leagues/cfl/events` | — | `dates`, `limit` |
+| `espnCflFranchise` | `core_v2` `/football/leagues/cfl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnCflFranchises` | `core_v2` `/football/leagues/cfl/franchises` | — | `limit` |
+| `espnCflInjuries` | `site_v2` `/football/cfl/injuries` | — | — |
+| `espnCflLeaders` | `web_v3` `/football/cfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnCflLeadersCore` | `core_v2` `/football/leagues/cfl/leaders` | — | — |
+| `espnCflLeagueNotes` | `core_v2` `/football/leagues/cfl/notes` | — | — |
+| `espnCflLeagueRoot` | `core_v2` `/football/leagues/cfl` | — | — |
+| `espnCflNews` | `site_v2` `/football/cfl/news` | — | `limit` |
+| `espnCflPosition` | `core_v2` `/football/leagues/cfl/positions/{position_id}` | `position_id`\* | — |
+| `espnCflPositions` | `core_v2` `/football/leagues/cfl/positions` | — | — |
+| `espnCflScoreboard` | `site_v2` `/football/cfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnCflSeasonAthletes` | `core_v2` `/football/leagues/cfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnCflSeasonAwards` | `core_v2` `/football/leagues/cfl/seasons/{season}/awards` | `season`\* | — |
+| `espnCflSeasonCoaches` | `core_v2` `/football/leagues/cfl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnCflSeasonDraft` | `core_v2` `/football/leagues/cfl/seasons/{season}/draft` | `season`\* | — |
+| `espnCflSeasonDraftRoundPicks` | `core_v2` `/football/leagues/cfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnCflSeasonFreeagents` | `core_v2` `/football/leagues/cfl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnCflSeasonFutures` | `core_v2` `/football/leagues/cfl/seasons/{season}/futures` | `season`\* | — |
+| `espnCflSeasonGroup` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCflSeasonGroupChildren` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCflSeasonGroupTeams` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnCflSeasonGroups` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnCflSeasonInfo` | `core_v2` `/football/leagues/cfl/seasons/{season}` | `season`\* | — |
+| `espnCflSeasonPointer` | `core_v2` `/football/leagues/cfl/season` | — | — |
+| `espnCflSeasonPowerindex` | `core_v2` `/football/leagues/cfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnCflSeasonPowerindexLeaders` | `core_v2` `/football/leagues/cfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnCflSeasonTeam` | `core_v2` `/football/leagues/cfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnCflSeasonTeams` | `core_v2` `/football/leagues/cfl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnCflSeasonType` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnCflSeasonTypeCorrections` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnCflSeasonTypeLeaders` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnCflSeasonTypes` | `core_v2` `/football/leagues/cfl/seasons/{season}/types` | `season`\* | — |
+| `espnCflSeasonWeek` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCflSeasonWeekEvents` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnCflSeasonWeeks` | `core_v2` `/football/leagues/cfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnCflSeasons` | `core_v2` `/football/leagues/cfl/seasons` | — | `limit` |
+| `espnCflStandings` | `site_v2_alt` `/football/cfl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnCflStandingsCore` | `core_v2` `/football/leagues/cfl/standings` | — | — |
+| `espnCflStatisticsLeague` | `site_v2` `/football/cfl/statistics` | — | — |
+| `espnCflSummary` | `site_v2` `/football/cfl/summary` | — | `event_id` → `event` |
+| `espnCflTalentpicks` | `core_v2` `/football/leagues/cfl/talentpicks` | — | — |
+| `espnCflTeam` | `site_v2` `/football/cfl/teams/{team_id}` | `team_id`\* | — |
+| `espnCflTeamCore` | `core_v2` `/football/leagues/cfl/teams/{team_id}` | `team_id`\* | — |
+| `espnCflTeamDepthcharts` | `site_v2` `/football/cfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnCflTeamHistory` | `site_v2` `/football/cfl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnCflTeamInjuries` | `site_v2` `/football/cfl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnCflTeamLeaders` | `site_v2` `/football/cfl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnCflTeamNews` | `site_v2` `/football/cfl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnCflTeamRecord` | `site_v2` `/football/cfl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnCflTeamRoster` | `site_v2` `/football/cfl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnCflTeamSchedule` | `site_v2` `/football/cfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnCflTeamTransactions` | `site_v2` `/football/cfl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnCflTeamsCore` | `core_v2` `/football/leagues/cfl/teams` | — | `limit` |
+| `espnCflTeamsSite` | `site_v2` `/football/cfl/teams` | — | `limit` |
+| `espnCflTournaments` | `core_v2` `/football/leagues/cfl/tournaments` | — | — |
+| `espnCflTransactions` | `site_v2` `/football/cfl/transactions` | — | — |
+| `espnCflVenue` | `core_v2` `/football/leagues/cfl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnCflVenues` | `core_v2` `/football/leagues/cfl/venues` | — | `limit` |

--- a/docs/docs/reference/college_baseball.md
+++ b/docs/docs/reference/college_baseball.md
@@ -14,133 +14,133 @@ sidebar_position: 11
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.college_baseball.espn_college_baseball_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.college_baseball.espnCollegeBaseball<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_college_baseball_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.college_baseball.espn_college_baseball_scoreboard({});
+await sdv.college_baseball.espnCollegeBaseballScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_college_baseball_athlete_awards` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_bio` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_career_stats` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_college_baseball_athlete_contracts` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_core` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_eventlog` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_gamelog` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_college_baseball_athlete_info` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_injuries` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_news` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_notes` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_overview` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_records` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_seasons` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_splits` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_college_baseball_athlete_statisticslog` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_college_baseball_athlete_stats` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_college_baseball_athlete_vs_athlete` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_college_baseball_athletes_index` | `core_v2` `/baseball/leagues/college-baseball/athletes` | — | `active`, `limit`, `page` |
-| `espn_college_baseball_award` | `core_v2` `/baseball/leagues/college-baseball/awards/{award_id}` | `award_id`\* | — |
-| `espn_college_baseball_awards` | `core_v2` `/baseball/leagues/college-baseball/awards` | — | — |
-| `espn_college_baseball_calendar` | `site_v2` `/baseball/college-baseball/calendar` | — | — |
-| `espn_college_baseball_coach` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_college_baseball_coach_record` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_college_baseball_coach_season` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_college_baseball_conferences` | `site_v2` `/baseball/college-baseball/groups` | — | — |
-| `espn_college_baseball_draft` | `site_v2` `/baseball/college-baseball/draft` | — | — |
-| `espn_college_baseball_event` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}` | `event_id`\* | — |
-| `espn_college_baseball_event_broadcasts` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_competition` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor_leaders` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor_linescores` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor_record` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor_roster` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitor_statistics` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_baseball_event_competitors` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_leaders` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_odds` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_official_detail` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_college_baseball_event_officials` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_play` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_college_baseball_event_play_personnel` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_college_baseball_event_plays` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_college_baseball_event_powerindex` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_predictor` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_probabilities` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_college_baseball_event_propbets` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_scoringplays` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_situation` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_event_status` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_college_baseball_events` | `core_v2` `/baseball/leagues/college-baseball/events` | — | `dates`, `limit` |
-| `espn_college_baseball_franchise` | `core_v2` `/baseball/leagues/college-baseball/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_college_baseball_franchises` | `core_v2` `/baseball/leagues/college-baseball/franchises` | — | `limit` |
-| `espn_college_baseball_injuries` | `site_v2` `/baseball/college-baseball/injuries` | — | — |
-| `espn_college_baseball_leaders` | `web_v3` `/baseball/college-baseball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_college_baseball_leaders_core` | `core_v2` `/baseball/leagues/college-baseball/leaders` | — | — |
-| `espn_college_baseball_league_notes` | `core_v2` `/baseball/leagues/college-baseball/notes` | — | — |
-| `espn_college_baseball_league_root` | `core_v2` `/baseball/leagues/college-baseball` | — | — |
-| `espn_college_baseball_news` | `site_v2` `/baseball/college-baseball/news` | — | `limit` |
-| `espn_college_baseball_position` | `core_v2` `/baseball/leagues/college-baseball/positions/{position_id}` | `position_id`\* | — |
-| `espn_college_baseball_positions` | `core_v2` `/baseball/leagues/college-baseball/positions` | — | — |
-| `espn_college_baseball_scoreboard` | `site_v2` `/baseball/college-baseball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_college_baseball_season_athletes` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_college_baseball_season_awards` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/awards` | `season`\* | — |
-| `espn_college_baseball_season_coaches` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_college_baseball_season_draft` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/draft` | `season`\* | — |
-| `espn_college_baseball_season_draft_round_picks` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_college_baseball_season_freeagents` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_college_baseball_season_futures` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/futures` | `season`\* | — |
-| `espn_college_baseball_season_group` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_college_baseball_season_group_children` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_college_baseball_season_group_teams` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_college_baseball_season_groups` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_college_baseball_season_info` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}` | `season`\* | — |
-| `espn_college_baseball_season_pointer` | `core_v2` `/baseball/leagues/college-baseball/season` | — | — |
-| `espn_college_baseball_season_powerindex` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_college_baseball_season_powerindex_leaders` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_college_baseball_season_team` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_college_baseball_season_teams` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_college_baseball_season_type` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_college_baseball_season_type_corrections` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_college_baseball_season_type_leaders` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_college_baseball_season_types` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types` | `season`\* | — |
-| `espn_college_baseball_season_week` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_college_baseball_season_week_events` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_college_baseball_season_weeks` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_college_baseball_seasons` | `core_v2` `/baseball/leagues/college-baseball/seasons` | — | `limit` |
-| `espn_college_baseball_standings` | `site_v2_alt` `/baseball/college-baseball/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_college_baseball_standings_core` | `core_v2` `/baseball/leagues/college-baseball/standings` | — | — |
-| `espn_college_baseball_statistics_league` | `site_v2` `/baseball/college-baseball/statistics` | — | — |
-| `espn_college_baseball_summary` | `site_v2` `/baseball/college-baseball/summary` | — | `event_id` → `event` |
-| `espn_college_baseball_talentpicks` | `core_v2` `/baseball/leagues/college-baseball/talentpicks` | — | — |
-| `espn_college_baseball_team` | `site_v2` `/baseball/college-baseball/teams/{team_id}` | `team_id`\* | — |
-| `espn_college_baseball_team_core` | `core_v2` `/baseball/leagues/college-baseball/teams/{team_id}` | `team_id`\* | — |
-| `espn_college_baseball_team_depthcharts` | `site_v2` `/baseball/college-baseball/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_college_baseball_team_history` | `site_v2` `/baseball/college-baseball/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_college_baseball_team_injuries` | `site_v2` `/baseball/college-baseball/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_college_baseball_team_leaders` | `site_v2` `/baseball/college-baseball/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_college_baseball_team_news` | `site_v2` `/baseball/college-baseball/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_college_baseball_team_record` | `site_v2` `/baseball/college-baseball/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_college_baseball_team_roster` | `site_v2` `/baseball/college-baseball/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_college_baseball_team_schedule` | `site_v2` `/baseball/college-baseball/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_college_baseball_team_transactions` | `site_v2` `/baseball/college-baseball/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_college_baseball_teams_core` | `core_v2` `/baseball/leagues/college-baseball/teams` | — | `limit` |
-| `espn_college_baseball_teams_site` | `site_v2` `/baseball/college-baseball/teams` | — | `limit` |
-| `espn_college_baseball_tournaments` | `core_v2` `/baseball/leagues/college-baseball/tournaments` | — | — |
-| `espn_college_baseball_transactions` | `site_v2` `/baseball/college-baseball/transactions` | — | — |
-| `espn_college_baseball_venue` | `core_v2` `/baseball/leagues/college-baseball/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_college_baseball_venues` | `core_v2` `/baseball/leagues/college-baseball/venues` | — | `limit` |
+| `espnCollegeBaseballAthleteAwards` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteBio` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteCareerStats` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnCollegeBaseballAthleteContracts` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteCore` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteEventlog` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteGamelog` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnCollegeBaseballAthleteInfo` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteInjuries` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteNews` | `site_v2` `/baseball/college-baseball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteNotes` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteOverview` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteRecords` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteSeasons` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteSplits` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnCollegeBaseballAthleteStatisticslog` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnCollegeBaseballAthleteStats` | `web_v3` `/baseball/college-baseball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnCollegeBaseballAthleteVsAthlete` | `core_v2` `/baseball/leagues/college-baseball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnCollegeBaseballAthletesIndex` | `core_v2` `/baseball/leagues/college-baseball/athletes` | — | `active`, `limit`, `page` |
+| `espnCollegeBaseballAward` | `core_v2` `/baseball/leagues/college-baseball/awards/{award_id}` | `award_id`\* | — |
+| `espnCollegeBaseballAwards` | `core_v2` `/baseball/leagues/college-baseball/awards` | — | — |
+| `espnCollegeBaseballCalendar` | `site_v2` `/baseball/college-baseball/calendar` | — | — |
+| `espnCollegeBaseballCoach` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnCollegeBaseballCoachRecord` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnCollegeBaseballCoachSeason` | `core_v2` `/baseball/leagues/college-baseball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnCollegeBaseballConferences` | `site_v2` `/baseball/college-baseball/groups` | — | — |
+| `espnCollegeBaseballDraft` | `site_v2` `/baseball/college-baseball/draft` | — | — |
+| `espnCollegeBaseballEvent` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}` | `event_id`\* | — |
+| `espnCollegeBaseballEventBroadcasts` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetition` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitor` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitorLeaders` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitorLinescores` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitorRecord` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitorRoster` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitorStatistics` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeBaseballEventCompetitors` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventLeaders` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventOdds` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventOfficialDetail` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnCollegeBaseballEventOfficials` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventPlay` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCollegeBaseballEventPlayPersonnel` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCollegeBaseballEventPlays` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnCollegeBaseballEventPowerindex` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventPredictor` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventProbabilities` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnCollegeBaseballEventPropbets` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventScoringplays` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventSituation` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEventStatus` | `core_v2` `/baseball/leagues/college-baseball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnCollegeBaseballEvents` | `core_v2` `/baseball/leagues/college-baseball/events` | — | `dates`, `limit` |
+| `espnCollegeBaseballFranchise` | `core_v2` `/baseball/leagues/college-baseball/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnCollegeBaseballFranchises` | `core_v2` `/baseball/leagues/college-baseball/franchises` | — | `limit` |
+| `espnCollegeBaseballInjuries` | `site_v2` `/baseball/college-baseball/injuries` | — | — |
+| `espnCollegeBaseballLeaders` | `web_v3` `/baseball/college-baseball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnCollegeBaseballLeadersCore` | `core_v2` `/baseball/leagues/college-baseball/leaders` | — | — |
+| `espnCollegeBaseballLeagueNotes` | `core_v2` `/baseball/leagues/college-baseball/notes` | — | — |
+| `espnCollegeBaseballLeagueRoot` | `core_v2` `/baseball/leagues/college-baseball` | — | — |
+| `espnCollegeBaseballNews` | `site_v2` `/baseball/college-baseball/news` | — | `limit` |
+| `espnCollegeBaseballPosition` | `core_v2` `/baseball/leagues/college-baseball/positions/{position_id}` | `position_id`\* | — |
+| `espnCollegeBaseballPositions` | `core_v2` `/baseball/leagues/college-baseball/positions` | — | — |
+| `espnCollegeBaseballScoreboard` | `site_v2` `/baseball/college-baseball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnCollegeBaseballSeasonAthletes` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnCollegeBaseballSeasonAwards` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/awards` | `season`\* | — |
+| `espnCollegeBaseballSeasonCoaches` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnCollegeBaseballSeasonDraft` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/draft` | `season`\* | — |
+| `espnCollegeBaseballSeasonDraftRoundPicks` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnCollegeBaseballSeasonFreeagents` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/freeagents` | `season`\* | — |
+| `espnCollegeBaseballSeasonFutures` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/futures` | `season`\* | — |
+| `espnCollegeBaseballSeasonGroup` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCollegeBaseballSeasonGroupChildren` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCollegeBaseballSeasonGroupTeams` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnCollegeBaseballSeasonGroups` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnCollegeBaseballSeasonInfo` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}` | `season`\* | — |
+| `espnCollegeBaseballSeasonPointer` | `core_v2` `/baseball/leagues/college-baseball/season` | — | — |
+| `espnCollegeBaseballSeasonPowerindex` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnCollegeBaseballSeasonPowerindexLeaders` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnCollegeBaseballSeasonTeam` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnCollegeBaseballSeasonTeams` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnCollegeBaseballSeasonType` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnCollegeBaseballSeasonTypeCorrections` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnCollegeBaseballSeasonTypeLeaders` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnCollegeBaseballSeasonTypes` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types` | `season`\* | — |
+| `espnCollegeBaseballSeasonWeek` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCollegeBaseballSeasonWeekEvents` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnCollegeBaseballSeasonWeeks` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnCollegeBaseballSeasons` | `core_v2` `/baseball/leagues/college-baseball/seasons` | — | `limit` |
+| `espnCollegeBaseballStandings` | `site_v2_alt` `/baseball/college-baseball/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnCollegeBaseballStandingsCore` | `core_v2` `/baseball/leagues/college-baseball/standings` | — | — |
+| `espnCollegeBaseballStatisticsLeague` | `site_v2` `/baseball/college-baseball/statistics` | — | — |
+| `espnCollegeBaseballSummary` | `site_v2` `/baseball/college-baseball/summary` | — | `event_id` → `event` |
+| `espnCollegeBaseballTalentpicks` | `core_v2` `/baseball/leagues/college-baseball/talentpicks` | — | — |
+| `espnCollegeBaseballTeam` | `site_v2` `/baseball/college-baseball/teams/{team_id}` | `team_id`\* | — |
+| `espnCollegeBaseballTeamCore` | `core_v2` `/baseball/leagues/college-baseball/teams/{team_id}` | `team_id`\* | — |
+| `espnCollegeBaseballTeamDepthcharts` | `site_v2` `/baseball/college-baseball/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnCollegeBaseballTeamHistory` | `site_v2` `/baseball/college-baseball/teams/{team_id}/history` | `team_id`\* | — |
+| `espnCollegeBaseballTeamInjuries` | `site_v2` `/baseball/college-baseball/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnCollegeBaseballTeamLeaders` | `site_v2` `/baseball/college-baseball/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnCollegeBaseballTeamNews` | `site_v2` `/baseball/college-baseball/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnCollegeBaseballTeamRecord` | `site_v2` `/baseball/college-baseball/teams/{team_id}/record` | `team_id`\* | — |
+| `espnCollegeBaseballTeamRoster` | `site_v2` `/baseball/college-baseball/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnCollegeBaseballTeamSchedule` | `site_v2` `/baseball/college-baseball/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnCollegeBaseballTeamTransactions` | `site_v2` `/baseball/college-baseball/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnCollegeBaseballTeamsCore` | `core_v2` `/baseball/leagues/college-baseball/teams` | — | `limit` |
+| `espnCollegeBaseballTeamsSite` | `site_v2` `/baseball/college-baseball/teams` | — | `limit` |
+| `espnCollegeBaseballTournaments` | `core_v2` `/baseball/leagues/college-baseball/tournaments` | — | — |
+| `espnCollegeBaseballTransactions` | `site_v2` `/baseball/college-baseball/transactions` | — | — |
+| `espnCollegeBaseballVenue` | `core_v2` `/baseball/leagues/college-baseball/venues/{venue_id}` | `venue_id`\* | — |
+| `espnCollegeBaseballVenues` | `core_v2` `/baseball/leagues/college-baseball/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_college_baseball_rankings` | `site_v2` `/baseball/college-baseball/rankings` | — | — |
-| `espn_college_baseball_season_recruits` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_college_baseball_season_week_rankings` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCollegeBaseballRankings` | `site_v2` `/baseball/college-baseball/rankings` | — | — |
+| `espnCollegeBaseballSeasonRecruits` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnCollegeBaseballSeasonWeekRankings` | `core_v2` `/baseball/leagues/college-baseball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/college_softball.md
+++ b/docs/docs/reference/college_softball.md
@@ -14,133 +14,133 @@ sidebar_position: 12
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.college_softball.espn_college_softball_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.college_softball.espnCollegeSoftball<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_college_softball_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.college_softball.espn_college_softball_scoreboard({});
+await sdv.college_softball.espnCollegeSoftballScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_college_softball_athlete_awards` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_bio` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_career_stats` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_college_softball_athlete_contracts` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_core` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_eventlog` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_gamelog` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_college_softball_athlete_info` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_injuries` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_news` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_notes` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_overview` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_records` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_seasons` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_splits` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_college_softball_athlete_statisticslog` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_college_softball_athlete_stats` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_college_softball_athlete_vs_athlete` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_college_softball_athletes_index` | `core_v2` `/baseball/leagues/college-softball/athletes` | — | `active`, `limit`, `page` |
-| `espn_college_softball_award` | `core_v2` `/baseball/leagues/college-softball/awards/{award_id}` | `award_id`\* | — |
-| `espn_college_softball_awards` | `core_v2` `/baseball/leagues/college-softball/awards` | — | — |
-| `espn_college_softball_calendar` | `site_v2` `/baseball/college-softball/calendar` | — | — |
-| `espn_college_softball_coach` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_college_softball_coach_record` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_college_softball_coach_season` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_college_softball_conferences` | `site_v2` `/baseball/college-softball/groups` | — | — |
-| `espn_college_softball_draft` | `site_v2` `/baseball/college-softball/draft` | — | — |
-| `espn_college_softball_event` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}` | `event_id`\* | — |
-| `espn_college_softball_event_broadcasts` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_competition` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor_leaders` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor_linescores` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor_record` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor_roster` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitor_statistics` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_college_softball_event_competitors` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_leaders` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_odds` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_official_detail` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_college_softball_event_officials` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_play` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_college_softball_event_play_personnel` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_college_softball_event_plays` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_college_softball_event_powerindex` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_predictor` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_probabilities` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_college_softball_event_propbets` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_scoringplays` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_situation` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_college_softball_event_status` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_college_softball_events` | `core_v2` `/baseball/leagues/college-softball/events` | — | `dates`, `limit` |
-| `espn_college_softball_franchise` | `core_v2` `/baseball/leagues/college-softball/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_college_softball_franchises` | `core_v2` `/baseball/leagues/college-softball/franchises` | — | `limit` |
-| `espn_college_softball_injuries` | `site_v2` `/baseball/college-softball/injuries` | — | — |
-| `espn_college_softball_leaders` | `web_v3` `/baseball/college-softball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_college_softball_leaders_core` | `core_v2` `/baseball/leagues/college-softball/leaders` | — | — |
-| `espn_college_softball_league_notes` | `core_v2` `/baseball/leagues/college-softball/notes` | — | — |
-| `espn_college_softball_league_root` | `core_v2` `/baseball/leagues/college-softball` | — | — |
-| `espn_college_softball_news` | `site_v2` `/baseball/college-softball/news` | — | `limit` |
-| `espn_college_softball_position` | `core_v2` `/baseball/leagues/college-softball/positions/{position_id}` | `position_id`\* | — |
-| `espn_college_softball_positions` | `core_v2` `/baseball/leagues/college-softball/positions` | — | — |
-| `espn_college_softball_scoreboard` | `site_v2` `/baseball/college-softball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_college_softball_season_athletes` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_college_softball_season_awards` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/awards` | `season`\* | — |
-| `espn_college_softball_season_coaches` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_college_softball_season_draft` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/draft` | `season`\* | — |
-| `espn_college_softball_season_draft_round_picks` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_college_softball_season_freeagents` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_college_softball_season_futures` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/futures` | `season`\* | — |
-| `espn_college_softball_season_group` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_college_softball_season_group_children` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_college_softball_season_group_teams` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_college_softball_season_groups` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_college_softball_season_info` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}` | `season`\* | — |
-| `espn_college_softball_season_pointer` | `core_v2` `/baseball/leagues/college-softball/season` | — | — |
-| `espn_college_softball_season_powerindex` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_college_softball_season_powerindex_leaders` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_college_softball_season_team` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_college_softball_season_teams` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_college_softball_season_type` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_college_softball_season_type_corrections` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_college_softball_season_type_leaders` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_college_softball_season_types` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types` | `season`\* | — |
-| `espn_college_softball_season_week` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_college_softball_season_week_events` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_college_softball_season_weeks` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_college_softball_seasons` | `core_v2` `/baseball/leagues/college-softball/seasons` | — | `limit` |
-| `espn_college_softball_standings` | `site_v2_alt` `/baseball/college-softball/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_college_softball_standings_core` | `core_v2` `/baseball/leagues/college-softball/standings` | — | — |
-| `espn_college_softball_statistics_league` | `site_v2` `/baseball/college-softball/statistics` | — | — |
-| `espn_college_softball_summary` | `site_v2` `/baseball/college-softball/summary` | — | `event_id` → `event` |
-| `espn_college_softball_talentpicks` | `core_v2` `/baseball/leagues/college-softball/talentpicks` | — | — |
-| `espn_college_softball_team` | `site_v2` `/baseball/college-softball/teams/{team_id}` | `team_id`\* | — |
-| `espn_college_softball_team_core` | `core_v2` `/baseball/leagues/college-softball/teams/{team_id}` | `team_id`\* | — |
-| `espn_college_softball_team_depthcharts` | `site_v2` `/baseball/college-softball/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_college_softball_team_history` | `site_v2` `/baseball/college-softball/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_college_softball_team_injuries` | `site_v2` `/baseball/college-softball/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_college_softball_team_leaders` | `site_v2` `/baseball/college-softball/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_college_softball_team_news` | `site_v2` `/baseball/college-softball/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_college_softball_team_record` | `site_v2` `/baseball/college-softball/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_college_softball_team_roster` | `site_v2` `/baseball/college-softball/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_college_softball_team_schedule` | `site_v2` `/baseball/college-softball/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_college_softball_team_transactions` | `site_v2` `/baseball/college-softball/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_college_softball_teams_core` | `core_v2` `/baseball/leagues/college-softball/teams` | — | `limit` |
-| `espn_college_softball_teams_site` | `site_v2` `/baseball/college-softball/teams` | — | `limit` |
-| `espn_college_softball_tournaments` | `core_v2` `/baseball/leagues/college-softball/tournaments` | — | — |
-| `espn_college_softball_transactions` | `site_v2` `/baseball/college-softball/transactions` | — | — |
-| `espn_college_softball_venue` | `core_v2` `/baseball/leagues/college-softball/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_college_softball_venues` | `core_v2` `/baseball/leagues/college-softball/venues` | — | `limit` |
+| `espnCollegeSoftballAthleteAwards` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteBio` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteCareerStats` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnCollegeSoftballAthleteContracts` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteCore` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteEventlog` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteGamelog` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnCollegeSoftballAthleteInfo` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteInjuries` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteNews` | `site_v2` `/baseball/college-softball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteNotes` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteOverview` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteRecords` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteSeasons` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteSplits` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnCollegeSoftballAthleteStatisticslog` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnCollegeSoftballAthleteStats` | `web_v3` `/baseball/college-softball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnCollegeSoftballAthleteVsAthlete` | `core_v2` `/baseball/leagues/college-softball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnCollegeSoftballAthletesIndex` | `core_v2` `/baseball/leagues/college-softball/athletes` | — | `active`, `limit`, `page` |
+| `espnCollegeSoftballAward` | `core_v2` `/baseball/leagues/college-softball/awards/{award_id}` | `award_id`\* | — |
+| `espnCollegeSoftballAwards` | `core_v2` `/baseball/leagues/college-softball/awards` | — | — |
+| `espnCollegeSoftballCalendar` | `site_v2` `/baseball/college-softball/calendar` | — | — |
+| `espnCollegeSoftballCoach` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnCollegeSoftballCoachRecord` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnCollegeSoftballCoachSeason` | `core_v2` `/baseball/leagues/college-softball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnCollegeSoftballConferences` | `site_v2` `/baseball/college-softball/groups` | — | — |
+| `espnCollegeSoftballDraft` | `site_v2` `/baseball/college-softball/draft` | — | — |
+| `espnCollegeSoftballEvent` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}` | `event_id`\* | — |
+| `espnCollegeSoftballEventBroadcasts` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetition` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitor` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitorLeaders` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitorLinescores` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitorRecord` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitorRoster` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitorStatistics` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCollegeSoftballEventCompetitors` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventLeaders` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventOdds` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventOfficialDetail` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnCollegeSoftballEventOfficials` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventPlay` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCollegeSoftballEventPlayPersonnel` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCollegeSoftballEventPlays` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnCollegeSoftballEventPowerindex` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventPredictor` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventProbabilities` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnCollegeSoftballEventPropbets` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventScoringplays` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventSituation` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEventStatus` | `core_v2` `/baseball/leagues/college-softball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnCollegeSoftballEvents` | `core_v2` `/baseball/leagues/college-softball/events` | — | `dates`, `limit` |
+| `espnCollegeSoftballFranchise` | `core_v2` `/baseball/leagues/college-softball/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnCollegeSoftballFranchises` | `core_v2` `/baseball/leagues/college-softball/franchises` | — | `limit` |
+| `espnCollegeSoftballInjuries` | `site_v2` `/baseball/college-softball/injuries` | — | — |
+| `espnCollegeSoftballLeaders` | `web_v3` `/baseball/college-softball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnCollegeSoftballLeadersCore` | `core_v2` `/baseball/leagues/college-softball/leaders` | — | — |
+| `espnCollegeSoftballLeagueNotes` | `core_v2` `/baseball/leagues/college-softball/notes` | — | — |
+| `espnCollegeSoftballLeagueRoot` | `core_v2` `/baseball/leagues/college-softball` | — | — |
+| `espnCollegeSoftballNews` | `site_v2` `/baseball/college-softball/news` | — | `limit` |
+| `espnCollegeSoftballPosition` | `core_v2` `/baseball/leagues/college-softball/positions/{position_id}` | `position_id`\* | — |
+| `espnCollegeSoftballPositions` | `core_v2` `/baseball/leagues/college-softball/positions` | — | — |
+| `espnCollegeSoftballScoreboard` | `site_v2` `/baseball/college-softball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnCollegeSoftballSeasonAthletes` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnCollegeSoftballSeasonAwards` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/awards` | `season`\* | — |
+| `espnCollegeSoftballSeasonCoaches` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnCollegeSoftballSeasonDraft` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/draft` | `season`\* | — |
+| `espnCollegeSoftballSeasonDraftRoundPicks` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnCollegeSoftballSeasonFreeagents` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/freeagents` | `season`\* | — |
+| `espnCollegeSoftballSeasonFutures` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/futures` | `season`\* | — |
+| `espnCollegeSoftballSeasonGroup` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCollegeSoftballSeasonGroupChildren` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCollegeSoftballSeasonGroupTeams` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnCollegeSoftballSeasonGroups` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnCollegeSoftballSeasonInfo` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}` | `season`\* | — |
+| `espnCollegeSoftballSeasonPointer` | `core_v2` `/baseball/leagues/college-softball/season` | — | — |
+| `espnCollegeSoftballSeasonPowerindex` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnCollegeSoftballSeasonPowerindexLeaders` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnCollegeSoftballSeasonTeam` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnCollegeSoftballSeasonTeams` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnCollegeSoftballSeasonType` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnCollegeSoftballSeasonTypeCorrections` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnCollegeSoftballSeasonTypeLeaders` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnCollegeSoftballSeasonTypes` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types` | `season`\* | — |
+| `espnCollegeSoftballSeasonWeek` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCollegeSoftballSeasonWeekEvents` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnCollegeSoftballSeasonWeeks` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnCollegeSoftballSeasons` | `core_v2` `/baseball/leagues/college-softball/seasons` | — | `limit` |
+| `espnCollegeSoftballStandings` | `site_v2_alt` `/baseball/college-softball/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnCollegeSoftballStandingsCore` | `core_v2` `/baseball/leagues/college-softball/standings` | — | — |
+| `espnCollegeSoftballStatisticsLeague` | `site_v2` `/baseball/college-softball/statistics` | — | — |
+| `espnCollegeSoftballSummary` | `site_v2` `/baseball/college-softball/summary` | — | `event_id` → `event` |
+| `espnCollegeSoftballTalentpicks` | `core_v2` `/baseball/leagues/college-softball/talentpicks` | — | — |
+| `espnCollegeSoftballTeam` | `site_v2` `/baseball/college-softball/teams/{team_id}` | `team_id`\* | — |
+| `espnCollegeSoftballTeamCore` | `core_v2` `/baseball/leagues/college-softball/teams/{team_id}` | `team_id`\* | — |
+| `espnCollegeSoftballTeamDepthcharts` | `site_v2` `/baseball/college-softball/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnCollegeSoftballTeamHistory` | `site_v2` `/baseball/college-softball/teams/{team_id}/history` | `team_id`\* | — |
+| `espnCollegeSoftballTeamInjuries` | `site_v2` `/baseball/college-softball/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnCollegeSoftballTeamLeaders` | `site_v2` `/baseball/college-softball/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnCollegeSoftballTeamNews` | `site_v2` `/baseball/college-softball/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnCollegeSoftballTeamRecord` | `site_v2` `/baseball/college-softball/teams/{team_id}/record` | `team_id`\* | — |
+| `espnCollegeSoftballTeamRoster` | `site_v2` `/baseball/college-softball/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnCollegeSoftballTeamSchedule` | `site_v2` `/baseball/college-softball/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnCollegeSoftballTeamTransactions` | `site_v2` `/baseball/college-softball/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnCollegeSoftballTeamsCore` | `core_v2` `/baseball/leagues/college-softball/teams` | — | `limit` |
+| `espnCollegeSoftballTeamsSite` | `site_v2` `/baseball/college-softball/teams` | — | `limit` |
+| `espnCollegeSoftballTournaments` | `core_v2` `/baseball/leagues/college-softball/tournaments` | — | — |
+| `espnCollegeSoftballTransactions` | `site_v2` `/baseball/college-softball/transactions` | — | — |
+| `espnCollegeSoftballVenue` | `core_v2` `/baseball/leagues/college-softball/venues/{venue_id}` | `venue_id`\* | — |
+| `espnCollegeSoftballVenues` | `core_v2` `/baseball/leagues/college-softball/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_college_softball_rankings` | `site_v2` `/baseball/college-softball/rankings` | — | — |
-| `espn_college_softball_season_recruits` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_college_softball_season_week_rankings` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCollegeSoftballRankings` | `site_v2` `/baseball/college-softball/rankings` | — | — |
+| `espnCollegeSoftballSeasonRecruits` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnCollegeSoftballSeasonWeekRankings` | `core_v2` `/baseball/leagues/college-softball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/cricket.md
+++ b/docs/docs/reference/cricket.md
@@ -14,125 +14,125 @@ sidebar_position: 29
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.cricket.espn_cricket_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.cricket.espnCricket<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_cricket_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.cricket.espn_cricket_scoreboard({ league: 'eng.1' });
+await sdv.cricket.espnCricketScoreboard({ league: 'eng.1' });
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_cricket_athlete_awards` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_cricket_athlete_bio` | `site_v2` `/cricket/{league}/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_cricket_athlete_career_stats` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_cricket_athlete_contracts` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_cricket_athlete_core` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cricket_athlete_eventlog` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_cricket_athlete_gamelog` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_cricket_athlete_info` | `site_v2` `/cricket/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_cricket_athlete_injuries` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_cricket_athlete_news` | `site_v2` `/cricket/{league}/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_cricket_athlete_notes` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_cricket_athlete_overview` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_cricket_athlete_records` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_cricket_athlete_seasons` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_cricket_athlete_splits` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_cricket_athlete_statisticslog` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_cricket_athlete_stats` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_cricket_athlete_vs_athlete` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_cricket_athletes_index` | `core_v2` `/cricket/leagues/{league}/athletes` | — | `active`, `limit`, `page` |
-| `espn_cricket_award` | `core_v2` `/cricket/leagues/{league}/awards/{award_id}` | `award_id`\* | — |
-| `espn_cricket_awards` | `core_v2` `/cricket/leagues/{league}/awards` | — | — |
-| `espn_cricket_calendar` | `site_v2` `/cricket/{league}/calendar` | — | — |
-| `espn_cricket_coach` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_cricket_coach_record` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_cricket_coach_season` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_cricket_conferences` | `site_v2` `/cricket/{league}/groups` | — | — |
-| `espn_cricket_draft` | `site_v2` `/cricket/{league}/draft` | — | — |
-| `espn_cricket_event` | `core_v2` `/cricket/leagues/{league}/events/{event_id}` | `event_id`\* | — |
-| `espn_cricket_event_broadcasts` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_competition` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_competitor` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitor_leaders` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitor_linescores` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitor_record` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitor_roster` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitor_statistics` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_cricket_event_competitors` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_leaders` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_odds` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_official_detail` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_cricket_event_officials` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_play` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cricket_event_play_personnel` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_cricket_event_plays` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_cricket_event_powerindex` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_predictor` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_probabilities` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_cricket_event_propbets` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_scoringplays` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_situation` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_cricket_event_status` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_cricket_events` | `core_v2` `/cricket/leagues/{league}/events` | — | `dates`, `limit` |
-| `espn_cricket_franchise` | `core_v2` `/cricket/leagues/{league}/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_cricket_franchises` | `core_v2` `/cricket/leagues/{league}/franchises` | — | `limit` |
-| `espn_cricket_injuries` | `site_v2` `/cricket/{league}/injuries` | — | — |
-| `espn_cricket_leaders` | `web_v3` `/cricket/{league}/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_cricket_leaders_core` | `core_v2` `/cricket/leagues/{league}/leaders` | — | — |
-| `espn_cricket_league_notes` | `core_v2` `/cricket/leagues/{league}/notes` | — | — |
-| `espn_cricket_league_root` | `core_v2` `/cricket/leagues/{league}` | — | — |
-| `espn_cricket_news` | `site_v2` `/cricket/{league}/news` | — | `limit` |
-| `espn_cricket_position` | `core_v2` `/cricket/leagues/{league}/positions/{position_id}` | `position_id`\* | — |
-| `espn_cricket_positions` | `core_v2` `/cricket/leagues/{league}/positions` | — | — |
-| `espn_cricket_scoreboard` | `site_v2` `/cricket/{league}/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_cricket_season_athletes` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_cricket_season_awards` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/awards` | `season`\* | — |
-| `espn_cricket_season_coaches` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_cricket_season_draft` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/draft` | `season`\* | — |
-| `espn_cricket_season_draft_round_picks` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_cricket_season_freeagents` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_cricket_season_futures` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/futures` | `season`\* | — |
-| `espn_cricket_season_group` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cricket_season_group_children` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_cricket_season_group_teams` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_cricket_season_groups` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_cricket_season_info` | `core_v2` `/cricket/leagues/{league}/seasons/{season}` | `season`\* | — |
-| `espn_cricket_season_pointer` | `core_v2` `/cricket/leagues/{league}/season` | — | — |
-| `espn_cricket_season_powerindex` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_cricket_season_powerindex_leaders` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_cricket_season_team` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_cricket_season_teams` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_cricket_season_type` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_cricket_season_type_corrections` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_cricket_season_type_leaders` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_cricket_season_types` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types` | `season`\* | — |
-| `espn_cricket_season_week` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_cricket_season_week_events` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_cricket_season_weeks` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_cricket_seasons` | `core_v2` `/cricket/leagues/{league}/seasons` | — | `limit` |
-| `espn_cricket_standings` | `site_v2_alt` `/cricket/{league}/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_cricket_standings_core` | `core_v2` `/cricket/leagues/{league}/standings` | — | — |
-| `espn_cricket_statistics_league` | `site_v2` `/cricket/{league}/statistics` | — | — |
-| `espn_cricket_summary` | `site_v2` `/cricket/{league}/summary` | — | `event_id` → `event` |
-| `espn_cricket_talentpicks` | `core_v2` `/cricket/leagues/{league}/talentpicks` | — | — |
-| `espn_cricket_team` | `site_v2` `/cricket/{league}/teams/{team_id}` | `team_id`\* | — |
-| `espn_cricket_team_core` | `core_v2` `/cricket/leagues/{league}/teams/{team_id}` | `team_id`\* | — |
-| `espn_cricket_team_depthcharts` | `site_v2` `/cricket/{league}/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_cricket_team_history` | `site_v2` `/cricket/{league}/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_cricket_team_injuries` | `site_v2` `/cricket/{league}/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_cricket_team_leaders` | `site_v2` `/cricket/{league}/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_cricket_team_news` | `site_v2` `/cricket/{league}/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_cricket_team_record` | `site_v2` `/cricket/{league}/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_cricket_team_roster` | `site_v2` `/cricket/{league}/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_cricket_team_schedule` | `site_v2` `/cricket/{league}/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_cricket_team_transactions` | `site_v2` `/cricket/{league}/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_cricket_teams_core` | `core_v2` `/cricket/leagues/{league}/teams` | — | `limit` |
-| `espn_cricket_teams_site` | `site_v2` `/cricket/{league}/teams` | — | `limit` |
-| `espn_cricket_tournaments` | `core_v2` `/cricket/leagues/{league}/tournaments` | — | — |
-| `espn_cricket_transactions` | `site_v2` `/cricket/{league}/transactions` | — | — |
-| `espn_cricket_venue` | `core_v2` `/cricket/leagues/{league}/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_cricket_venues` | `core_v2` `/cricket/leagues/{league}/venues` | — | `limit` |
+| `espnCricketAthleteAwards` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnCricketAthleteBio` | `site_v2` `/cricket/{league}/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnCricketAthleteCareerStats` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnCricketAthleteContracts` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnCricketAthleteCore` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCricketAthleteEventlog` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnCricketAthleteGamelog` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnCricketAthleteInfo` | `site_v2` `/cricket/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnCricketAthleteInjuries` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnCricketAthleteNews` | `site_v2` `/cricket/{league}/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnCricketAthleteNotes` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnCricketAthleteOverview` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnCricketAthleteRecords` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnCricketAthleteSeasons` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnCricketAthleteSplits` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnCricketAthleteStatisticslog` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnCricketAthleteStats` | `web_v3` `/cricket/{league}/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnCricketAthleteVsAthlete` | `core_v2` `/cricket/leagues/{league}/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnCricketAthletesIndex` | `core_v2` `/cricket/leagues/{league}/athletes` | — | `active`, `limit`, `page` |
+| `espnCricketAward` | `core_v2` `/cricket/leagues/{league}/awards/{award_id}` | `award_id`\* | — |
+| `espnCricketAwards` | `core_v2` `/cricket/leagues/{league}/awards` | — | — |
+| `espnCricketCalendar` | `site_v2` `/cricket/{league}/calendar` | — | — |
+| `espnCricketCoach` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnCricketCoachRecord` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnCricketCoachSeason` | `core_v2` `/cricket/leagues/{league}/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnCricketConferences` | `site_v2` `/cricket/{league}/groups` | — | — |
+| `espnCricketDraft` | `site_v2` `/cricket/{league}/draft` | — | — |
+| `espnCricketEvent` | `core_v2` `/cricket/leagues/{league}/events/{event_id}` | `event_id`\* | — |
+| `espnCricketEventBroadcasts` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnCricketEventCompetition` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnCricketEventCompetitor` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitorLeaders` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitorLinescores` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitorRecord` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitorRoster` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitorStatistics` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnCricketEventCompetitors` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnCricketEventLeaders` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnCricketEventOdds` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnCricketEventOfficialDetail` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnCricketEventOfficials` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnCricketEventPlay` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCricketEventPlayPersonnel` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnCricketEventPlays` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnCricketEventPowerindex` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnCricketEventPredictor` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnCricketEventProbabilities` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnCricketEventPropbets` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnCricketEventScoringplays` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnCricketEventSituation` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnCricketEventStatus` | `core_v2` `/cricket/leagues/{league}/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnCricketEvents` | `core_v2` `/cricket/leagues/{league}/events` | — | `dates`, `limit` |
+| `espnCricketFranchise` | `core_v2` `/cricket/leagues/{league}/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnCricketFranchises` | `core_v2` `/cricket/leagues/{league}/franchises` | — | `limit` |
+| `espnCricketInjuries` | `site_v2` `/cricket/{league}/injuries` | — | — |
+| `espnCricketLeaders` | `web_v3` `/cricket/{league}/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnCricketLeadersCore` | `core_v2` `/cricket/leagues/{league}/leaders` | — | — |
+| `espnCricketLeagueNotes` | `core_v2` `/cricket/leagues/{league}/notes` | — | — |
+| `espnCricketLeagueRoot` | `core_v2` `/cricket/leagues/{league}` | — | — |
+| `espnCricketNews` | `site_v2` `/cricket/{league}/news` | — | `limit` |
+| `espnCricketPosition` | `core_v2` `/cricket/leagues/{league}/positions/{position_id}` | `position_id`\* | — |
+| `espnCricketPositions` | `core_v2` `/cricket/leagues/{league}/positions` | — | — |
+| `espnCricketScoreboard` | `site_v2` `/cricket/{league}/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnCricketSeasonAthletes` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnCricketSeasonAwards` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/awards` | `season`\* | — |
+| `espnCricketSeasonCoaches` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnCricketSeasonDraft` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/draft` | `season`\* | — |
+| `espnCricketSeasonDraftRoundPicks` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnCricketSeasonFreeagents` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/freeagents` | `season`\* | — |
+| `espnCricketSeasonFutures` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/futures` | `season`\* | — |
+| `espnCricketSeasonGroup` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCricketSeasonGroupChildren` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnCricketSeasonGroupTeams` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnCricketSeasonGroups` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnCricketSeasonInfo` | `core_v2` `/cricket/leagues/{league}/seasons/{season}` | `season`\* | — |
+| `espnCricketSeasonPointer` | `core_v2` `/cricket/leagues/{league}/season` | — | — |
+| `espnCricketSeasonPowerindex` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnCricketSeasonPowerindexLeaders` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnCricketSeasonTeam` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnCricketSeasonTeams` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnCricketSeasonType` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnCricketSeasonTypeCorrections` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnCricketSeasonTypeLeaders` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnCricketSeasonTypes` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types` | `season`\* | — |
+| `espnCricketSeasonWeek` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnCricketSeasonWeekEvents` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnCricketSeasonWeeks` | `core_v2` `/cricket/leagues/{league}/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnCricketSeasons` | `core_v2` `/cricket/leagues/{league}/seasons` | — | `limit` |
+| `espnCricketStandings` | `site_v2_alt` `/cricket/{league}/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnCricketStandingsCore` | `core_v2` `/cricket/leagues/{league}/standings` | — | — |
+| `espnCricketStatisticsLeague` | `site_v2` `/cricket/{league}/statistics` | — | — |
+| `espnCricketSummary` | `site_v2` `/cricket/{league}/summary` | — | `event_id` → `event` |
+| `espnCricketTalentpicks` | `core_v2` `/cricket/leagues/{league}/talentpicks` | — | — |
+| `espnCricketTeam` | `site_v2` `/cricket/{league}/teams/{team_id}` | `team_id`\* | — |
+| `espnCricketTeamCore` | `core_v2` `/cricket/leagues/{league}/teams/{team_id}` | `team_id`\* | — |
+| `espnCricketTeamDepthcharts` | `site_v2` `/cricket/{league}/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnCricketTeamHistory` | `site_v2` `/cricket/{league}/teams/{team_id}/history` | `team_id`\* | — |
+| `espnCricketTeamInjuries` | `site_v2` `/cricket/{league}/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnCricketTeamLeaders` | `site_v2` `/cricket/{league}/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnCricketTeamNews` | `site_v2` `/cricket/{league}/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnCricketTeamRecord` | `site_v2` `/cricket/{league}/teams/{team_id}/record` | `team_id`\* | — |
+| `espnCricketTeamRoster` | `site_v2` `/cricket/{league}/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnCricketTeamSchedule` | `site_v2` `/cricket/{league}/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnCricketTeamTransactions` | `site_v2` `/cricket/{league}/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnCricketTeamsCore` | `core_v2` `/cricket/leagues/{league}/teams` | — | `limit` |
+| `espnCricketTeamsSite` | `site_v2` `/cricket/{league}/teams` | — | `limit` |
+| `espnCricketTournaments` | `core_v2` `/cricket/leagues/{league}/tournaments` | — | — |
+| `espnCricketTransactions` | `site_v2` `/cricket/{league}/transactions` | — | — |
+| `espnCricketVenue` | `core_v2` `/cricket/leagues/{league}/venues/{venue_id}` | `venue_id`\* | — |
+| `espnCricketVenues` | `core_v2` `/cricket/leagues/{league}/venues` | — | `limit` |

--- a/docs/docs/reference/epl.md
+++ b/docs/docs/reference/epl.md
@@ -14,125 +14,125 @@ sidebar_position: 17
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.epl.espn_epl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.epl.espnEpl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_epl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.epl.espn_epl_scoreboard({});
+await sdv.epl.espnEplScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_epl_athlete_awards` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_epl_athlete_bio` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_epl_athlete_career_stats` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_epl_athlete_contracts` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_epl_athlete_core` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_epl_athlete_eventlog` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_epl_athlete_gamelog` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_epl_athlete_info` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_epl_athlete_injuries` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_epl_athlete_news` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_epl_athlete_notes` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_epl_athlete_overview` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_epl_athlete_records` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_epl_athlete_seasons` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_epl_athlete_splits` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_epl_athlete_statisticslog` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_epl_athlete_stats` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_epl_athlete_vs_athlete` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_epl_athletes_index` | `core_v2` `/soccer/leagues/eng.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_epl_award` | `core_v2` `/soccer/leagues/eng.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_epl_awards` | `core_v2` `/soccer/leagues/eng.1/awards` | — | — |
-| `espn_epl_calendar` | `site_v2` `/soccer/eng.1/calendar` | — | — |
-| `espn_epl_coach` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_epl_coach_record` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_epl_coach_season` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_epl_conferences` | `site_v2` `/soccer/eng.1/groups` | — | — |
-| `espn_epl_draft` | `site_v2` `/soccer/eng.1/draft` | — | — |
-| `espn_epl_event` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}` | `event_id`\* | — |
-| `espn_epl_event_broadcasts` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_epl_event_competition` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_epl_event_competitor` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitor_leaders` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitor_linescores` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitor_record` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitor_roster` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitor_statistics` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_epl_event_competitors` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_epl_event_leaders` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_epl_event_odds` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_epl_event_official_detail` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_epl_event_officials` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_epl_event_play` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_epl_event_play_personnel` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_epl_event_plays` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_epl_event_powerindex` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_epl_event_predictor` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_epl_event_probabilities` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_epl_event_propbets` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_epl_event_scoringplays` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_epl_event_situation` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_epl_event_status` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_epl_events` | `core_v2` `/soccer/leagues/eng.1/events` | — | `dates`, `limit` |
-| `espn_epl_franchise` | `core_v2` `/soccer/leagues/eng.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_epl_franchises` | `core_v2` `/soccer/leagues/eng.1/franchises` | — | `limit` |
-| `espn_epl_injuries` | `site_v2` `/soccer/eng.1/injuries` | — | — |
-| `espn_epl_leaders` | `web_v3` `/soccer/eng.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_epl_leaders_core` | `core_v2` `/soccer/leagues/eng.1/leaders` | — | — |
-| `espn_epl_league_notes` | `core_v2` `/soccer/leagues/eng.1/notes` | — | — |
-| `espn_epl_league_root` | `core_v2` `/soccer/leagues/eng.1` | — | — |
-| `espn_epl_news` | `site_v2` `/soccer/eng.1/news` | — | `limit` |
-| `espn_epl_position` | `core_v2` `/soccer/leagues/eng.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_epl_positions` | `core_v2` `/soccer/leagues/eng.1/positions` | — | — |
-| `espn_epl_scoreboard` | `site_v2` `/soccer/eng.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_epl_season_athletes` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_epl_season_awards` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_epl_season_coaches` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_epl_season_draft` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_epl_season_draft_round_picks` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_epl_season_freeagents` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_epl_season_futures` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_epl_season_group` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_epl_season_group_children` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_epl_season_group_teams` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_epl_season_groups` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_epl_season_info` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}` | `season`\* | — |
-| `espn_epl_season_pointer` | `core_v2` `/soccer/leagues/eng.1/season` | — | — |
-| `espn_epl_season_powerindex` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_epl_season_powerindex_leaders` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_epl_season_team` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_epl_season_teams` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_epl_season_type` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_epl_season_type_corrections` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_epl_season_type_leaders` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_epl_season_types` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types` | `season`\* | — |
-| `espn_epl_season_week` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_epl_season_week_events` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_epl_season_weeks` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_epl_seasons` | `core_v2` `/soccer/leagues/eng.1/seasons` | — | `limit` |
-| `espn_epl_standings` | `site_v2_alt` `/soccer/eng.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_epl_standings_core` | `core_v2` `/soccer/leagues/eng.1/standings` | — | — |
-| `espn_epl_statistics_league` | `site_v2` `/soccer/eng.1/statistics` | — | — |
-| `espn_epl_summary` | `site_v2` `/soccer/eng.1/summary` | — | `event_id` → `event` |
-| `espn_epl_talentpicks` | `core_v2` `/soccer/leagues/eng.1/talentpicks` | — | — |
-| `espn_epl_team` | `site_v2` `/soccer/eng.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_epl_team_core` | `core_v2` `/soccer/leagues/eng.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_epl_team_depthcharts` | `site_v2` `/soccer/eng.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_epl_team_history` | `site_v2` `/soccer/eng.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_epl_team_injuries` | `site_v2` `/soccer/eng.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_epl_team_leaders` | `site_v2` `/soccer/eng.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_epl_team_news` | `site_v2` `/soccer/eng.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_epl_team_record` | `site_v2` `/soccer/eng.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_epl_team_roster` | `site_v2` `/soccer/eng.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_epl_team_schedule` | `site_v2` `/soccer/eng.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_epl_team_transactions` | `site_v2` `/soccer/eng.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_epl_teams_core` | `core_v2` `/soccer/leagues/eng.1/teams` | — | `limit` |
-| `espn_epl_teams_site` | `site_v2` `/soccer/eng.1/teams` | — | `limit` |
-| `espn_epl_tournaments` | `core_v2` `/soccer/leagues/eng.1/tournaments` | — | — |
-| `espn_epl_transactions` | `site_v2` `/soccer/eng.1/transactions` | — | — |
-| `espn_epl_venue` | `core_v2` `/soccer/leagues/eng.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_epl_venues` | `core_v2` `/soccer/leagues/eng.1/venues` | — | `limit` |
+| `espnEplAthleteAwards` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnEplAthleteBio` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnEplAthleteCareerStats` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnEplAthleteContracts` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnEplAthleteCore` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnEplAthleteEventlog` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnEplAthleteGamelog` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnEplAthleteInfo` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnEplAthleteInjuries` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnEplAthleteNews` | `site_v2` `/soccer/eng.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnEplAthleteNotes` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnEplAthleteOverview` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnEplAthleteRecords` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnEplAthleteSeasons` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnEplAthleteSplits` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnEplAthleteStatisticslog` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnEplAthleteStats` | `web_v3` `/soccer/eng.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnEplAthleteVsAthlete` | `core_v2` `/soccer/leagues/eng.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnEplAthletesIndex` | `core_v2` `/soccer/leagues/eng.1/athletes` | — | `active`, `limit`, `page` |
+| `espnEplAward` | `core_v2` `/soccer/leagues/eng.1/awards/{award_id}` | `award_id`\* | — |
+| `espnEplAwards` | `core_v2` `/soccer/leagues/eng.1/awards` | — | — |
+| `espnEplCalendar` | `site_v2` `/soccer/eng.1/calendar` | — | — |
+| `espnEplCoach` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnEplCoachRecord` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnEplCoachSeason` | `core_v2` `/soccer/leagues/eng.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnEplConferences` | `site_v2` `/soccer/eng.1/groups` | — | — |
+| `espnEplDraft` | `site_v2` `/soccer/eng.1/draft` | — | — |
+| `espnEplEvent` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}` | `event_id`\* | — |
+| `espnEplEventBroadcasts` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnEplEventCompetition` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnEplEventCompetitor` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitorLeaders` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitorLinescores` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitorRecord` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitorRoster` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitorStatistics` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnEplEventCompetitors` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnEplEventLeaders` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnEplEventOdds` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnEplEventOfficialDetail` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnEplEventOfficials` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnEplEventPlay` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnEplEventPlayPersonnel` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnEplEventPlays` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnEplEventPowerindex` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnEplEventPredictor` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnEplEventProbabilities` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnEplEventPropbets` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnEplEventScoringplays` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnEplEventSituation` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnEplEventStatus` | `core_v2` `/soccer/leagues/eng.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnEplEvents` | `core_v2` `/soccer/leagues/eng.1/events` | — | `dates`, `limit` |
+| `espnEplFranchise` | `core_v2` `/soccer/leagues/eng.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnEplFranchises` | `core_v2` `/soccer/leagues/eng.1/franchises` | — | `limit` |
+| `espnEplInjuries` | `site_v2` `/soccer/eng.1/injuries` | — | — |
+| `espnEplLeaders` | `web_v3` `/soccer/eng.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnEplLeadersCore` | `core_v2` `/soccer/leagues/eng.1/leaders` | — | — |
+| `espnEplLeagueNotes` | `core_v2` `/soccer/leagues/eng.1/notes` | — | — |
+| `espnEplLeagueRoot` | `core_v2` `/soccer/leagues/eng.1` | — | — |
+| `espnEplNews` | `site_v2` `/soccer/eng.1/news` | — | `limit` |
+| `espnEplPosition` | `core_v2` `/soccer/leagues/eng.1/positions/{position_id}` | `position_id`\* | — |
+| `espnEplPositions` | `core_v2` `/soccer/leagues/eng.1/positions` | — | — |
+| `espnEplScoreboard` | `site_v2` `/soccer/eng.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnEplSeasonAthletes` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnEplSeasonAwards` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/awards` | `season`\* | — |
+| `espnEplSeasonCoaches` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnEplSeasonDraft` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/draft` | `season`\* | — |
+| `espnEplSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnEplSeasonFreeagents` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnEplSeasonFutures` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/futures` | `season`\* | — |
+| `espnEplSeasonGroup` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnEplSeasonGroupChildren` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnEplSeasonGroupTeams` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnEplSeasonGroups` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnEplSeasonInfo` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}` | `season`\* | — |
+| `espnEplSeasonPointer` | `core_v2` `/soccer/leagues/eng.1/season` | — | — |
+| `espnEplSeasonPowerindex` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnEplSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnEplSeasonTeam` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnEplSeasonTeams` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnEplSeasonType` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnEplSeasonTypeCorrections` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnEplSeasonTypeLeaders` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnEplSeasonTypes` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types` | `season`\* | — |
+| `espnEplSeasonWeek` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnEplSeasonWeekEvents` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnEplSeasonWeeks` | `core_v2` `/soccer/leagues/eng.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnEplSeasons` | `core_v2` `/soccer/leagues/eng.1/seasons` | — | `limit` |
+| `espnEplStandings` | `site_v2_alt` `/soccer/eng.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnEplStandingsCore` | `core_v2` `/soccer/leagues/eng.1/standings` | — | — |
+| `espnEplStatisticsLeague` | `site_v2` `/soccer/eng.1/statistics` | — | — |
+| `espnEplSummary` | `site_v2` `/soccer/eng.1/summary` | — | `event_id` → `event` |
+| `espnEplTalentpicks` | `core_v2` `/soccer/leagues/eng.1/talentpicks` | — | — |
+| `espnEplTeam` | `site_v2` `/soccer/eng.1/teams/{team_id}` | `team_id`\* | — |
+| `espnEplTeamCore` | `core_v2` `/soccer/leagues/eng.1/teams/{team_id}` | `team_id`\* | — |
+| `espnEplTeamDepthcharts` | `site_v2` `/soccer/eng.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnEplTeamHistory` | `site_v2` `/soccer/eng.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnEplTeamInjuries` | `site_v2` `/soccer/eng.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnEplTeamLeaders` | `site_v2` `/soccer/eng.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnEplTeamNews` | `site_v2` `/soccer/eng.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnEplTeamRecord` | `site_v2` `/soccer/eng.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnEplTeamRoster` | `site_v2` `/soccer/eng.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnEplTeamSchedule` | `site_v2` `/soccer/eng.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnEplTeamTransactions` | `site_v2` `/soccer/eng.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnEplTeamsCore` | `core_v2` `/soccer/leagues/eng.1/teams` | — | `limit` |
+| `espnEplTeamsSite` | `site_v2` `/soccer/eng.1/teams` | — | `limit` |
+| `espnEplTournaments` | `core_v2` `/soccer/leagues/eng.1/tournaments` | — | — |
+| `espnEplTransactions` | `site_v2` `/soccer/eng.1/transactions` | — | — |
+| `espnEplVenue` | `core_v2` `/soccer/leagues/eng.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnEplVenues` | `core_v2` `/soccer/leagues/eng.1/venues` | — | `limit` |

--- a/docs/docs/reference/index.md
+++ b/docs/docs/reference/index.md
@@ -9,7 +9,7 @@ sidebar_position: 0
 
 # ESPN cross-league reference
 
-Every league below exposes the same generated `espn_<league>_<endpoint>` surface, bound from a single YAML source of truth. Pick a league for its full endpoint table, or try any call live in the [playground](/playground).
+Every league below exposes the same generated `espn<League><Endpoint>` surface (e.g. `espnNbaScoreboard`), bound from a single YAML source of truth. Each method is also available under its snake_case name (`espn_nba_scoreboard`) for parity with the Python / R packages. Pick a league for its full endpoint table, or try any call live in the [playground](/playground).
 
 | League | sport | ESPN slug | scopes | wrappers |
 |---|---|---|---|---:|
@@ -45,8 +45,8 @@ Every league below exposes the same generated `espn_<league>_<endpoint>` surface
 
 :::tip Same call, every league
 ```js
-await sdv.nba.espn_nba_scoreboard({});
-await sdv.nfl.espn_nfl_scoreboard({ week: 1, season_type: 2 });
-await sdv.soccer.espn_soccer_scoreboard({ league: 'eng.1' });
+await sdv.nba.espnNbaScoreboard({});
+await sdv.nfl.espnNflScoreboard({ week: 1, seasonType: 2 });
+await sdv.soccer.espnSoccerScoreboard({ league: 'eng.1' });
 ```
 :::

--- a/docs/docs/reference/laliga.md
+++ b/docs/docs/reference/laliga.md
@@ -14,125 +14,125 @@ sidebar_position: 18
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.laliga.espn_laliga_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.laliga.espnLaliga<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_laliga_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.laliga.espn_laliga_scoreboard({});
+await sdv.laliga.espnLaligaScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_laliga_athlete_awards` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_laliga_athlete_bio` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_laliga_athlete_career_stats` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_laliga_athlete_contracts` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_laliga_athlete_core` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_laliga_athlete_eventlog` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_laliga_athlete_gamelog` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_laliga_athlete_info` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_laliga_athlete_injuries` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_laliga_athlete_news` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_laliga_athlete_notes` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_laliga_athlete_overview` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_laliga_athlete_records` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_laliga_athlete_seasons` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_laliga_athlete_splits` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_laliga_athlete_statisticslog` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_laliga_athlete_stats` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_laliga_athlete_vs_athlete` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_laliga_athletes_index` | `core_v2` `/soccer/leagues/esp.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_laliga_award` | `core_v2` `/soccer/leagues/esp.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_laliga_awards` | `core_v2` `/soccer/leagues/esp.1/awards` | — | — |
-| `espn_laliga_calendar` | `site_v2` `/soccer/esp.1/calendar` | — | — |
-| `espn_laliga_coach` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_laliga_coach_record` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_laliga_coach_season` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_laliga_conferences` | `site_v2` `/soccer/esp.1/groups` | — | — |
-| `espn_laliga_draft` | `site_v2` `/soccer/esp.1/draft` | — | — |
-| `espn_laliga_event` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}` | `event_id`\* | — |
-| `espn_laliga_event_broadcasts` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_competition` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_competitor` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitor_leaders` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitor_linescores` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitor_record` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitor_roster` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitor_statistics` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_laliga_event_competitors` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_leaders` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_odds` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_official_detail` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_laliga_event_officials` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_play` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_laliga_event_play_personnel` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_laliga_event_plays` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_laliga_event_powerindex` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_predictor` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_probabilities` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_laliga_event_propbets` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_scoringplays` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_situation` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_laliga_event_status` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_laliga_events` | `core_v2` `/soccer/leagues/esp.1/events` | — | `dates`, `limit` |
-| `espn_laliga_franchise` | `core_v2` `/soccer/leagues/esp.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_laliga_franchises` | `core_v2` `/soccer/leagues/esp.1/franchises` | — | `limit` |
-| `espn_laliga_injuries` | `site_v2` `/soccer/esp.1/injuries` | — | — |
-| `espn_laliga_leaders` | `web_v3` `/soccer/esp.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_laliga_leaders_core` | `core_v2` `/soccer/leagues/esp.1/leaders` | — | — |
-| `espn_laliga_league_notes` | `core_v2` `/soccer/leagues/esp.1/notes` | — | — |
-| `espn_laliga_league_root` | `core_v2` `/soccer/leagues/esp.1` | — | — |
-| `espn_laliga_news` | `site_v2` `/soccer/esp.1/news` | — | `limit` |
-| `espn_laliga_position` | `core_v2` `/soccer/leagues/esp.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_laliga_positions` | `core_v2` `/soccer/leagues/esp.1/positions` | — | — |
-| `espn_laliga_scoreboard` | `site_v2` `/soccer/esp.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_laliga_season_athletes` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_laliga_season_awards` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_laliga_season_coaches` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_laliga_season_draft` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_laliga_season_draft_round_picks` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_laliga_season_freeagents` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_laliga_season_futures` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_laliga_season_group` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_laliga_season_group_children` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_laliga_season_group_teams` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_laliga_season_groups` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_laliga_season_info` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}` | `season`\* | — |
-| `espn_laliga_season_pointer` | `core_v2` `/soccer/leagues/esp.1/season` | — | — |
-| `espn_laliga_season_powerindex` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_laliga_season_powerindex_leaders` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_laliga_season_team` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_laliga_season_teams` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_laliga_season_type` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_laliga_season_type_corrections` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_laliga_season_type_leaders` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_laliga_season_types` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types` | `season`\* | — |
-| `espn_laliga_season_week` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_laliga_season_week_events` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_laliga_season_weeks` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_laliga_seasons` | `core_v2` `/soccer/leagues/esp.1/seasons` | — | `limit` |
-| `espn_laliga_standings` | `site_v2_alt` `/soccer/esp.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_laliga_standings_core` | `core_v2` `/soccer/leagues/esp.1/standings` | — | — |
-| `espn_laliga_statistics_league` | `site_v2` `/soccer/esp.1/statistics` | — | — |
-| `espn_laliga_summary` | `site_v2` `/soccer/esp.1/summary` | — | `event_id` → `event` |
-| `espn_laliga_talentpicks` | `core_v2` `/soccer/leagues/esp.1/talentpicks` | — | — |
-| `espn_laliga_team` | `site_v2` `/soccer/esp.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_laliga_team_core` | `core_v2` `/soccer/leagues/esp.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_laliga_team_depthcharts` | `site_v2` `/soccer/esp.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_laliga_team_history` | `site_v2` `/soccer/esp.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_laliga_team_injuries` | `site_v2` `/soccer/esp.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_laliga_team_leaders` | `site_v2` `/soccer/esp.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_laliga_team_news` | `site_v2` `/soccer/esp.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_laliga_team_record` | `site_v2` `/soccer/esp.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_laliga_team_roster` | `site_v2` `/soccer/esp.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_laliga_team_schedule` | `site_v2` `/soccer/esp.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_laliga_team_transactions` | `site_v2` `/soccer/esp.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_laliga_teams_core` | `core_v2` `/soccer/leagues/esp.1/teams` | — | `limit` |
-| `espn_laliga_teams_site` | `site_v2` `/soccer/esp.1/teams` | — | `limit` |
-| `espn_laliga_tournaments` | `core_v2` `/soccer/leagues/esp.1/tournaments` | — | — |
-| `espn_laliga_transactions` | `site_v2` `/soccer/esp.1/transactions` | — | — |
-| `espn_laliga_venue` | `core_v2` `/soccer/leagues/esp.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_laliga_venues` | `core_v2` `/soccer/leagues/esp.1/venues` | — | `limit` |
+| `espnLaligaAthleteAwards` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnLaligaAthleteBio` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnLaligaAthleteCareerStats` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnLaligaAthleteContracts` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnLaligaAthleteCore` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLaligaAthleteEventlog` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnLaligaAthleteGamelog` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnLaligaAthleteInfo` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLaligaAthleteInjuries` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnLaligaAthleteNews` | `site_v2` `/soccer/esp.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnLaligaAthleteNotes` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnLaligaAthleteOverview` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnLaligaAthleteRecords` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnLaligaAthleteSeasons` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnLaligaAthleteSplits` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnLaligaAthleteStatisticslog` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnLaligaAthleteStats` | `web_v3` `/soccer/esp.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnLaligaAthleteVsAthlete` | `core_v2` `/soccer/leagues/esp.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnLaligaAthletesIndex` | `core_v2` `/soccer/leagues/esp.1/athletes` | — | `active`, `limit`, `page` |
+| `espnLaligaAward` | `core_v2` `/soccer/leagues/esp.1/awards/{award_id}` | `award_id`\* | — |
+| `espnLaligaAwards` | `core_v2` `/soccer/leagues/esp.1/awards` | — | — |
+| `espnLaligaCalendar` | `site_v2` `/soccer/esp.1/calendar` | — | — |
+| `espnLaligaCoach` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnLaligaCoachRecord` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnLaligaCoachSeason` | `core_v2` `/soccer/leagues/esp.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnLaligaConferences` | `site_v2` `/soccer/esp.1/groups` | — | — |
+| `espnLaligaDraft` | `site_v2` `/soccer/esp.1/draft` | — | — |
+| `espnLaligaEvent` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}` | `event_id`\* | — |
+| `espnLaligaEventBroadcasts` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnLaligaEventCompetition` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnLaligaEventCompetitor` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitorLeaders` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitorLinescores` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitorRecord` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitorRoster` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitorStatistics` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLaligaEventCompetitors` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnLaligaEventLeaders` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnLaligaEventOdds` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnLaligaEventOfficialDetail` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnLaligaEventOfficials` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnLaligaEventPlay` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLaligaEventPlayPersonnel` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLaligaEventPlays` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnLaligaEventPowerindex` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnLaligaEventPredictor` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnLaligaEventProbabilities` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnLaligaEventPropbets` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnLaligaEventScoringplays` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnLaligaEventSituation` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnLaligaEventStatus` | `core_v2` `/soccer/leagues/esp.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnLaligaEvents` | `core_v2` `/soccer/leagues/esp.1/events` | — | `dates`, `limit` |
+| `espnLaligaFranchise` | `core_v2` `/soccer/leagues/esp.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnLaligaFranchises` | `core_v2` `/soccer/leagues/esp.1/franchises` | — | `limit` |
+| `espnLaligaInjuries` | `site_v2` `/soccer/esp.1/injuries` | — | — |
+| `espnLaligaLeaders` | `web_v3` `/soccer/esp.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnLaligaLeadersCore` | `core_v2` `/soccer/leagues/esp.1/leaders` | — | — |
+| `espnLaligaLeagueNotes` | `core_v2` `/soccer/leagues/esp.1/notes` | — | — |
+| `espnLaligaLeagueRoot` | `core_v2` `/soccer/leagues/esp.1` | — | — |
+| `espnLaligaNews` | `site_v2` `/soccer/esp.1/news` | — | `limit` |
+| `espnLaligaPosition` | `core_v2` `/soccer/leagues/esp.1/positions/{position_id}` | `position_id`\* | — |
+| `espnLaligaPositions` | `core_v2` `/soccer/leagues/esp.1/positions` | — | — |
+| `espnLaligaScoreboard` | `site_v2` `/soccer/esp.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnLaligaSeasonAthletes` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnLaligaSeasonAwards` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/awards` | `season`\* | — |
+| `espnLaligaSeasonCoaches` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnLaligaSeasonDraft` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/draft` | `season`\* | — |
+| `espnLaligaSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnLaligaSeasonFreeagents` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnLaligaSeasonFutures` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/futures` | `season`\* | — |
+| `espnLaligaSeasonGroup` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLaligaSeasonGroupChildren` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLaligaSeasonGroupTeams` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnLaligaSeasonGroups` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnLaligaSeasonInfo` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}` | `season`\* | — |
+| `espnLaligaSeasonPointer` | `core_v2` `/soccer/leagues/esp.1/season` | — | — |
+| `espnLaligaSeasonPowerindex` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnLaligaSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnLaligaSeasonTeam` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnLaligaSeasonTeams` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnLaligaSeasonType` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnLaligaSeasonTypeCorrections` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnLaligaSeasonTypeLeaders` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnLaligaSeasonTypes` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types` | `season`\* | — |
+| `espnLaligaSeasonWeek` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnLaligaSeasonWeekEvents` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnLaligaSeasonWeeks` | `core_v2` `/soccer/leagues/esp.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnLaligaSeasons` | `core_v2` `/soccer/leagues/esp.1/seasons` | — | `limit` |
+| `espnLaligaStandings` | `site_v2_alt` `/soccer/esp.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnLaligaStandingsCore` | `core_v2` `/soccer/leagues/esp.1/standings` | — | — |
+| `espnLaligaStatisticsLeague` | `site_v2` `/soccer/esp.1/statistics` | — | — |
+| `espnLaligaSummary` | `site_v2` `/soccer/esp.1/summary` | — | `event_id` → `event` |
+| `espnLaligaTalentpicks` | `core_v2` `/soccer/leagues/esp.1/talentpicks` | — | — |
+| `espnLaligaTeam` | `site_v2` `/soccer/esp.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLaligaTeamCore` | `core_v2` `/soccer/leagues/esp.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLaligaTeamDepthcharts` | `site_v2` `/soccer/esp.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnLaligaTeamHistory` | `site_v2` `/soccer/esp.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnLaligaTeamInjuries` | `site_v2` `/soccer/esp.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnLaligaTeamLeaders` | `site_v2` `/soccer/esp.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnLaligaTeamNews` | `site_v2` `/soccer/esp.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnLaligaTeamRecord` | `site_v2` `/soccer/esp.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnLaligaTeamRoster` | `site_v2` `/soccer/esp.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnLaligaTeamSchedule` | `site_v2` `/soccer/esp.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnLaligaTeamTransactions` | `site_v2` `/soccer/esp.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnLaligaTeamsCore` | `core_v2` `/soccer/leagues/esp.1/teams` | — | `limit` |
+| `espnLaligaTeamsSite` | `site_v2` `/soccer/esp.1/teams` | — | `limit` |
+| `espnLaligaTournaments` | `core_v2` `/soccer/leagues/esp.1/tournaments` | — | — |
+| `espnLaligaTransactions` | `site_v2` `/soccer/esp.1/transactions` | — | — |
+| `espnLaligaVenue` | `core_v2` `/soccer/leagues/esp.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnLaligaVenues` | `core_v2` `/soccer/leagues/esp.1/venues` | — | `limit` |

--- a/docs/docs/reference/ligamx.md
+++ b/docs/docs/reference/ligamx.md
@@ -14,125 +14,125 @@ sidebar_position: 23
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.ligamx.espn_ligamx_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.ligamx.espnLigamx<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_ligamx_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.ligamx.espn_ligamx_scoreboard({});
+await sdv.ligamx.espnLigamxScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_ligamx_athlete_awards` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_bio` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_career_stats` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_ligamx_athlete_contracts` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_core` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_eventlog` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_gamelog` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_ligamx_athlete_info` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_injuries` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_news` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_notes` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_overview` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_records` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_seasons` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_splits` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_ligamx_athlete_statisticslog` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_ligamx_athlete_stats` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_ligamx_athlete_vs_athlete` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_ligamx_athletes_index` | `core_v2` `/soccer/leagues/mex.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_ligamx_award` | `core_v2` `/soccer/leagues/mex.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_ligamx_awards` | `core_v2` `/soccer/leagues/mex.1/awards` | — | — |
-| `espn_ligamx_calendar` | `site_v2` `/soccer/mex.1/calendar` | — | — |
-| `espn_ligamx_coach` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_ligamx_coach_record` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_ligamx_coach_season` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_ligamx_conferences` | `site_v2` `/soccer/mex.1/groups` | — | — |
-| `espn_ligamx_draft` | `site_v2` `/soccer/mex.1/draft` | — | — |
-| `espn_ligamx_event` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}` | `event_id`\* | — |
-| `espn_ligamx_event_broadcasts` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_competition` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor_leaders` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor_linescores` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor_record` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor_roster` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitor_statistics` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligamx_event_competitors` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_leaders` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_odds` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_official_detail` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_ligamx_event_officials` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_play` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ligamx_event_play_personnel` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ligamx_event_plays` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_ligamx_event_powerindex` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_predictor` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_probabilities` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_ligamx_event_propbets` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_scoringplays` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_situation` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_ligamx_event_status` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_ligamx_events` | `core_v2` `/soccer/leagues/mex.1/events` | — | `dates`, `limit` |
-| `espn_ligamx_franchise` | `core_v2` `/soccer/leagues/mex.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_ligamx_franchises` | `core_v2` `/soccer/leagues/mex.1/franchises` | — | `limit` |
-| `espn_ligamx_injuries` | `site_v2` `/soccer/mex.1/injuries` | — | — |
-| `espn_ligamx_leaders` | `web_v3` `/soccer/mex.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_ligamx_leaders_core` | `core_v2` `/soccer/leagues/mex.1/leaders` | — | — |
-| `espn_ligamx_league_notes` | `core_v2` `/soccer/leagues/mex.1/notes` | — | — |
-| `espn_ligamx_league_root` | `core_v2` `/soccer/leagues/mex.1` | — | — |
-| `espn_ligamx_news` | `site_v2` `/soccer/mex.1/news` | — | `limit` |
-| `espn_ligamx_position` | `core_v2` `/soccer/leagues/mex.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_ligamx_positions` | `core_v2` `/soccer/leagues/mex.1/positions` | — | — |
-| `espn_ligamx_scoreboard` | `site_v2` `/soccer/mex.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_ligamx_season_athletes` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_ligamx_season_awards` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_ligamx_season_coaches` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_ligamx_season_draft` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_ligamx_season_draft_round_picks` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_ligamx_season_freeagents` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_ligamx_season_futures` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_ligamx_season_group` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ligamx_season_group_children` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ligamx_season_group_teams` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_ligamx_season_groups` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_ligamx_season_info` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}` | `season`\* | — |
-| `espn_ligamx_season_pointer` | `core_v2` `/soccer/leagues/mex.1/season` | — | — |
-| `espn_ligamx_season_powerindex` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_ligamx_season_powerindex_leaders` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_ligamx_season_team` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_ligamx_season_teams` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_ligamx_season_type` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_ligamx_season_type_corrections` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_ligamx_season_type_leaders` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_ligamx_season_types` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types` | `season`\* | — |
-| `espn_ligamx_season_week` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_ligamx_season_week_events` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_ligamx_season_weeks` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_ligamx_seasons` | `core_v2` `/soccer/leagues/mex.1/seasons` | — | `limit` |
-| `espn_ligamx_standings` | `site_v2_alt` `/soccer/mex.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_ligamx_standings_core` | `core_v2` `/soccer/leagues/mex.1/standings` | — | — |
-| `espn_ligamx_statistics_league` | `site_v2` `/soccer/mex.1/statistics` | — | — |
-| `espn_ligamx_summary` | `site_v2` `/soccer/mex.1/summary` | — | `event_id` → `event` |
-| `espn_ligamx_talentpicks` | `core_v2` `/soccer/leagues/mex.1/talentpicks` | — | — |
-| `espn_ligamx_team` | `site_v2` `/soccer/mex.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_ligamx_team_core` | `core_v2` `/soccer/leagues/mex.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_ligamx_team_depthcharts` | `site_v2` `/soccer/mex.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_ligamx_team_history` | `site_v2` `/soccer/mex.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_ligamx_team_injuries` | `site_v2` `/soccer/mex.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_ligamx_team_leaders` | `site_v2` `/soccer/mex.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_ligamx_team_news` | `site_v2` `/soccer/mex.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_ligamx_team_record` | `site_v2` `/soccer/mex.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_ligamx_team_roster` | `site_v2` `/soccer/mex.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_ligamx_team_schedule` | `site_v2` `/soccer/mex.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_ligamx_team_transactions` | `site_v2` `/soccer/mex.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_ligamx_teams_core` | `core_v2` `/soccer/leagues/mex.1/teams` | — | `limit` |
-| `espn_ligamx_teams_site` | `site_v2` `/soccer/mex.1/teams` | — | `limit` |
-| `espn_ligamx_tournaments` | `core_v2` `/soccer/leagues/mex.1/tournaments` | — | — |
-| `espn_ligamx_transactions` | `site_v2` `/soccer/mex.1/transactions` | — | — |
-| `espn_ligamx_venue` | `core_v2` `/soccer/leagues/mex.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_ligamx_venues` | `core_v2` `/soccer/leagues/mex.1/venues` | — | `limit` |
+| `espnLigamxAthleteAwards` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnLigamxAthleteBio` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnLigamxAthleteCareerStats` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnLigamxAthleteContracts` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnLigamxAthleteCore` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLigamxAthleteEventlog` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnLigamxAthleteGamelog` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnLigamxAthleteInfo` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLigamxAthleteInjuries` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnLigamxAthleteNews` | `site_v2` `/soccer/mex.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnLigamxAthleteNotes` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnLigamxAthleteOverview` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnLigamxAthleteRecords` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnLigamxAthleteSeasons` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnLigamxAthleteSplits` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnLigamxAthleteStatisticslog` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnLigamxAthleteStats` | `web_v3` `/soccer/mex.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnLigamxAthleteVsAthlete` | `core_v2` `/soccer/leagues/mex.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnLigamxAthletesIndex` | `core_v2` `/soccer/leagues/mex.1/athletes` | — | `active`, `limit`, `page` |
+| `espnLigamxAward` | `core_v2` `/soccer/leagues/mex.1/awards/{award_id}` | `award_id`\* | — |
+| `espnLigamxAwards` | `core_v2` `/soccer/leagues/mex.1/awards` | — | — |
+| `espnLigamxCalendar` | `site_v2` `/soccer/mex.1/calendar` | — | — |
+| `espnLigamxCoach` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnLigamxCoachRecord` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnLigamxCoachSeason` | `core_v2` `/soccer/leagues/mex.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnLigamxConferences` | `site_v2` `/soccer/mex.1/groups` | — | — |
+| `espnLigamxDraft` | `site_v2` `/soccer/mex.1/draft` | — | — |
+| `espnLigamxEvent` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}` | `event_id`\* | — |
+| `espnLigamxEventBroadcasts` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnLigamxEventCompetition` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnLigamxEventCompetitor` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitorLeaders` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitorLinescores` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitorRecord` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitorRoster` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitorStatistics` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigamxEventCompetitors` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnLigamxEventLeaders` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnLigamxEventOdds` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnLigamxEventOfficialDetail` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnLigamxEventOfficials` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnLigamxEventPlay` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLigamxEventPlayPersonnel` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLigamxEventPlays` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnLigamxEventPowerindex` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnLigamxEventPredictor` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnLigamxEventProbabilities` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnLigamxEventPropbets` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnLigamxEventScoringplays` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnLigamxEventSituation` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnLigamxEventStatus` | `core_v2` `/soccer/leagues/mex.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnLigamxEvents` | `core_v2` `/soccer/leagues/mex.1/events` | — | `dates`, `limit` |
+| `espnLigamxFranchise` | `core_v2` `/soccer/leagues/mex.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnLigamxFranchises` | `core_v2` `/soccer/leagues/mex.1/franchises` | — | `limit` |
+| `espnLigamxInjuries` | `site_v2` `/soccer/mex.1/injuries` | — | — |
+| `espnLigamxLeaders` | `web_v3` `/soccer/mex.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnLigamxLeadersCore` | `core_v2` `/soccer/leagues/mex.1/leaders` | — | — |
+| `espnLigamxLeagueNotes` | `core_v2` `/soccer/leagues/mex.1/notes` | — | — |
+| `espnLigamxLeagueRoot` | `core_v2` `/soccer/leagues/mex.1` | — | — |
+| `espnLigamxNews` | `site_v2` `/soccer/mex.1/news` | — | `limit` |
+| `espnLigamxPosition` | `core_v2` `/soccer/leagues/mex.1/positions/{position_id}` | `position_id`\* | — |
+| `espnLigamxPositions` | `core_v2` `/soccer/leagues/mex.1/positions` | — | — |
+| `espnLigamxScoreboard` | `site_v2` `/soccer/mex.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnLigamxSeasonAthletes` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnLigamxSeasonAwards` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/awards` | `season`\* | — |
+| `espnLigamxSeasonCoaches` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnLigamxSeasonDraft` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/draft` | `season`\* | — |
+| `espnLigamxSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnLigamxSeasonFreeagents` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnLigamxSeasonFutures` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/futures` | `season`\* | — |
+| `espnLigamxSeasonGroup` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLigamxSeasonGroupChildren` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLigamxSeasonGroupTeams` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnLigamxSeasonGroups` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnLigamxSeasonInfo` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}` | `season`\* | — |
+| `espnLigamxSeasonPointer` | `core_v2` `/soccer/leagues/mex.1/season` | — | — |
+| `espnLigamxSeasonPowerindex` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnLigamxSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnLigamxSeasonTeam` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnLigamxSeasonTeams` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnLigamxSeasonType` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnLigamxSeasonTypeCorrections` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnLigamxSeasonTypeLeaders` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnLigamxSeasonTypes` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types` | `season`\* | — |
+| `espnLigamxSeasonWeek` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnLigamxSeasonWeekEvents` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnLigamxSeasonWeeks` | `core_v2` `/soccer/leagues/mex.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnLigamxSeasons` | `core_v2` `/soccer/leagues/mex.1/seasons` | — | `limit` |
+| `espnLigamxStandings` | `site_v2_alt` `/soccer/mex.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnLigamxStandingsCore` | `core_v2` `/soccer/leagues/mex.1/standings` | — | — |
+| `espnLigamxStatisticsLeague` | `site_v2` `/soccer/mex.1/statistics` | — | — |
+| `espnLigamxSummary` | `site_v2` `/soccer/mex.1/summary` | — | `event_id` → `event` |
+| `espnLigamxTalentpicks` | `core_v2` `/soccer/leagues/mex.1/talentpicks` | — | — |
+| `espnLigamxTeam` | `site_v2` `/soccer/mex.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLigamxTeamCore` | `core_v2` `/soccer/leagues/mex.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLigamxTeamDepthcharts` | `site_v2` `/soccer/mex.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnLigamxTeamHistory` | `site_v2` `/soccer/mex.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnLigamxTeamInjuries` | `site_v2` `/soccer/mex.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnLigamxTeamLeaders` | `site_v2` `/soccer/mex.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnLigamxTeamNews` | `site_v2` `/soccer/mex.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnLigamxTeamRecord` | `site_v2` `/soccer/mex.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnLigamxTeamRoster` | `site_v2` `/soccer/mex.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnLigamxTeamSchedule` | `site_v2` `/soccer/mex.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnLigamxTeamTransactions` | `site_v2` `/soccer/mex.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnLigamxTeamsCore` | `core_v2` `/soccer/leagues/mex.1/teams` | — | `limit` |
+| `espnLigamxTeamsSite` | `site_v2` `/soccer/mex.1/teams` | — | `limit` |
+| `espnLigamxTournaments` | `core_v2` `/soccer/leagues/mex.1/tournaments` | — | — |
+| `espnLigamxTransactions` | `site_v2` `/soccer/mex.1/transactions` | — | — |
+| `espnLigamxVenue` | `core_v2` `/soccer/leagues/mex.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnLigamxVenues` | `core_v2` `/soccer/leagues/mex.1/venues` | — | `limit` |

--- a/docs/docs/reference/ligue1.md
+++ b/docs/docs/reference/ligue1.md
@@ -14,125 +14,125 @@ sidebar_position: 21
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.ligue1.espn_ligue1_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.ligue1.espnLigue1<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_ligue1_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.ligue1.espn_ligue1_scoreboard({});
+await sdv.ligue1.espnLigue1Scoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_ligue1_athlete_awards` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_bio` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_career_stats` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_ligue1_athlete_contracts` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_core` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_eventlog` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_gamelog` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_ligue1_athlete_info` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_injuries` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_news` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_notes` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_overview` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_records` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_seasons` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_splits` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_ligue1_athlete_statisticslog` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_ligue1_athlete_stats` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_ligue1_athlete_vs_athlete` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_ligue1_athletes_index` | `core_v2` `/soccer/leagues/fra.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_ligue1_award` | `core_v2` `/soccer/leagues/fra.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_ligue1_awards` | `core_v2` `/soccer/leagues/fra.1/awards` | — | — |
-| `espn_ligue1_calendar` | `site_v2` `/soccer/fra.1/calendar` | — | — |
-| `espn_ligue1_coach` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_ligue1_coach_record` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_ligue1_coach_season` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_ligue1_conferences` | `site_v2` `/soccer/fra.1/groups` | — | — |
-| `espn_ligue1_draft` | `site_v2` `/soccer/fra.1/draft` | — | — |
-| `espn_ligue1_event` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}` | `event_id`\* | — |
-| `espn_ligue1_event_broadcasts` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_competition` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor_leaders` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor_linescores` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor_record` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor_roster` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitor_statistics` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ligue1_event_competitors` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_leaders` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_odds` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_official_detail` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_ligue1_event_officials` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_play` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ligue1_event_play_personnel` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ligue1_event_plays` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_ligue1_event_powerindex` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_predictor` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_probabilities` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_ligue1_event_propbets` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_scoringplays` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_situation` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_ligue1_event_status` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_ligue1_events` | `core_v2` `/soccer/leagues/fra.1/events` | — | `dates`, `limit` |
-| `espn_ligue1_franchise` | `core_v2` `/soccer/leagues/fra.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_ligue1_franchises` | `core_v2` `/soccer/leagues/fra.1/franchises` | — | `limit` |
-| `espn_ligue1_injuries` | `site_v2` `/soccer/fra.1/injuries` | — | — |
-| `espn_ligue1_leaders` | `web_v3` `/soccer/fra.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_ligue1_leaders_core` | `core_v2` `/soccer/leagues/fra.1/leaders` | — | — |
-| `espn_ligue1_league_notes` | `core_v2` `/soccer/leagues/fra.1/notes` | — | — |
-| `espn_ligue1_league_root` | `core_v2` `/soccer/leagues/fra.1` | — | — |
-| `espn_ligue1_news` | `site_v2` `/soccer/fra.1/news` | — | `limit` |
-| `espn_ligue1_position` | `core_v2` `/soccer/leagues/fra.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_ligue1_positions` | `core_v2` `/soccer/leagues/fra.1/positions` | — | — |
-| `espn_ligue1_scoreboard` | `site_v2` `/soccer/fra.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_ligue1_season_athletes` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_ligue1_season_awards` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_ligue1_season_coaches` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_ligue1_season_draft` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_ligue1_season_draft_round_picks` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_ligue1_season_freeagents` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_ligue1_season_futures` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_ligue1_season_group` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ligue1_season_group_children` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ligue1_season_group_teams` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_ligue1_season_groups` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_ligue1_season_info` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}` | `season`\* | — |
-| `espn_ligue1_season_pointer` | `core_v2` `/soccer/leagues/fra.1/season` | — | — |
-| `espn_ligue1_season_powerindex` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_ligue1_season_powerindex_leaders` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_ligue1_season_team` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_ligue1_season_teams` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_ligue1_season_type` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_ligue1_season_type_corrections` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_ligue1_season_type_leaders` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_ligue1_season_types` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types` | `season`\* | — |
-| `espn_ligue1_season_week` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_ligue1_season_week_events` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_ligue1_season_weeks` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_ligue1_seasons` | `core_v2` `/soccer/leagues/fra.1/seasons` | — | `limit` |
-| `espn_ligue1_standings` | `site_v2_alt` `/soccer/fra.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_ligue1_standings_core` | `core_v2` `/soccer/leagues/fra.1/standings` | — | — |
-| `espn_ligue1_statistics_league` | `site_v2` `/soccer/fra.1/statistics` | — | — |
-| `espn_ligue1_summary` | `site_v2` `/soccer/fra.1/summary` | — | `event_id` → `event` |
-| `espn_ligue1_talentpicks` | `core_v2` `/soccer/leagues/fra.1/talentpicks` | — | — |
-| `espn_ligue1_team` | `site_v2` `/soccer/fra.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_ligue1_team_core` | `core_v2` `/soccer/leagues/fra.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_ligue1_team_depthcharts` | `site_v2` `/soccer/fra.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_ligue1_team_history` | `site_v2` `/soccer/fra.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_ligue1_team_injuries` | `site_v2` `/soccer/fra.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_ligue1_team_leaders` | `site_v2` `/soccer/fra.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_ligue1_team_news` | `site_v2` `/soccer/fra.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_ligue1_team_record` | `site_v2` `/soccer/fra.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_ligue1_team_roster` | `site_v2` `/soccer/fra.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_ligue1_team_schedule` | `site_v2` `/soccer/fra.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_ligue1_team_transactions` | `site_v2` `/soccer/fra.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_ligue1_teams_core` | `core_v2` `/soccer/leagues/fra.1/teams` | — | `limit` |
-| `espn_ligue1_teams_site` | `site_v2` `/soccer/fra.1/teams` | — | `limit` |
-| `espn_ligue1_tournaments` | `core_v2` `/soccer/leagues/fra.1/tournaments` | — | — |
-| `espn_ligue1_transactions` | `site_v2` `/soccer/fra.1/transactions` | — | — |
-| `espn_ligue1_venue` | `core_v2` `/soccer/leagues/fra.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_ligue1_venues` | `core_v2` `/soccer/leagues/fra.1/venues` | — | `limit` |
+| `espnLigue1AthleteAwards` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnLigue1AthleteBio` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnLigue1AthleteCareerStats` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnLigue1AthleteContracts` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnLigue1AthleteCore` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLigue1AthleteEventlog` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnLigue1AthleteGamelog` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnLigue1AthleteInfo` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnLigue1AthleteInjuries` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnLigue1AthleteNews` | `site_v2` `/soccer/fra.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnLigue1AthleteNotes` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnLigue1AthleteOverview` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnLigue1AthleteRecords` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnLigue1AthleteSeasons` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnLigue1AthleteSplits` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnLigue1AthleteStatisticslog` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnLigue1AthleteStats` | `web_v3` `/soccer/fra.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnLigue1AthleteVsAthlete` | `core_v2` `/soccer/leagues/fra.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnLigue1AthletesIndex` | `core_v2` `/soccer/leagues/fra.1/athletes` | — | `active`, `limit`, `page` |
+| `espnLigue1Award` | `core_v2` `/soccer/leagues/fra.1/awards/{award_id}` | `award_id`\* | — |
+| `espnLigue1Awards` | `core_v2` `/soccer/leagues/fra.1/awards` | — | — |
+| `espnLigue1Calendar` | `site_v2` `/soccer/fra.1/calendar` | — | — |
+| `espnLigue1Coach` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnLigue1CoachRecord` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnLigue1CoachSeason` | `core_v2` `/soccer/leagues/fra.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnLigue1Conferences` | `site_v2` `/soccer/fra.1/groups` | — | — |
+| `espnLigue1Draft` | `site_v2` `/soccer/fra.1/draft` | — | — |
+| `espnLigue1Event` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}` | `event_id`\* | — |
+| `espnLigue1EventBroadcasts` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnLigue1EventCompetition` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnLigue1EventCompetitor` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitorLeaders` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitorLinescores` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitorRecord` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitorRoster` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitorStatistics` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnLigue1EventCompetitors` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnLigue1EventLeaders` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnLigue1EventOdds` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnLigue1EventOfficialDetail` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnLigue1EventOfficials` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnLigue1EventPlay` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLigue1EventPlayPersonnel` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnLigue1EventPlays` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnLigue1EventPowerindex` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnLigue1EventPredictor` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnLigue1EventProbabilities` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnLigue1EventPropbets` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnLigue1EventScoringplays` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnLigue1EventSituation` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnLigue1EventStatus` | `core_v2` `/soccer/leagues/fra.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnLigue1Events` | `core_v2` `/soccer/leagues/fra.1/events` | — | `dates`, `limit` |
+| `espnLigue1Franchise` | `core_v2` `/soccer/leagues/fra.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnLigue1Franchises` | `core_v2` `/soccer/leagues/fra.1/franchises` | — | `limit` |
+| `espnLigue1Injuries` | `site_v2` `/soccer/fra.1/injuries` | — | — |
+| `espnLigue1Leaders` | `web_v3` `/soccer/fra.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnLigue1LeadersCore` | `core_v2` `/soccer/leagues/fra.1/leaders` | — | — |
+| `espnLigue1LeagueNotes` | `core_v2` `/soccer/leagues/fra.1/notes` | — | — |
+| `espnLigue1LeagueRoot` | `core_v2` `/soccer/leagues/fra.1` | — | — |
+| `espnLigue1News` | `site_v2` `/soccer/fra.1/news` | — | `limit` |
+| `espnLigue1Position` | `core_v2` `/soccer/leagues/fra.1/positions/{position_id}` | `position_id`\* | — |
+| `espnLigue1Positions` | `core_v2` `/soccer/leagues/fra.1/positions` | — | — |
+| `espnLigue1Scoreboard` | `site_v2` `/soccer/fra.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnLigue1SeasonAthletes` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnLigue1SeasonAwards` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/awards` | `season`\* | — |
+| `espnLigue1SeasonCoaches` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnLigue1SeasonDraft` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/draft` | `season`\* | — |
+| `espnLigue1SeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnLigue1SeasonFreeagents` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnLigue1SeasonFutures` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/futures` | `season`\* | — |
+| `espnLigue1SeasonGroup` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLigue1SeasonGroupChildren` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnLigue1SeasonGroupTeams` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnLigue1SeasonGroups` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnLigue1SeasonInfo` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}` | `season`\* | — |
+| `espnLigue1SeasonPointer` | `core_v2` `/soccer/leagues/fra.1/season` | — | — |
+| `espnLigue1SeasonPowerindex` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnLigue1SeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnLigue1SeasonTeam` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnLigue1SeasonTeams` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnLigue1SeasonType` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnLigue1SeasonTypeCorrections` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnLigue1SeasonTypeLeaders` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnLigue1SeasonTypes` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types` | `season`\* | — |
+| `espnLigue1SeasonWeek` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnLigue1SeasonWeekEvents` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnLigue1SeasonWeeks` | `core_v2` `/soccer/leagues/fra.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnLigue1Seasons` | `core_v2` `/soccer/leagues/fra.1/seasons` | — | `limit` |
+| `espnLigue1Standings` | `site_v2_alt` `/soccer/fra.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnLigue1StandingsCore` | `core_v2` `/soccer/leagues/fra.1/standings` | — | — |
+| `espnLigue1StatisticsLeague` | `site_v2` `/soccer/fra.1/statistics` | — | — |
+| `espnLigue1Summary` | `site_v2` `/soccer/fra.1/summary` | — | `event_id` → `event` |
+| `espnLigue1Talentpicks` | `core_v2` `/soccer/leagues/fra.1/talentpicks` | — | — |
+| `espnLigue1Team` | `site_v2` `/soccer/fra.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLigue1TeamCore` | `core_v2` `/soccer/leagues/fra.1/teams/{team_id}` | `team_id`\* | — |
+| `espnLigue1TeamDepthcharts` | `site_v2` `/soccer/fra.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnLigue1TeamHistory` | `site_v2` `/soccer/fra.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnLigue1TeamInjuries` | `site_v2` `/soccer/fra.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnLigue1TeamLeaders` | `site_v2` `/soccer/fra.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnLigue1TeamNews` | `site_v2` `/soccer/fra.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnLigue1TeamRecord` | `site_v2` `/soccer/fra.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnLigue1TeamRoster` | `site_v2` `/soccer/fra.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnLigue1TeamSchedule` | `site_v2` `/soccer/fra.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnLigue1TeamTransactions` | `site_v2` `/soccer/fra.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnLigue1TeamsCore` | `core_v2` `/soccer/leagues/fra.1/teams` | — | `limit` |
+| `espnLigue1TeamsSite` | `site_v2` `/soccer/fra.1/teams` | — | `limit` |
+| `espnLigue1Tournaments` | `core_v2` `/soccer/leagues/fra.1/tournaments` | — | — |
+| `espnLigue1Transactions` | `site_v2` `/soccer/fra.1/transactions` | — | — |
+| `espnLigue1Venue` | `core_v2` `/soccer/leagues/fra.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnLigue1Venues` | `core_v2` `/soccer/leagues/fra.1/venues` | — | `limit` |

--- a/docs/docs/reference/mbb.md
+++ b/docs/docs/reference/mbb.md
@@ -14,133 +14,133 @@ sidebar_position: 3
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.mbb.espn_mbb_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.mbb.espnMbb<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_mbb_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.mbb.espn_mbb_scoreboard({});
+await sdv.mbb.espnMbbScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mbb_athlete_awards` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_mbb_athlete_bio` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_mbb_athlete_career_stats` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_mbb_athlete_contracts` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_mbb_athlete_core` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mbb_athlete_eventlog` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_mbb_athlete_gamelog` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_mbb_athlete_info` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mbb_athlete_injuries` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_mbb_athlete_news` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_mbb_athlete_notes` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_mbb_athlete_overview` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_mbb_athlete_records` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_mbb_athlete_seasons` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_mbb_athlete_splits` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_mbb_athlete_statisticslog` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_mbb_athlete_stats` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_mbb_athlete_vs_athlete` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_mbb_athletes_index` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes` | — | `active`, `limit`, `page` |
-| `espn_mbb_award` | `core_v2` `/basketball/leagues/mens-college-basketball/awards/{award_id}` | `award_id`\* | — |
-| `espn_mbb_awards` | `core_v2` `/basketball/leagues/mens-college-basketball/awards` | — | — |
-| `espn_mbb_calendar` | `site_v2` `/basketball/mens-college-basketball/calendar` | — | — |
-| `espn_mbb_coach` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_mbb_coach_record` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_mbb_coach_season` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_mbb_conferences` | `site_v2` `/basketball/mens-college-basketball/groups` | — | — |
-| `espn_mbb_draft` | `site_v2` `/basketball/mens-college-basketball/draft` | — | — |
-| `espn_mbb_event` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}` | `event_id`\* | — |
-| `espn_mbb_event_broadcasts` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_competition` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_competitor` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitor_leaders` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitor_linescores` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitor_record` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitor_roster` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitor_statistics` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mbb_event_competitors` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_leaders` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_odds` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_official_detail` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_mbb_event_officials` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_play` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mbb_event_play_personnel` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mbb_event_plays` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_mbb_event_powerindex` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_predictor` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_probabilities` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_mbb_event_propbets` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_scoringplays` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_situation` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_mbb_event_status` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_mbb_events` | `core_v2` `/basketball/leagues/mens-college-basketball/events` | — | `dates`, `limit` |
-| `espn_mbb_franchise` | `core_v2` `/basketball/leagues/mens-college-basketball/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_mbb_franchises` | `core_v2` `/basketball/leagues/mens-college-basketball/franchises` | — | `limit` |
-| `espn_mbb_injuries` | `site_v2` `/basketball/mens-college-basketball/injuries` | — | — |
-| `espn_mbb_leaders` | `web_v3` `/basketball/mens-college-basketball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_mbb_leaders_core` | `core_v2` `/basketball/leagues/mens-college-basketball/leaders` | — | — |
-| `espn_mbb_league_notes` | `core_v2` `/basketball/leagues/mens-college-basketball/notes` | — | — |
-| `espn_mbb_league_root` | `core_v2` `/basketball/leagues/mens-college-basketball` | — | — |
-| `espn_mbb_news` | `site_v2` `/basketball/mens-college-basketball/news` | — | `limit` |
-| `espn_mbb_position` | `core_v2` `/basketball/leagues/mens-college-basketball/positions/{position_id}` | `position_id`\* | — |
-| `espn_mbb_positions` | `core_v2` `/basketball/leagues/mens-college-basketball/positions` | — | — |
-| `espn_mbb_scoreboard` | `site_v2` `/basketball/mens-college-basketball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_mbb_season_athletes` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_mbb_season_awards` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/awards` | `season`\* | — |
-| `espn_mbb_season_coaches` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_mbb_season_draft` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/draft` | `season`\* | — |
-| `espn_mbb_season_draft_round_picks` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_mbb_season_freeagents` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_mbb_season_futures` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/futures` | `season`\* | — |
-| `espn_mbb_season_group` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mbb_season_group_children` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mbb_season_group_teams` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_mbb_season_groups` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_mbb_season_info` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}` | `season`\* | — |
-| `espn_mbb_season_pointer` | `core_v2` `/basketball/leagues/mens-college-basketball/season` | — | — |
-| `espn_mbb_season_powerindex` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_mbb_season_powerindex_leaders` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_mbb_season_team` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_mbb_season_teams` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_mbb_season_type` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_mbb_season_type_corrections` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_mbb_season_type_leaders` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_mbb_season_types` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types` | `season`\* | — |
-| `espn_mbb_season_week` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_mbb_season_week_events` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_mbb_season_weeks` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_mbb_seasons` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons` | — | `limit` |
-| `espn_mbb_standings` | `site_v2_alt` `/basketball/mens-college-basketball/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_mbb_standings_core` | `core_v2` `/basketball/leagues/mens-college-basketball/standings` | — | — |
-| `espn_mbb_statistics_league` | `site_v2` `/basketball/mens-college-basketball/statistics` | — | — |
-| `espn_mbb_summary` | `site_v2` `/basketball/mens-college-basketball/summary` | — | `event_id` → `event` |
-| `espn_mbb_talentpicks` | `core_v2` `/basketball/leagues/mens-college-basketball/talentpicks` | — | — |
-| `espn_mbb_team` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}` | `team_id`\* | — |
-| `espn_mbb_team_core` | `core_v2` `/basketball/leagues/mens-college-basketball/teams/{team_id}` | `team_id`\* | — |
-| `espn_mbb_team_depthcharts` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_mbb_team_history` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_mbb_team_injuries` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_mbb_team_leaders` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_mbb_team_news` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_mbb_team_record` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_mbb_team_roster` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_mbb_team_schedule` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_mbb_team_transactions` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_mbb_teams_core` | `core_v2` `/basketball/leagues/mens-college-basketball/teams` | — | `limit` |
-| `espn_mbb_teams_site` | `site_v2` `/basketball/mens-college-basketball/teams` | — | `limit` |
-| `espn_mbb_tournaments` | `core_v2` `/basketball/leagues/mens-college-basketball/tournaments` | — | — |
-| `espn_mbb_transactions` | `site_v2` `/basketball/mens-college-basketball/transactions` | — | — |
-| `espn_mbb_venue` | `core_v2` `/basketball/leagues/mens-college-basketball/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_mbb_venues` | `core_v2` `/basketball/leagues/mens-college-basketball/venues` | — | `limit` |
+| `espnMbbAthleteAwards` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnMbbAthleteBio` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnMbbAthleteCareerStats` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnMbbAthleteContracts` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnMbbAthleteCore` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMbbAthleteEventlog` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnMbbAthleteGamelog` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnMbbAthleteInfo` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMbbAthleteInjuries` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnMbbAthleteNews` | `site_v2` `/basketball/mens-college-basketball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnMbbAthleteNotes` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnMbbAthleteOverview` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnMbbAthleteRecords` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnMbbAthleteSeasons` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnMbbAthleteSplits` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnMbbAthleteStatisticslog` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnMbbAthleteStats` | `web_v3` `/basketball/mens-college-basketball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnMbbAthleteVsAthlete` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnMbbAthletesIndex` | `core_v2` `/basketball/leagues/mens-college-basketball/athletes` | — | `active`, `limit`, `page` |
+| `espnMbbAward` | `core_v2` `/basketball/leagues/mens-college-basketball/awards/{award_id}` | `award_id`\* | — |
+| `espnMbbAwards` | `core_v2` `/basketball/leagues/mens-college-basketball/awards` | — | — |
+| `espnMbbCalendar` | `site_v2` `/basketball/mens-college-basketball/calendar` | — | — |
+| `espnMbbCoach` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnMbbCoachRecord` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnMbbCoachSeason` | `core_v2` `/basketball/leagues/mens-college-basketball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnMbbConferences` | `site_v2` `/basketball/mens-college-basketball/groups` | — | — |
+| `espnMbbDraft` | `site_v2` `/basketball/mens-college-basketball/draft` | — | — |
+| `espnMbbEvent` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}` | `event_id`\* | — |
+| `espnMbbEventBroadcasts` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnMbbEventCompetition` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnMbbEventCompetitor` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitorLeaders` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitorLinescores` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitorRecord` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitorRoster` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitorStatistics` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMbbEventCompetitors` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnMbbEventLeaders` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnMbbEventOdds` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnMbbEventOfficialDetail` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnMbbEventOfficials` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnMbbEventPlay` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMbbEventPlayPersonnel` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMbbEventPlays` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnMbbEventPowerindex` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnMbbEventPredictor` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnMbbEventProbabilities` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnMbbEventPropbets` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnMbbEventScoringplays` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnMbbEventSituation` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnMbbEventStatus` | `core_v2` `/basketball/leagues/mens-college-basketball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnMbbEvents` | `core_v2` `/basketball/leagues/mens-college-basketball/events` | — | `dates`, `limit` |
+| `espnMbbFranchise` | `core_v2` `/basketball/leagues/mens-college-basketball/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnMbbFranchises` | `core_v2` `/basketball/leagues/mens-college-basketball/franchises` | — | `limit` |
+| `espnMbbInjuries` | `site_v2` `/basketball/mens-college-basketball/injuries` | — | — |
+| `espnMbbLeaders` | `web_v3` `/basketball/mens-college-basketball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnMbbLeadersCore` | `core_v2` `/basketball/leagues/mens-college-basketball/leaders` | — | — |
+| `espnMbbLeagueNotes` | `core_v2` `/basketball/leagues/mens-college-basketball/notes` | — | — |
+| `espnMbbLeagueRoot` | `core_v2` `/basketball/leagues/mens-college-basketball` | — | — |
+| `espnMbbNews` | `site_v2` `/basketball/mens-college-basketball/news` | — | `limit` |
+| `espnMbbPosition` | `core_v2` `/basketball/leagues/mens-college-basketball/positions/{position_id}` | `position_id`\* | — |
+| `espnMbbPositions` | `core_v2` `/basketball/leagues/mens-college-basketball/positions` | — | — |
+| `espnMbbScoreboard` | `site_v2` `/basketball/mens-college-basketball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnMbbSeasonAthletes` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnMbbSeasonAwards` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/awards` | `season`\* | — |
+| `espnMbbSeasonCoaches` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnMbbSeasonDraft` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/draft` | `season`\* | — |
+| `espnMbbSeasonDraftRoundPicks` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnMbbSeasonFreeagents` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/freeagents` | `season`\* | — |
+| `espnMbbSeasonFutures` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/futures` | `season`\* | — |
+| `espnMbbSeasonGroup` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMbbSeasonGroupChildren` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMbbSeasonGroupTeams` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnMbbSeasonGroups` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnMbbSeasonInfo` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}` | `season`\* | — |
+| `espnMbbSeasonPointer` | `core_v2` `/basketball/leagues/mens-college-basketball/season` | — | — |
+| `espnMbbSeasonPowerindex` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnMbbSeasonPowerindexLeaders` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnMbbSeasonTeam` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnMbbSeasonTeams` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnMbbSeasonType` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnMbbSeasonTypeCorrections` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnMbbSeasonTypeLeaders` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnMbbSeasonTypes` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types` | `season`\* | — |
+| `espnMbbSeasonWeek` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMbbSeasonWeekEvents` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnMbbSeasonWeeks` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnMbbSeasons` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons` | — | `limit` |
+| `espnMbbStandings` | `site_v2_alt` `/basketball/mens-college-basketball/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnMbbStandingsCore` | `core_v2` `/basketball/leagues/mens-college-basketball/standings` | — | — |
+| `espnMbbStatisticsLeague` | `site_v2` `/basketball/mens-college-basketball/statistics` | — | — |
+| `espnMbbSummary` | `site_v2` `/basketball/mens-college-basketball/summary` | — | `event_id` → `event` |
+| `espnMbbTalentpicks` | `core_v2` `/basketball/leagues/mens-college-basketball/talentpicks` | — | — |
+| `espnMbbTeam` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}` | `team_id`\* | — |
+| `espnMbbTeamCore` | `core_v2` `/basketball/leagues/mens-college-basketball/teams/{team_id}` | `team_id`\* | — |
+| `espnMbbTeamDepthcharts` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnMbbTeamHistory` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/history` | `team_id`\* | — |
+| `espnMbbTeamInjuries` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnMbbTeamLeaders` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnMbbTeamNews` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnMbbTeamRecord` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/record` | `team_id`\* | — |
+| `espnMbbTeamRoster` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnMbbTeamSchedule` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnMbbTeamTransactions` | `site_v2` `/basketball/mens-college-basketball/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnMbbTeamsCore` | `core_v2` `/basketball/leagues/mens-college-basketball/teams` | — | `limit` |
+| `espnMbbTeamsSite` | `site_v2` `/basketball/mens-college-basketball/teams` | — | `limit` |
+| `espnMbbTournaments` | `core_v2` `/basketball/leagues/mens-college-basketball/tournaments` | — | — |
+| `espnMbbTransactions` | `site_v2` `/basketball/mens-college-basketball/transactions` | — | — |
+| `espnMbbVenue` | `core_v2` `/basketball/leagues/mens-college-basketball/venues/{venue_id}` | `venue_id`\* | — |
+| `espnMbbVenues` | `core_v2` `/basketball/leagues/mens-college-basketball/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mbb_rankings` | `site_v2` `/basketball/mens-college-basketball/rankings` | — | — |
-| `espn_mbb_season_recruits` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_mbb_season_week_rankings` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMbbRankings` | `site_v2` `/basketball/mens-college-basketball/rankings` | — | — |
+| `espnMbbSeasonRecruits` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnMbbSeasonWeekRankings` | `core_v2` `/basketball/leagues/mens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/mch.md
+++ b/docs/docs/reference/mch.md
@@ -14,133 +14,133 @@ sidebar_position: 9
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.mch.espn_mch_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.mch.espnMch<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_mch_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.mch.espn_mch_scoreboard({});
+await sdv.mch.espnMchScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mch_athlete_awards` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_mch_athlete_bio` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_mch_athlete_career_stats` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_mch_athlete_contracts` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_mch_athlete_core` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mch_athlete_eventlog` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_mch_athlete_gamelog` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_mch_athlete_info` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mch_athlete_injuries` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_mch_athlete_news` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_mch_athlete_notes` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_mch_athlete_overview` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_mch_athlete_records` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_mch_athlete_seasons` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_mch_athlete_splits` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_mch_athlete_statisticslog` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_mch_athlete_stats` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_mch_athlete_vs_athlete` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_mch_athletes_index` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes` | — | `active`, `limit`, `page` |
-| `espn_mch_award` | `core_v2` `/hockey/leagues/mens-college-hockey/awards/{award_id}` | `award_id`\* | — |
-| `espn_mch_awards` | `core_v2` `/hockey/leagues/mens-college-hockey/awards` | — | — |
-| `espn_mch_calendar` | `site_v2` `/hockey/mens-college-hockey/calendar` | — | — |
-| `espn_mch_coach` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_mch_coach_record` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_mch_coach_season` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_mch_conferences` | `site_v2` `/hockey/mens-college-hockey/groups` | — | — |
-| `espn_mch_draft` | `site_v2` `/hockey/mens-college-hockey/draft` | — | — |
-| `espn_mch_event` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}` | `event_id`\* | — |
-| `espn_mch_event_broadcasts` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_mch_event_competition` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_mch_event_competitor` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitor_leaders` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitor_linescores` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitor_record` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitor_roster` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitor_statistics` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mch_event_competitors` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_mch_event_leaders` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_mch_event_odds` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_mch_event_official_detail` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_mch_event_officials` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_mch_event_play` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mch_event_play_personnel` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mch_event_plays` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_mch_event_powerindex` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_mch_event_predictor` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_mch_event_probabilities` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_mch_event_propbets` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_mch_event_scoringplays` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_mch_event_situation` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_mch_event_status` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_mch_events` | `core_v2` `/hockey/leagues/mens-college-hockey/events` | — | `dates`, `limit` |
-| `espn_mch_franchise` | `core_v2` `/hockey/leagues/mens-college-hockey/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_mch_franchises` | `core_v2` `/hockey/leagues/mens-college-hockey/franchises` | — | `limit` |
-| `espn_mch_injuries` | `site_v2` `/hockey/mens-college-hockey/injuries` | — | — |
-| `espn_mch_leaders` | `web_v3` `/hockey/mens-college-hockey/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_mch_leaders_core` | `core_v2` `/hockey/leagues/mens-college-hockey/leaders` | — | — |
-| `espn_mch_league_notes` | `core_v2` `/hockey/leagues/mens-college-hockey/notes` | — | — |
-| `espn_mch_league_root` | `core_v2` `/hockey/leagues/mens-college-hockey` | — | — |
-| `espn_mch_news` | `site_v2` `/hockey/mens-college-hockey/news` | — | `limit` |
-| `espn_mch_position` | `core_v2` `/hockey/leagues/mens-college-hockey/positions/{position_id}` | `position_id`\* | — |
-| `espn_mch_positions` | `core_v2` `/hockey/leagues/mens-college-hockey/positions` | — | — |
-| `espn_mch_scoreboard` | `site_v2` `/hockey/mens-college-hockey/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_mch_season_athletes` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_mch_season_awards` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/awards` | `season`\* | — |
-| `espn_mch_season_coaches` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_mch_season_draft` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/draft` | `season`\* | — |
-| `espn_mch_season_draft_round_picks` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_mch_season_freeagents` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_mch_season_futures` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/futures` | `season`\* | — |
-| `espn_mch_season_group` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mch_season_group_children` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mch_season_group_teams` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_mch_season_groups` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_mch_season_info` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}` | `season`\* | — |
-| `espn_mch_season_pointer` | `core_v2` `/hockey/leagues/mens-college-hockey/season` | — | — |
-| `espn_mch_season_powerindex` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_mch_season_powerindex_leaders` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_mch_season_team` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_mch_season_teams` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_mch_season_type` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_mch_season_type_corrections` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_mch_season_type_leaders` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_mch_season_types` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types` | `season`\* | — |
-| `espn_mch_season_week` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_mch_season_week_events` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_mch_season_weeks` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_mch_seasons` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons` | — | `limit` |
-| `espn_mch_standings` | `site_v2_alt` `/hockey/mens-college-hockey/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_mch_standings_core` | `core_v2` `/hockey/leagues/mens-college-hockey/standings` | — | — |
-| `espn_mch_statistics_league` | `site_v2` `/hockey/mens-college-hockey/statistics` | — | — |
-| `espn_mch_summary` | `site_v2` `/hockey/mens-college-hockey/summary` | — | `event_id` → `event` |
-| `espn_mch_talentpicks` | `core_v2` `/hockey/leagues/mens-college-hockey/talentpicks` | — | — |
-| `espn_mch_team` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}` | `team_id`\* | — |
-| `espn_mch_team_core` | `core_v2` `/hockey/leagues/mens-college-hockey/teams/{team_id}` | `team_id`\* | — |
-| `espn_mch_team_depthcharts` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_mch_team_history` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_mch_team_injuries` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_mch_team_leaders` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_mch_team_news` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_mch_team_record` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_mch_team_roster` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_mch_team_schedule` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_mch_team_transactions` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_mch_teams_core` | `core_v2` `/hockey/leagues/mens-college-hockey/teams` | — | `limit` |
-| `espn_mch_teams_site` | `site_v2` `/hockey/mens-college-hockey/teams` | — | `limit` |
-| `espn_mch_tournaments` | `core_v2` `/hockey/leagues/mens-college-hockey/tournaments` | — | — |
-| `espn_mch_transactions` | `site_v2` `/hockey/mens-college-hockey/transactions` | — | — |
-| `espn_mch_venue` | `core_v2` `/hockey/leagues/mens-college-hockey/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_mch_venues` | `core_v2` `/hockey/leagues/mens-college-hockey/venues` | — | `limit` |
+| `espnMchAthleteAwards` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnMchAthleteBio` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnMchAthleteCareerStats` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnMchAthleteContracts` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnMchAthleteCore` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMchAthleteEventlog` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnMchAthleteGamelog` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnMchAthleteInfo` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMchAthleteInjuries` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnMchAthleteNews` | `site_v2` `/hockey/mens-college-hockey/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnMchAthleteNotes` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnMchAthleteOverview` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnMchAthleteRecords` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnMchAthleteSeasons` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnMchAthleteSplits` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnMchAthleteStatisticslog` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnMchAthleteStats` | `web_v3` `/hockey/mens-college-hockey/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnMchAthleteVsAthlete` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnMchAthletesIndex` | `core_v2` `/hockey/leagues/mens-college-hockey/athletes` | — | `active`, `limit`, `page` |
+| `espnMchAward` | `core_v2` `/hockey/leagues/mens-college-hockey/awards/{award_id}` | `award_id`\* | — |
+| `espnMchAwards` | `core_v2` `/hockey/leagues/mens-college-hockey/awards` | — | — |
+| `espnMchCalendar` | `site_v2` `/hockey/mens-college-hockey/calendar` | — | — |
+| `espnMchCoach` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnMchCoachRecord` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnMchCoachSeason` | `core_v2` `/hockey/leagues/mens-college-hockey/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnMchConferences` | `site_v2` `/hockey/mens-college-hockey/groups` | — | — |
+| `espnMchDraft` | `site_v2` `/hockey/mens-college-hockey/draft` | — | — |
+| `espnMchEvent` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}` | `event_id`\* | — |
+| `espnMchEventBroadcasts` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnMchEventCompetition` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnMchEventCompetitor` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitorLeaders` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitorLinescores` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitorRecord` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitorRoster` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitorStatistics` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMchEventCompetitors` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnMchEventLeaders` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnMchEventOdds` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnMchEventOfficialDetail` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnMchEventOfficials` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnMchEventPlay` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMchEventPlayPersonnel` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMchEventPlays` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnMchEventPowerindex` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnMchEventPredictor` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnMchEventProbabilities` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnMchEventPropbets` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnMchEventScoringplays` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnMchEventSituation` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnMchEventStatus` | `core_v2` `/hockey/leagues/mens-college-hockey/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnMchEvents` | `core_v2` `/hockey/leagues/mens-college-hockey/events` | — | `dates`, `limit` |
+| `espnMchFranchise` | `core_v2` `/hockey/leagues/mens-college-hockey/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnMchFranchises` | `core_v2` `/hockey/leagues/mens-college-hockey/franchises` | — | `limit` |
+| `espnMchInjuries` | `site_v2` `/hockey/mens-college-hockey/injuries` | — | — |
+| `espnMchLeaders` | `web_v3` `/hockey/mens-college-hockey/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnMchLeadersCore` | `core_v2` `/hockey/leagues/mens-college-hockey/leaders` | — | — |
+| `espnMchLeagueNotes` | `core_v2` `/hockey/leagues/mens-college-hockey/notes` | — | — |
+| `espnMchLeagueRoot` | `core_v2` `/hockey/leagues/mens-college-hockey` | — | — |
+| `espnMchNews` | `site_v2` `/hockey/mens-college-hockey/news` | — | `limit` |
+| `espnMchPosition` | `core_v2` `/hockey/leagues/mens-college-hockey/positions/{position_id}` | `position_id`\* | — |
+| `espnMchPositions` | `core_v2` `/hockey/leagues/mens-college-hockey/positions` | — | — |
+| `espnMchScoreboard` | `site_v2` `/hockey/mens-college-hockey/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnMchSeasonAthletes` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnMchSeasonAwards` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/awards` | `season`\* | — |
+| `espnMchSeasonCoaches` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnMchSeasonDraft` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/draft` | `season`\* | — |
+| `espnMchSeasonDraftRoundPicks` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnMchSeasonFreeagents` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/freeagents` | `season`\* | — |
+| `espnMchSeasonFutures` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/futures` | `season`\* | — |
+| `espnMchSeasonGroup` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMchSeasonGroupChildren` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMchSeasonGroupTeams` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnMchSeasonGroups` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnMchSeasonInfo` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}` | `season`\* | — |
+| `espnMchSeasonPointer` | `core_v2` `/hockey/leagues/mens-college-hockey/season` | — | — |
+| `espnMchSeasonPowerindex` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnMchSeasonPowerindexLeaders` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnMchSeasonTeam` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnMchSeasonTeams` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnMchSeasonType` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnMchSeasonTypeCorrections` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnMchSeasonTypeLeaders` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnMchSeasonTypes` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types` | `season`\* | — |
+| `espnMchSeasonWeek` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMchSeasonWeekEvents` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnMchSeasonWeeks` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnMchSeasons` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons` | — | `limit` |
+| `espnMchStandings` | `site_v2_alt` `/hockey/mens-college-hockey/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnMchStandingsCore` | `core_v2` `/hockey/leagues/mens-college-hockey/standings` | — | — |
+| `espnMchStatisticsLeague` | `site_v2` `/hockey/mens-college-hockey/statistics` | — | — |
+| `espnMchSummary` | `site_v2` `/hockey/mens-college-hockey/summary` | — | `event_id` → `event` |
+| `espnMchTalentpicks` | `core_v2` `/hockey/leagues/mens-college-hockey/talentpicks` | — | — |
+| `espnMchTeam` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}` | `team_id`\* | — |
+| `espnMchTeamCore` | `core_v2` `/hockey/leagues/mens-college-hockey/teams/{team_id}` | `team_id`\* | — |
+| `espnMchTeamDepthcharts` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnMchTeamHistory` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/history` | `team_id`\* | — |
+| `espnMchTeamInjuries` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnMchTeamLeaders` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnMchTeamNews` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnMchTeamRecord` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/record` | `team_id`\* | — |
+| `espnMchTeamRoster` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnMchTeamSchedule` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnMchTeamTransactions` | `site_v2` `/hockey/mens-college-hockey/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnMchTeamsCore` | `core_v2` `/hockey/leagues/mens-college-hockey/teams` | — | `limit` |
+| `espnMchTeamsSite` | `site_v2` `/hockey/mens-college-hockey/teams` | — | `limit` |
+| `espnMchTournaments` | `core_v2` `/hockey/leagues/mens-college-hockey/tournaments` | — | — |
+| `espnMchTransactions` | `site_v2` `/hockey/mens-college-hockey/transactions` | — | — |
+| `espnMchVenue` | `core_v2` `/hockey/leagues/mens-college-hockey/venues/{venue_id}` | `venue_id`\* | — |
+| `espnMchVenues` | `core_v2` `/hockey/leagues/mens-college-hockey/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mch_rankings` | `site_v2` `/hockey/mens-college-hockey/rankings` | — | — |
-| `espn_mch_season_recruits` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_mch_season_week_rankings` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMchRankings` | `site_v2` `/hockey/mens-college-hockey/rankings` | — | — |
+| `espnMchSeasonRecruits` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnMchSeasonWeekRankings` | `core_v2` `/hockey/leagues/mens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/mlb.md
+++ b/docs/docs/reference/mlb.md
@@ -14,131 +14,131 @@ sidebar_position: 7
 - **scopes:** `universal`, `mlb`
 - **wrappers:** 111
 
-Every endpoint is called as `sdv.mlb.espn_mlb_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.mlb.espnMlb<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_mlb_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.mlb.espn_mlb_scoreboard({});
+await sdv.mlb.espnMlbScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mlb_athlete_awards` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_mlb_athlete_bio` | `site_v2` `/baseball/mlb/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_mlb_athlete_career_stats` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_mlb_athlete_contracts` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_mlb_athlete_core` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mlb_athlete_eventlog` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_mlb_athlete_gamelog` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_mlb_athlete_info` | `site_v2` `/baseball/mlb/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mlb_athlete_injuries` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_mlb_athlete_news` | `site_v2` `/baseball/mlb/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_mlb_athlete_notes` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_mlb_athlete_overview` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_mlb_athlete_records` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_mlb_athlete_seasons` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_mlb_athlete_splits` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_mlb_athlete_statisticslog` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_mlb_athlete_stats` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_mlb_athlete_vs_athlete` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_mlb_athletes_index` | `core_v2` `/baseball/leagues/mlb/athletes` | — | `active`, `limit`, `page` |
-| `espn_mlb_award` | `core_v2` `/baseball/leagues/mlb/awards/{award_id}` | `award_id`\* | — |
-| `espn_mlb_awards` | `core_v2` `/baseball/leagues/mlb/awards` | — | — |
-| `espn_mlb_calendar` | `site_v2` `/baseball/mlb/calendar` | — | — |
-| `espn_mlb_coach` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_mlb_coach_record` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_mlb_coach_season` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_mlb_conferences` | `site_v2` `/baseball/mlb/groups` | — | — |
-| `espn_mlb_draft` | `site_v2` `/baseball/mlb/draft` | — | — |
-| `espn_mlb_event` | `core_v2` `/baseball/leagues/mlb/events/{event_id}` | `event_id`\* | — |
-| `espn_mlb_event_broadcasts` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_competition` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_competitor` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitor_leaders` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitor_linescores` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitor_record` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitor_roster` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitor_statistics` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mlb_event_competitors` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_leaders` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_odds` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_official_detail` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_mlb_event_officials` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_play` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mlb_event_play_personnel` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mlb_event_plays` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_mlb_event_powerindex` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_predictor` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_probabilities` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_mlb_event_propbets` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_scoringplays` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_situation` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_mlb_event_status` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_mlb_events` | `core_v2` `/baseball/leagues/mlb/events` | — | `dates`, `limit` |
-| `espn_mlb_franchise` | `core_v2` `/baseball/leagues/mlb/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_mlb_franchises` | `core_v2` `/baseball/leagues/mlb/franchises` | — | `limit` |
-| `espn_mlb_injuries` | `site_v2` `/baseball/mlb/injuries` | — | — |
-| `espn_mlb_leaders` | `web_v3` `/baseball/mlb/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_mlb_leaders_core` | `core_v2` `/baseball/leagues/mlb/leaders` | — | — |
-| `espn_mlb_league_notes` | `core_v2` `/baseball/leagues/mlb/notes` | — | — |
-| `espn_mlb_league_root` | `core_v2` `/baseball/leagues/mlb` | — | — |
-| `espn_mlb_news` | `site_v2` `/baseball/mlb/news` | — | `limit` |
-| `espn_mlb_position` | `core_v2` `/baseball/leagues/mlb/positions/{position_id}` | `position_id`\* | — |
-| `espn_mlb_positions` | `core_v2` `/baseball/leagues/mlb/positions` | — | — |
-| `espn_mlb_scoreboard` | `site_v2` `/baseball/mlb/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_mlb_season_athletes` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_mlb_season_awards` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/awards` | `season`\* | — |
-| `espn_mlb_season_coaches` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_mlb_season_draft` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/draft` | `season`\* | — |
-| `espn_mlb_season_draft_round_picks` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_mlb_season_freeagents` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_mlb_season_futures` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/futures` | `season`\* | — |
-| `espn_mlb_season_group` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mlb_season_group_children` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mlb_season_group_teams` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_mlb_season_groups` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_mlb_season_info` | `core_v2` `/baseball/leagues/mlb/seasons/{season}` | `season`\* | — |
-| `espn_mlb_season_pointer` | `core_v2` `/baseball/leagues/mlb/season` | — | — |
-| `espn_mlb_season_powerindex` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_mlb_season_powerindex_leaders` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_mlb_season_team` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_mlb_season_teams` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_mlb_season_type` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_mlb_season_type_corrections` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_mlb_season_type_leaders` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_mlb_season_types` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types` | `season`\* | — |
-| `espn_mlb_season_week` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_mlb_season_week_events` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_mlb_season_weeks` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_mlb_seasons` | `core_v2` `/baseball/leagues/mlb/seasons` | — | `limit` |
-| `espn_mlb_standings` | `site_v2_alt` `/baseball/mlb/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_mlb_standings_core` | `core_v2` `/baseball/leagues/mlb/standings` | — | — |
-| `espn_mlb_statistics_league` | `site_v2` `/baseball/mlb/statistics` | — | — |
-| `espn_mlb_summary` | `site_v2` `/baseball/mlb/summary` | — | `event_id` → `event` |
-| `espn_mlb_talentpicks` | `core_v2` `/baseball/leagues/mlb/talentpicks` | — | — |
-| `espn_mlb_team` | `site_v2` `/baseball/mlb/teams/{team_id}` | `team_id`\* | — |
-| `espn_mlb_team_core` | `core_v2` `/baseball/leagues/mlb/teams/{team_id}` | `team_id`\* | — |
-| `espn_mlb_team_depthcharts` | `site_v2` `/baseball/mlb/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_mlb_team_history` | `site_v2` `/baseball/mlb/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_mlb_team_injuries` | `site_v2` `/baseball/mlb/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_mlb_team_leaders` | `site_v2` `/baseball/mlb/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_mlb_team_news` | `site_v2` `/baseball/mlb/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_mlb_team_record` | `site_v2` `/baseball/mlb/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_mlb_team_roster` | `site_v2` `/baseball/mlb/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_mlb_team_schedule` | `site_v2` `/baseball/mlb/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_mlb_team_transactions` | `site_v2` `/baseball/mlb/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_mlb_teams_core` | `core_v2` `/baseball/leagues/mlb/teams` | — | `limit` |
-| `espn_mlb_teams_site` | `site_v2` `/baseball/mlb/teams` | — | `limit` |
-| `espn_mlb_tournaments` | `core_v2` `/baseball/leagues/mlb/tournaments` | — | — |
-| `espn_mlb_transactions` | `site_v2` `/baseball/mlb/transactions` | — | — |
-| `espn_mlb_venue` | `core_v2` `/baseball/leagues/mlb/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_mlb_venues` | `core_v2` `/baseball/leagues/mlb/venues` | — | `limit` |
+| `espnMlbAthleteAwards` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnMlbAthleteBio` | `site_v2` `/baseball/mlb/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnMlbAthleteCareerStats` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnMlbAthleteContracts` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnMlbAthleteCore` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMlbAthleteEventlog` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnMlbAthleteGamelog` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnMlbAthleteInfo` | `site_v2` `/baseball/mlb/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMlbAthleteInjuries` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnMlbAthleteNews` | `site_v2` `/baseball/mlb/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnMlbAthleteNotes` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnMlbAthleteOverview` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnMlbAthleteRecords` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnMlbAthleteSeasons` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnMlbAthleteSplits` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnMlbAthleteStatisticslog` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnMlbAthleteStats` | `web_v3` `/baseball/mlb/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnMlbAthleteVsAthlete` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnMlbAthletesIndex` | `core_v2` `/baseball/leagues/mlb/athletes` | — | `active`, `limit`, `page` |
+| `espnMlbAward` | `core_v2` `/baseball/leagues/mlb/awards/{award_id}` | `award_id`\* | — |
+| `espnMlbAwards` | `core_v2` `/baseball/leagues/mlb/awards` | — | — |
+| `espnMlbCalendar` | `site_v2` `/baseball/mlb/calendar` | — | — |
+| `espnMlbCoach` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnMlbCoachRecord` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnMlbCoachSeason` | `core_v2` `/baseball/leagues/mlb/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnMlbConferences` | `site_v2` `/baseball/mlb/groups` | — | — |
+| `espnMlbDraft` | `site_v2` `/baseball/mlb/draft` | — | — |
+| `espnMlbEvent` | `core_v2` `/baseball/leagues/mlb/events/{event_id}` | `event_id`\* | — |
+| `espnMlbEventBroadcasts` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnMlbEventCompetition` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnMlbEventCompetitor` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitorLeaders` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitorLinescores` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitorRecord` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitorRoster` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitorStatistics` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlbEventCompetitors` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnMlbEventLeaders` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnMlbEventOdds` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnMlbEventOfficialDetail` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnMlbEventOfficials` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnMlbEventPlay` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMlbEventPlayPersonnel` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMlbEventPlays` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnMlbEventPowerindex` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnMlbEventPredictor` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnMlbEventProbabilities` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnMlbEventPropbets` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnMlbEventScoringplays` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnMlbEventSituation` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnMlbEventStatus` | `core_v2` `/baseball/leagues/mlb/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnMlbEvents` | `core_v2` `/baseball/leagues/mlb/events` | — | `dates`, `limit` |
+| `espnMlbFranchise` | `core_v2` `/baseball/leagues/mlb/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnMlbFranchises` | `core_v2` `/baseball/leagues/mlb/franchises` | — | `limit` |
+| `espnMlbInjuries` | `site_v2` `/baseball/mlb/injuries` | — | — |
+| `espnMlbLeaders` | `web_v3` `/baseball/mlb/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnMlbLeadersCore` | `core_v2` `/baseball/leagues/mlb/leaders` | — | — |
+| `espnMlbLeagueNotes` | `core_v2` `/baseball/leagues/mlb/notes` | — | — |
+| `espnMlbLeagueRoot` | `core_v2` `/baseball/leagues/mlb` | — | — |
+| `espnMlbNews` | `site_v2` `/baseball/mlb/news` | — | `limit` |
+| `espnMlbPosition` | `core_v2` `/baseball/leagues/mlb/positions/{position_id}` | `position_id`\* | — |
+| `espnMlbPositions` | `core_v2` `/baseball/leagues/mlb/positions` | — | — |
+| `espnMlbScoreboard` | `site_v2` `/baseball/mlb/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnMlbSeasonAthletes` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnMlbSeasonAwards` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/awards` | `season`\* | — |
+| `espnMlbSeasonCoaches` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnMlbSeasonDraft` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/draft` | `season`\* | — |
+| `espnMlbSeasonDraftRoundPicks` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnMlbSeasonFreeagents` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/freeagents` | `season`\* | — |
+| `espnMlbSeasonFutures` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/futures` | `season`\* | — |
+| `espnMlbSeasonGroup` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMlbSeasonGroupChildren` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMlbSeasonGroupTeams` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnMlbSeasonGroups` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnMlbSeasonInfo` | `core_v2` `/baseball/leagues/mlb/seasons/{season}` | `season`\* | — |
+| `espnMlbSeasonPointer` | `core_v2` `/baseball/leagues/mlb/season` | — | — |
+| `espnMlbSeasonPowerindex` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnMlbSeasonPowerindexLeaders` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnMlbSeasonTeam` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnMlbSeasonTeams` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnMlbSeasonType` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnMlbSeasonTypeCorrections` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnMlbSeasonTypeLeaders` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnMlbSeasonTypes` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types` | `season`\* | — |
+| `espnMlbSeasonWeek` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMlbSeasonWeekEvents` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnMlbSeasonWeeks` | `core_v2` `/baseball/leagues/mlb/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnMlbSeasons` | `core_v2` `/baseball/leagues/mlb/seasons` | — | `limit` |
+| `espnMlbStandings` | `site_v2_alt` `/baseball/mlb/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnMlbStandingsCore` | `core_v2` `/baseball/leagues/mlb/standings` | — | — |
+| `espnMlbStatisticsLeague` | `site_v2` `/baseball/mlb/statistics` | — | — |
+| `espnMlbSummary` | `site_v2` `/baseball/mlb/summary` | — | `event_id` → `event` |
+| `espnMlbTalentpicks` | `core_v2` `/baseball/leagues/mlb/talentpicks` | — | — |
+| `espnMlbTeam` | `site_v2` `/baseball/mlb/teams/{team_id}` | `team_id`\* | — |
+| `espnMlbTeamCore` | `core_v2` `/baseball/leagues/mlb/teams/{team_id}` | `team_id`\* | — |
+| `espnMlbTeamDepthcharts` | `site_v2` `/baseball/mlb/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnMlbTeamHistory` | `site_v2` `/baseball/mlb/teams/{team_id}/history` | `team_id`\* | — |
+| `espnMlbTeamInjuries` | `site_v2` `/baseball/mlb/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnMlbTeamLeaders` | `site_v2` `/baseball/mlb/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnMlbTeamNews` | `site_v2` `/baseball/mlb/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnMlbTeamRecord` | `site_v2` `/baseball/mlb/teams/{team_id}/record` | `team_id`\* | — |
+| `espnMlbTeamRoster` | `site_v2` `/baseball/mlb/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnMlbTeamSchedule` | `site_v2` `/baseball/mlb/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnMlbTeamTransactions` | `site_v2` `/baseball/mlb/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnMlbTeamsCore` | `core_v2` `/baseball/leagues/mlb/teams` | — | `limit` |
+| `espnMlbTeamsSite` | `site_v2` `/baseball/mlb/teams` | — | `limit` |
+| `espnMlbTournaments` | `core_v2` `/baseball/leagues/mlb/tournaments` | — | — |
+| `espnMlbTransactions` | `site_v2` `/baseball/mlb/transactions` | — | — |
+| `espnMlbVenue` | `core_v2` `/baseball/leagues/mlb/venues/{venue_id}` | `venue_id`\* | — |
+| `espnMlbVenues` | `core_v2` `/baseball/leagues/mlb/venues` | — | `limit` |
 
 ## MLB endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mlb_athlete_hotzones` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/hotzones` | `athlete_id`\* | — |
+| `espnMlbAthleteHotzones` | `core_v2` `/baseball/leagues/mlb/athletes/{athlete_id}/hotzones` | `athlete_id`\* | — |

--- a/docs/docs/reference/mls.md
+++ b/docs/docs/reference/mls.md
@@ -14,125 +14,125 @@ sidebar_position: 22
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.mls.espn_mls_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.mls.espnMls<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_mls_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.mls.espn_mls_scoreboard({});
+await sdv.mls.espnMlsScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_mls_athlete_awards` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_mls_athlete_bio` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_mls_athlete_career_stats` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_mls_athlete_contracts` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_mls_athlete_core` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mls_athlete_eventlog` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_mls_athlete_gamelog` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_mls_athlete_info` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_mls_athlete_injuries` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_mls_athlete_news` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_mls_athlete_notes` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_mls_athlete_overview` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_mls_athlete_records` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_mls_athlete_seasons` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_mls_athlete_splits` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_mls_athlete_statisticslog` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_mls_athlete_stats` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_mls_athlete_vs_athlete` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_mls_athletes_index` | `core_v2` `/soccer/leagues/usa.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_mls_award` | `core_v2` `/soccer/leagues/usa.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_mls_awards` | `core_v2` `/soccer/leagues/usa.1/awards` | — | — |
-| `espn_mls_calendar` | `site_v2` `/soccer/usa.1/calendar` | — | — |
-| `espn_mls_coach` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_mls_coach_record` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_mls_coach_season` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_mls_conferences` | `site_v2` `/soccer/usa.1/groups` | — | — |
-| `espn_mls_draft` | `site_v2` `/soccer/usa.1/draft` | — | — |
-| `espn_mls_event` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}` | `event_id`\* | — |
-| `espn_mls_event_broadcasts` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_mls_event_competition` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_mls_event_competitor` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitor_leaders` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitor_linescores` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitor_record` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitor_roster` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitor_statistics` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_mls_event_competitors` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_mls_event_leaders` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_mls_event_odds` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_mls_event_official_detail` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_mls_event_officials` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_mls_event_play` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mls_event_play_personnel` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_mls_event_plays` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_mls_event_powerindex` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_mls_event_predictor` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_mls_event_probabilities` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_mls_event_propbets` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_mls_event_scoringplays` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_mls_event_situation` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_mls_event_status` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_mls_events` | `core_v2` `/soccer/leagues/usa.1/events` | — | `dates`, `limit` |
-| `espn_mls_franchise` | `core_v2` `/soccer/leagues/usa.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_mls_franchises` | `core_v2` `/soccer/leagues/usa.1/franchises` | — | `limit` |
-| `espn_mls_injuries` | `site_v2` `/soccer/usa.1/injuries` | — | — |
-| `espn_mls_leaders` | `web_v3` `/soccer/usa.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_mls_leaders_core` | `core_v2` `/soccer/leagues/usa.1/leaders` | — | — |
-| `espn_mls_league_notes` | `core_v2` `/soccer/leagues/usa.1/notes` | — | — |
-| `espn_mls_league_root` | `core_v2` `/soccer/leagues/usa.1` | — | — |
-| `espn_mls_news` | `site_v2` `/soccer/usa.1/news` | — | `limit` |
-| `espn_mls_position` | `core_v2` `/soccer/leagues/usa.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_mls_positions` | `core_v2` `/soccer/leagues/usa.1/positions` | — | — |
-| `espn_mls_scoreboard` | `site_v2` `/soccer/usa.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_mls_season_athletes` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_mls_season_awards` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_mls_season_coaches` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_mls_season_draft` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_mls_season_draft_round_picks` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_mls_season_freeagents` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_mls_season_futures` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_mls_season_group` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mls_season_group_children` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_mls_season_group_teams` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_mls_season_groups` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_mls_season_info` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}` | `season`\* | — |
-| `espn_mls_season_pointer` | `core_v2` `/soccer/leagues/usa.1/season` | — | — |
-| `espn_mls_season_powerindex` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_mls_season_powerindex_leaders` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_mls_season_team` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_mls_season_teams` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_mls_season_type` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_mls_season_type_corrections` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_mls_season_type_leaders` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_mls_season_types` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types` | `season`\* | — |
-| `espn_mls_season_week` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_mls_season_week_events` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_mls_season_weeks` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_mls_seasons` | `core_v2` `/soccer/leagues/usa.1/seasons` | — | `limit` |
-| `espn_mls_standings` | `site_v2_alt` `/soccer/usa.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_mls_standings_core` | `core_v2` `/soccer/leagues/usa.1/standings` | — | — |
-| `espn_mls_statistics_league` | `site_v2` `/soccer/usa.1/statistics` | — | — |
-| `espn_mls_summary` | `site_v2` `/soccer/usa.1/summary` | — | `event_id` → `event` |
-| `espn_mls_talentpicks` | `core_v2` `/soccer/leagues/usa.1/talentpicks` | — | — |
-| `espn_mls_team` | `site_v2` `/soccer/usa.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_mls_team_core` | `core_v2` `/soccer/leagues/usa.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_mls_team_depthcharts` | `site_v2` `/soccer/usa.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_mls_team_history` | `site_v2` `/soccer/usa.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_mls_team_injuries` | `site_v2` `/soccer/usa.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_mls_team_leaders` | `site_v2` `/soccer/usa.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_mls_team_news` | `site_v2` `/soccer/usa.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_mls_team_record` | `site_v2` `/soccer/usa.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_mls_team_roster` | `site_v2` `/soccer/usa.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_mls_team_schedule` | `site_v2` `/soccer/usa.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_mls_team_transactions` | `site_v2` `/soccer/usa.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_mls_teams_core` | `core_v2` `/soccer/leagues/usa.1/teams` | — | `limit` |
-| `espn_mls_teams_site` | `site_v2` `/soccer/usa.1/teams` | — | `limit` |
-| `espn_mls_tournaments` | `core_v2` `/soccer/leagues/usa.1/tournaments` | — | — |
-| `espn_mls_transactions` | `site_v2` `/soccer/usa.1/transactions` | — | — |
-| `espn_mls_venue` | `core_v2` `/soccer/leagues/usa.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_mls_venues` | `core_v2` `/soccer/leagues/usa.1/venues` | — | `limit` |
+| `espnMlsAthleteAwards` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnMlsAthleteBio` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnMlsAthleteCareerStats` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnMlsAthleteContracts` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnMlsAthleteCore` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMlsAthleteEventlog` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnMlsAthleteGamelog` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnMlsAthleteInfo` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnMlsAthleteInjuries` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnMlsAthleteNews` | `site_v2` `/soccer/usa.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnMlsAthleteNotes` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnMlsAthleteOverview` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnMlsAthleteRecords` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnMlsAthleteSeasons` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnMlsAthleteSplits` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnMlsAthleteStatisticslog` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnMlsAthleteStats` | `web_v3` `/soccer/usa.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnMlsAthleteVsAthlete` | `core_v2` `/soccer/leagues/usa.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnMlsAthletesIndex` | `core_v2` `/soccer/leagues/usa.1/athletes` | — | `active`, `limit`, `page` |
+| `espnMlsAward` | `core_v2` `/soccer/leagues/usa.1/awards/{award_id}` | `award_id`\* | — |
+| `espnMlsAwards` | `core_v2` `/soccer/leagues/usa.1/awards` | — | — |
+| `espnMlsCalendar` | `site_v2` `/soccer/usa.1/calendar` | — | — |
+| `espnMlsCoach` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnMlsCoachRecord` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnMlsCoachSeason` | `core_v2` `/soccer/leagues/usa.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnMlsConferences` | `site_v2` `/soccer/usa.1/groups` | — | — |
+| `espnMlsDraft` | `site_v2` `/soccer/usa.1/draft` | — | — |
+| `espnMlsEvent` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}` | `event_id`\* | — |
+| `espnMlsEventBroadcasts` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnMlsEventCompetition` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnMlsEventCompetitor` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitorLeaders` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitorLinescores` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitorRecord` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitorRoster` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitorStatistics` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnMlsEventCompetitors` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnMlsEventLeaders` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnMlsEventOdds` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnMlsEventOfficialDetail` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnMlsEventOfficials` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnMlsEventPlay` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMlsEventPlayPersonnel` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnMlsEventPlays` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnMlsEventPowerindex` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnMlsEventPredictor` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnMlsEventProbabilities` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnMlsEventPropbets` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnMlsEventScoringplays` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnMlsEventSituation` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnMlsEventStatus` | `core_v2` `/soccer/leagues/usa.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnMlsEvents` | `core_v2` `/soccer/leagues/usa.1/events` | — | `dates`, `limit` |
+| `espnMlsFranchise` | `core_v2` `/soccer/leagues/usa.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnMlsFranchises` | `core_v2` `/soccer/leagues/usa.1/franchises` | — | `limit` |
+| `espnMlsInjuries` | `site_v2` `/soccer/usa.1/injuries` | — | — |
+| `espnMlsLeaders` | `web_v3` `/soccer/usa.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnMlsLeadersCore` | `core_v2` `/soccer/leagues/usa.1/leaders` | — | — |
+| `espnMlsLeagueNotes` | `core_v2` `/soccer/leagues/usa.1/notes` | — | — |
+| `espnMlsLeagueRoot` | `core_v2` `/soccer/leagues/usa.1` | — | — |
+| `espnMlsNews` | `site_v2` `/soccer/usa.1/news` | — | `limit` |
+| `espnMlsPosition` | `core_v2` `/soccer/leagues/usa.1/positions/{position_id}` | `position_id`\* | — |
+| `espnMlsPositions` | `core_v2` `/soccer/leagues/usa.1/positions` | — | — |
+| `espnMlsScoreboard` | `site_v2` `/soccer/usa.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnMlsSeasonAthletes` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnMlsSeasonAwards` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/awards` | `season`\* | — |
+| `espnMlsSeasonCoaches` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnMlsSeasonDraft` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/draft` | `season`\* | — |
+| `espnMlsSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnMlsSeasonFreeagents` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnMlsSeasonFutures` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/futures` | `season`\* | — |
+| `espnMlsSeasonGroup` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMlsSeasonGroupChildren` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnMlsSeasonGroupTeams` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnMlsSeasonGroups` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnMlsSeasonInfo` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}` | `season`\* | — |
+| `espnMlsSeasonPointer` | `core_v2` `/soccer/leagues/usa.1/season` | — | — |
+| `espnMlsSeasonPowerindex` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnMlsSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnMlsSeasonTeam` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnMlsSeasonTeams` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnMlsSeasonType` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnMlsSeasonTypeCorrections` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnMlsSeasonTypeLeaders` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnMlsSeasonTypes` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types` | `season`\* | — |
+| `espnMlsSeasonWeek` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnMlsSeasonWeekEvents` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnMlsSeasonWeeks` | `core_v2` `/soccer/leagues/usa.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnMlsSeasons` | `core_v2` `/soccer/leagues/usa.1/seasons` | — | `limit` |
+| `espnMlsStandings` | `site_v2_alt` `/soccer/usa.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnMlsStandingsCore` | `core_v2` `/soccer/leagues/usa.1/standings` | — | — |
+| `espnMlsStatisticsLeague` | `site_v2` `/soccer/usa.1/statistics` | — | — |
+| `espnMlsSummary` | `site_v2` `/soccer/usa.1/summary` | — | `event_id` → `event` |
+| `espnMlsTalentpicks` | `core_v2` `/soccer/leagues/usa.1/talentpicks` | — | — |
+| `espnMlsTeam` | `site_v2` `/soccer/usa.1/teams/{team_id}` | `team_id`\* | — |
+| `espnMlsTeamCore` | `core_v2` `/soccer/leagues/usa.1/teams/{team_id}` | `team_id`\* | — |
+| `espnMlsTeamDepthcharts` | `site_v2` `/soccer/usa.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnMlsTeamHistory` | `site_v2` `/soccer/usa.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnMlsTeamInjuries` | `site_v2` `/soccer/usa.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnMlsTeamLeaders` | `site_v2` `/soccer/usa.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnMlsTeamNews` | `site_v2` `/soccer/usa.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnMlsTeamRecord` | `site_v2` `/soccer/usa.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnMlsTeamRoster` | `site_v2` `/soccer/usa.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnMlsTeamSchedule` | `site_v2` `/soccer/usa.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnMlsTeamTransactions` | `site_v2` `/soccer/usa.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnMlsTeamsCore` | `core_v2` `/soccer/leagues/usa.1/teams` | — | `limit` |
+| `espnMlsTeamsSite` | `site_v2` `/soccer/usa.1/teams` | — | `limit` |
+| `espnMlsTournaments` | `core_v2` `/soccer/leagues/usa.1/tournaments` | — | — |
+| `espnMlsTransactions` | `site_v2` `/soccer/usa.1/transactions` | — | — |
+| `espnMlsVenue` | `core_v2` `/soccer/leagues/usa.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnMlsVenues` | `core_v2` `/soccer/leagues/usa.1/venues` | — | `limit` |

--- a/docs/docs/reference/nba.md
+++ b/docs/docs/reference/nba.md
@@ -14,125 +14,125 @@ sidebar_position: 1
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.nba.espn_nba_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.nba.espnNba<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_nba_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.nba.espn_nba_scoreboard({});
+await sdv.nba.espnNbaScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_nba_athlete_awards` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_nba_athlete_bio` | `site_v2` `/basketball/nba/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_nba_athlete_career_stats` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_nba_athlete_contracts` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_nba_athlete_core` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nba_athlete_eventlog` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_nba_athlete_gamelog` | `web_v3` `/basketball/nba/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_nba_athlete_info` | `site_v2` `/basketball/nba/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nba_athlete_injuries` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_nba_athlete_news` | `site_v2` `/basketball/nba/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_nba_athlete_notes` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_nba_athlete_overview` | `web_v3` `/basketball/nba/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_nba_athlete_records` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_nba_athlete_seasons` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_nba_athlete_splits` | `web_v3` `/basketball/nba/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_nba_athlete_statisticslog` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_nba_athlete_stats` | `web_v3` `/basketball/nba/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_nba_athlete_vs_athlete` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_nba_athletes_index` | `core_v2` `/basketball/leagues/nba/athletes` | — | `active`, `limit`, `page` |
-| `espn_nba_award` | `core_v2` `/basketball/leagues/nba/awards/{award_id}` | `award_id`\* | — |
-| `espn_nba_awards` | `core_v2` `/basketball/leagues/nba/awards` | — | — |
-| `espn_nba_calendar` | `site_v2` `/basketball/nba/calendar` | — | — |
-| `espn_nba_coach` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_nba_coach_record` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_nba_coach_season` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_nba_conferences` | `site_v2` `/basketball/nba/groups` | — | — |
-| `espn_nba_draft` | `site_v2` `/basketball/nba/draft` | — | — |
-| `espn_nba_event` | `core_v2` `/basketball/leagues/nba/events/{event_id}` | `event_id`\* | — |
-| `espn_nba_event_broadcasts` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_nba_event_competition` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_nba_event_competitor` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitor_leaders` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitor_linescores` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitor_record` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitor_roster` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitor_statistics` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nba_event_competitors` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_nba_event_leaders` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_nba_event_odds` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_nba_event_official_detail` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_nba_event_officials` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_nba_event_play` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nba_event_play_personnel` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nba_event_plays` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_nba_event_powerindex` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_nba_event_predictor` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_nba_event_probabilities` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_nba_event_propbets` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_nba_event_scoringplays` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_nba_event_situation` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_nba_event_status` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_nba_events` | `core_v2` `/basketball/leagues/nba/events` | — | `dates`, `limit` |
-| `espn_nba_franchise` | `core_v2` `/basketball/leagues/nba/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_nba_franchises` | `core_v2` `/basketball/leagues/nba/franchises` | — | `limit` |
-| `espn_nba_injuries` | `site_v2` `/basketball/nba/injuries` | — | — |
-| `espn_nba_leaders` | `web_v3` `/basketball/nba/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_nba_leaders_core` | `core_v2` `/basketball/leagues/nba/leaders` | — | — |
-| `espn_nba_league_notes` | `core_v2` `/basketball/leagues/nba/notes` | — | — |
-| `espn_nba_league_root` | `core_v2` `/basketball/leagues/nba` | — | — |
-| `espn_nba_news` | `site_v2` `/basketball/nba/news` | — | `limit` |
-| `espn_nba_position` | `core_v2` `/basketball/leagues/nba/positions/{position_id}` | `position_id`\* | — |
-| `espn_nba_positions` | `core_v2` `/basketball/leagues/nba/positions` | — | — |
-| `espn_nba_scoreboard` | `site_v2` `/basketball/nba/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_nba_season_athletes` | `core_v2` `/basketball/leagues/nba/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_nba_season_awards` | `core_v2` `/basketball/leagues/nba/seasons/{season}/awards` | `season`\* | — |
-| `espn_nba_season_coaches` | `core_v2` `/basketball/leagues/nba/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_nba_season_draft` | `core_v2` `/basketball/leagues/nba/seasons/{season}/draft` | `season`\* | — |
-| `espn_nba_season_draft_round_picks` | `core_v2` `/basketball/leagues/nba/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_nba_season_freeagents` | `core_v2` `/basketball/leagues/nba/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_nba_season_futures` | `core_v2` `/basketball/leagues/nba/seasons/{season}/futures` | `season`\* | — |
-| `espn_nba_season_group` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nba_season_group_children` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nba_season_group_teams` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_nba_season_groups` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_nba_season_info` | `core_v2` `/basketball/leagues/nba/seasons/{season}` | `season`\* | — |
-| `espn_nba_season_pointer` | `core_v2` `/basketball/leagues/nba/season` | — | — |
-| `espn_nba_season_powerindex` | `core_v2` `/basketball/leagues/nba/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_nba_season_powerindex_leaders` | `core_v2` `/basketball/leagues/nba/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_nba_season_team` | `core_v2` `/basketball/leagues/nba/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_nba_season_teams` | `core_v2` `/basketball/leagues/nba/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_nba_season_type` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_nba_season_type_corrections` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_nba_season_type_leaders` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_nba_season_types` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types` | `season`\* | — |
-| `espn_nba_season_week` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_nba_season_week_events` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_nba_season_weeks` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_nba_seasons` | `core_v2` `/basketball/leagues/nba/seasons` | — | `limit` |
-| `espn_nba_standings` | `site_v2_alt` `/basketball/nba/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_nba_standings_core` | `core_v2` `/basketball/leagues/nba/standings` | — | — |
-| `espn_nba_statistics_league` | `site_v2` `/basketball/nba/statistics` | — | — |
-| `espn_nba_summary` | `site_v2` `/basketball/nba/summary` | — | `event_id` → `event` |
-| `espn_nba_talentpicks` | `core_v2` `/basketball/leagues/nba/talentpicks` | — | — |
-| `espn_nba_team` | `site_v2` `/basketball/nba/teams/{team_id}` | `team_id`\* | — |
-| `espn_nba_team_core` | `core_v2` `/basketball/leagues/nba/teams/{team_id}` | `team_id`\* | — |
-| `espn_nba_team_depthcharts` | `site_v2` `/basketball/nba/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_nba_team_history` | `site_v2` `/basketball/nba/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_nba_team_injuries` | `site_v2` `/basketball/nba/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_nba_team_leaders` | `site_v2` `/basketball/nba/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_nba_team_news` | `site_v2` `/basketball/nba/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_nba_team_record` | `site_v2` `/basketball/nba/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_nba_team_roster` | `site_v2` `/basketball/nba/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_nba_team_schedule` | `site_v2` `/basketball/nba/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_nba_team_transactions` | `site_v2` `/basketball/nba/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_nba_teams_core` | `core_v2` `/basketball/leagues/nba/teams` | — | `limit` |
-| `espn_nba_teams_site` | `site_v2` `/basketball/nba/teams` | — | `limit` |
-| `espn_nba_tournaments` | `core_v2` `/basketball/leagues/nba/tournaments` | — | — |
-| `espn_nba_transactions` | `site_v2` `/basketball/nba/transactions` | — | — |
-| `espn_nba_venue` | `core_v2` `/basketball/leagues/nba/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_nba_venues` | `core_v2` `/basketball/leagues/nba/venues` | — | `limit` |
+| `espnNbaAthleteAwards` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnNbaAthleteBio` | `site_v2` `/basketball/nba/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnNbaAthleteCareerStats` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnNbaAthleteContracts` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnNbaAthleteCore` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNbaAthleteEventlog` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnNbaAthleteGamelog` | `web_v3` `/basketball/nba/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnNbaAthleteInfo` | `site_v2` `/basketball/nba/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNbaAthleteInjuries` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnNbaAthleteNews` | `site_v2` `/basketball/nba/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnNbaAthleteNotes` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnNbaAthleteOverview` | `web_v3` `/basketball/nba/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnNbaAthleteRecords` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnNbaAthleteSeasons` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnNbaAthleteSplits` | `web_v3` `/basketball/nba/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnNbaAthleteStatisticslog` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnNbaAthleteStats` | `web_v3` `/basketball/nba/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnNbaAthleteVsAthlete` | `core_v2` `/basketball/leagues/nba/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnNbaAthletesIndex` | `core_v2` `/basketball/leagues/nba/athletes` | — | `active`, `limit`, `page` |
+| `espnNbaAward` | `core_v2` `/basketball/leagues/nba/awards/{award_id}` | `award_id`\* | — |
+| `espnNbaAwards` | `core_v2` `/basketball/leagues/nba/awards` | — | — |
+| `espnNbaCalendar` | `site_v2` `/basketball/nba/calendar` | — | — |
+| `espnNbaCoach` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnNbaCoachRecord` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnNbaCoachSeason` | `core_v2` `/basketball/leagues/nba/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnNbaConferences` | `site_v2` `/basketball/nba/groups` | — | — |
+| `espnNbaDraft` | `site_v2` `/basketball/nba/draft` | — | — |
+| `espnNbaEvent` | `core_v2` `/basketball/leagues/nba/events/{event_id}` | `event_id`\* | — |
+| `espnNbaEventBroadcasts` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnNbaEventCompetition` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnNbaEventCompetitor` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitorLeaders` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitorLinescores` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitorRecord` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitorRoster` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitorStatistics` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNbaEventCompetitors` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnNbaEventLeaders` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnNbaEventOdds` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnNbaEventOfficialDetail` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnNbaEventOfficials` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnNbaEventPlay` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNbaEventPlayPersonnel` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNbaEventPlays` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnNbaEventPowerindex` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnNbaEventPredictor` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnNbaEventProbabilities` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnNbaEventPropbets` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnNbaEventScoringplays` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnNbaEventSituation` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnNbaEventStatus` | `core_v2` `/basketball/leagues/nba/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnNbaEvents` | `core_v2` `/basketball/leagues/nba/events` | — | `dates`, `limit` |
+| `espnNbaFranchise` | `core_v2` `/basketball/leagues/nba/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnNbaFranchises` | `core_v2` `/basketball/leagues/nba/franchises` | — | `limit` |
+| `espnNbaInjuries` | `site_v2` `/basketball/nba/injuries` | — | — |
+| `espnNbaLeaders` | `web_v3` `/basketball/nba/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnNbaLeadersCore` | `core_v2` `/basketball/leagues/nba/leaders` | — | — |
+| `espnNbaLeagueNotes` | `core_v2` `/basketball/leagues/nba/notes` | — | — |
+| `espnNbaLeagueRoot` | `core_v2` `/basketball/leagues/nba` | — | — |
+| `espnNbaNews` | `site_v2` `/basketball/nba/news` | — | `limit` |
+| `espnNbaPosition` | `core_v2` `/basketball/leagues/nba/positions/{position_id}` | `position_id`\* | — |
+| `espnNbaPositions` | `core_v2` `/basketball/leagues/nba/positions` | — | — |
+| `espnNbaScoreboard` | `site_v2` `/basketball/nba/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnNbaSeasonAthletes` | `core_v2` `/basketball/leagues/nba/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnNbaSeasonAwards` | `core_v2` `/basketball/leagues/nba/seasons/{season}/awards` | `season`\* | — |
+| `espnNbaSeasonCoaches` | `core_v2` `/basketball/leagues/nba/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnNbaSeasonDraft` | `core_v2` `/basketball/leagues/nba/seasons/{season}/draft` | `season`\* | — |
+| `espnNbaSeasonDraftRoundPicks` | `core_v2` `/basketball/leagues/nba/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnNbaSeasonFreeagents` | `core_v2` `/basketball/leagues/nba/seasons/{season}/freeagents` | `season`\* | — |
+| `espnNbaSeasonFutures` | `core_v2` `/basketball/leagues/nba/seasons/{season}/futures` | `season`\* | — |
+| `espnNbaSeasonGroup` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNbaSeasonGroupChildren` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNbaSeasonGroupTeams` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnNbaSeasonGroups` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnNbaSeasonInfo` | `core_v2` `/basketball/leagues/nba/seasons/{season}` | `season`\* | — |
+| `espnNbaSeasonPointer` | `core_v2` `/basketball/leagues/nba/season` | — | — |
+| `espnNbaSeasonPowerindex` | `core_v2` `/basketball/leagues/nba/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnNbaSeasonPowerindexLeaders` | `core_v2` `/basketball/leagues/nba/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnNbaSeasonTeam` | `core_v2` `/basketball/leagues/nba/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnNbaSeasonTeams` | `core_v2` `/basketball/leagues/nba/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnNbaSeasonType` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnNbaSeasonTypeCorrections` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnNbaSeasonTypeLeaders` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnNbaSeasonTypes` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types` | `season`\* | — |
+| `espnNbaSeasonWeek` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnNbaSeasonWeekEvents` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnNbaSeasonWeeks` | `core_v2` `/basketball/leagues/nba/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnNbaSeasons` | `core_v2` `/basketball/leagues/nba/seasons` | — | `limit` |
+| `espnNbaStandings` | `site_v2_alt` `/basketball/nba/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnNbaStandingsCore` | `core_v2` `/basketball/leagues/nba/standings` | — | — |
+| `espnNbaStatisticsLeague` | `site_v2` `/basketball/nba/statistics` | — | — |
+| `espnNbaSummary` | `site_v2` `/basketball/nba/summary` | — | `event_id` → `event` |
+| `espnNbaTalentpicks` | `core_v2` `/basketball/leagues/nba/talentpicks` | — | — |
+| `espnNbaTeam` | `site_v2` `/basketball/nba/teams/{team_id}` | `team_id`\* | — |
+| `espnNbaTeamCore` | `core_v2` `/basketball/leagues/nba/teams/{team_id}` | `team_id`\* | — |
+| `espnNbaTeamDepthcharts` | `site_v2` `/basketball/nba/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnNbaTeamHistory` | `site_v2` `/basketball/nba/teams/{team_id}/history` | `team_id`\* | — |
+| `espnNbaTeamInjuries` | `site_v2` `/basketball/nba/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnNbaTeamLeaders` | `site_v2` `/basketball/nba/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnNbaTeamNews` | `site_v2` `/basketball/nba/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnNbaTeamRecord` | `site_v2` `/basketball/nba/teams/{team_id}/record` | `team_id`\* | — |
+| `espnNbaTeamRoster` | `site_v2` `/basketball/nba/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnNbaTeamSchedule` | `site_v2` `/basketball/nba/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnNbaTeamTransactions` | `site_v2` `/basketball/nba/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnNbaTeamsCore` | `core_v2` `/basketball/leagues/nba/teams` | — | `limit` |
+| `espnNbaTeamsSite` | `site_v2` `/basketball/nba/teams` | — | `limit` |
+| `espnNbaTournaments` | `core_v2` `/basketball/leagues/nba/tournaments` | — | — |
+| `espnNbaTransactions` | `site_v2` `/basketball/nba/transactions` | — | — |
+| `espnNbaVenue` | `core_v2` `/basketball/leagues/nba/venues/{venue_id}` | `venue_id`\* | — |
+| `espnNbaVenues` | `core_v2` `/basketball/leagues/nba/venues` | — | `limit` |

--- a/docs/docs/reference/nfl.md
+++ b/docs/docs/reference/nfl.md
@@ -14,132 +14,132 @@ sidebar_position: 6
 - **scopes:** `universal`, `football`
 - **wrappers:** 112
 
-Every endpoint is called as `sdv.nfl.espn_nfl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.nfl.espnNfl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_nfl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.nfl.espn_nfl_scoreboard({});
+await sdv.nfl.espnNflScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_nfl_athlete_awards` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_nfl_athlete_bio` | `site_v2` `/football/nfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_nfl_athlete_career_stats` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_nfl_athlete_contracts` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_nfl_athlete_core` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nfl_athlete_eventlog` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_nfl_athlete_gamelog` | `web_v3` `/football/nfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_nfl_athlete_info` | `site_v2` `/football/nfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nfl_athlete_injuries` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_nfl_athlete_news` | `site_v2` `/football/nfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_nfl_athlete_notes` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_nfl_athlete_overview` | `web_v3` `/football/nfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_nfl_athlete_records` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_nfl_athlete_seasons` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_nfl_athlete_splits` | `web_v3` `/football/nfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_nfl_athlete_statisticslog` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_nfl_athlete_stats` | `web_v3` `/football/nfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_nfl_athlete_vs_athlete` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_nfl_athletes_index` | `core_v2` `/football/leagues/nfl/athletes` | — | `active`, `limit`, `page` |
-| `espn_nfl_award` | `core_v2` `/football/leagues/nfl/awards/{award_id}` | `award_id`\* | — |
-| `espn_nfl_awards` | `core_v2` `/football/leagues/nfl/awards` | — | — |
-| `espn_nfl_calendar` | `site_v2` `/football/nfl/calendar` | — | — |
-| `espn_nfl_coach` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_nfl_coach_record` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_nfl_coach_season` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_nfl_conferences` | `site_v2` `/football/nfl/groups` | — | — |
-| `espn_nfl_draft` | `site_v2` `/football/nfl/draft` | — | — |
-| `espn_nfl_event` | `core_v2` `/football/leagues/nfl/events/{event_id}` | `event_id`\* | — |
-| `espn_nfl_event_broadcasts` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_competition` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_competitor` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitor_leaders` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitor_linescores` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitor_record` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitor_roster` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitor_statistics` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nfl_event_competitors` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_leaders` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_odds` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_official_detail` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_nfl_event_officials` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_play` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nfl_event_play_personnel` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nfl_event_plays` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_nfl_event_powerindex` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_predictor` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_probabilities` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_nfl_event_propbets` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_scoringplays` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_situation` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_nfl_event_status` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_nfl_events` | `core_v2` `/football/leagues/nfl/events` | — | `dates`, `limit` |
-| `espn_nfl_franchise` | `core_v2` `/football/leagues/nfl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_nfl_franchises` | `core_v2` `/football/leagues/nfl/franchises` | — | `limit` |
-| `espn_nfl_injuries` | `site_v2` `/football/nfl/injuries` | — | — |
-| `espn_nfl_leaders` | `web_v3` `/football/nfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_nfl_leaders_core` | `core_v2` `/football/leagues/nfl/leaders` | — | — |
-| `espn_nfl_league_notes` | `core_v2` `/football/leagues/nfl/notes` | — | — |
-| `espn_nfl_league_root` | `core_v2` `/football/leagues/nfl` | — | — |
-| `espn_nfl_news` | `site_v2` `/football/nfl/news` | — | `limit` |
-| `espn_nfl_position` | `core_v2` `/football/leagues/nfl/positions/{position_id}` | `position_id`\* | — |
-| `espn_nfl_positions` | `core_v2` `/football/leagues/nfl/positions` | — | — |
-| `espn_nfl_scoreboard` | `site_v2` `/football/nfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_nfl_season_athletes` | `core_v2` `/football/leagues/nfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_nfl_season_awards` | `core_v2` `/football/leagues/nfl/seasons/{season}/awards` | `season`\* | — |
-| `espn_nfl_season_coaches` | `core_v2` `/football/leagues/nfl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_nfl_season_draft` | `core_v2` `/football/leagues/nfl/seasons/{season}/draft` | `season`\* | — |
-| `espn_nfl_season_draft_round_picks` | `core_v2` `/football/leagues/nfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_nfl_season_freeagents` | `core_v2` `/football/leagues/nfl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_nfl_season_futures` | `core_v2` `/football/leagues/nfl/seasons/{season}/futures` | `season`\* | — |
-| `espn_nfl_season_group` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nfl_season_group_children` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nfl_season_group_teams` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_nfl_season_groups` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_nfl_season_info` | `core_v2` `/football/leagues/nfl/seasons/{season}` | `season`\* | — |
-| `espn_nfl_season_pointer` | `core_v2` `/football/leagues/nfl/season` | — | — |
-| `espn_nfl_season_powerindex` | `core_v2` `/football/leagues/nfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_nfl_season_powerindex_leaders` | `core_v2` `/football/leagues/nfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_nfl_season_team` | `core_v2` `/football/leagues/nfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_nfl_season_teams` | `core_v2` `/football/leagues/nfl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_nfl_season_type` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_nfl_season_type_corrections` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_nfl_season_type_leaders` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_nfl_season_types` | `core_v2` `/football/leagues/nfl/seasons/{season}/types` | `season`\* | — |
-| `espn_nfl_season_week` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_nfl_season_week_events` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_nfl_season_weeks` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_nfl_seasons` | `core_v2` `/football/leagues/nfl/seasons` | — | `limit` |
-| `espn_nfl_standings` | `site_v2_alt` `/football/nfl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_nfl_standings_core` | `core_v2` `/football/leagues/nfl/standings` | — | — |
-| `espn_nfl_statistics_league` | `site_v2` `/football/nfl/statistics` | — | — |
-| `espn_nfl_summary` | `site_v2` `/football/nfl/summary` | — | `event_id` → `event` |
-| `espn_nfl_talentpicks` | `core_v2` `/football/leagues/nfl/talentpicks` | — | — |
-| `espn_nfl_team` | `site_v2` `/football/nfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nfl_team_core` | `core_v2` `/football/leagues/nfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nfl_team_depthcharts` | `site_v2` `/football/nfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_nfl_team_history` | `site_v2` `/football/nfl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_nfl_team_injuries` | `site_v2` `/football/nfl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_nfl_team_leaders` | `site_v2` `/football/nfl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_nfl_team_news` | `site_v2` `/football/nfl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_nfl_team_record` | `site_v2` `/football/nfl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_nfl_team_roster` | `site_v2` `/football/nfl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_nfl_team_schedule` | `site_v2` `/football/nfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_nfl_team_transactions` | `site_v2` `/football/nfl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_nfl_teams_core` | `core_v2` `/football/leagues/nfl/teams` | — | `limit` |
-| `espn_nfl_teams_site` | `site_v2` `/football/nfl/teams` | — | `limit` |
-| `espn_nfl_tournaments` | `core_v2` `/football/leagues/nfl/tournaments` | — | — |
-| `espn_nfl_transactions` | `site_v2` `/football/nfl/transactions` | — | — |
-| `espn_nfl_venue` | `core_v2` `/football/leagues/nfl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_nfl_venues` | `core_v2` `/football/leagues/nfl/venues` | — | `limit` |
+| `espnNflAthleteAwards` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnNflAthleteBio` | `site_v2` `/football/nfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnNflAthleteCareerStats` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnNflAthleteContracts` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnNflAthleteCore` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNflAthleteEventlog` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnNflAthleteGamelog` | `web_v3` `/football/nfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnNflAthleteInfo` | `site_v2` `/football/nfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNflAthleteInjuries` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnNflAthleteNews` | `site_v2` `/football/nfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnNflAthleteNotes` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnNflAthleteOverview` | `web_v3` `/football/nfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnNflAthleteRecords` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnNflAthleteSeasons` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnNflAthleteSplits` | `web_v3` `/football/nfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnNflAthleteStatisticslog` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnNflAthleteStats` | `web_v3` `/football/nfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnNflAthleteVsAthlete` | `core_v2` `/football/leagues/nfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnNflAthletesIndex` | `core_v2` `/football/leagues/nfl/athletes` | — | `active`, `limit`, `page` |
+| `espnNflAward` | `core_v2` `/football/leagues/nfl/awards/{award_id}` | `award_id`\* | — |
+| `espnNflAwards` | `core_v2` `/football/leagues/nfl/awards` | — | — |
+| `espnNflCalendar` | `site_v2` `/football/nfl/calendar` | — | — |
+| `espnNflCoach` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnNflCoachRecord` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnNflCoachSeason` | `core_v2` `/football/leagues/nfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnNflConferences` | `site_v2` `/football/nfl/groups` | — | — |
+| `espnNflDraft` | `site_v2` `/football/nfl/draft` | — | — |
+| `espnNflEvent` | `core_v2` `/football/leagues/nfl/events/{event_id}` | `event_id`\* | — |
+| `espnNflEventBroadcasts` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnNflEventCompetition` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnNflEventCompetitor` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitorLeaders` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitorLinescores` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitorRecord` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitorRoster` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitorStatistics` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNflEventCompetitors` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnNflEventLeaders` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnNflEventOdds` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnNflEventOfficialDetail` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnNflEventOfficials` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnNflEventPlay` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNflEventPlayPersonnel` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNflEventPlays` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnNflEventPowerindex` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnNflEventPredictor` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnNflEventProbabilities` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnNflEventPropbets` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnNflEventScoringplays` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnNflEventSituation` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnNflEventStatus` | `core_v2` `/football/leagues/nfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnNflEvents` | `core_v2` `/football/leagues/nfl/events` | — | `dates`, `limit` |
+| `espnNflFranchise` | `core_v2` `/football/leagues/nfl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnNflFranchises` | `core_v2` `/football/leagues/nfl/franchises` | — | `limit` |
+| `espnNflInjuries` | `site_v2` `/football/nfl/injuries` | — | — |
+| `espnNflLeaders` | `web_v3` `/football/nfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnNflLeadersCore` | `core_v2` `/football/leagues/nfl/leaders` | — | — |
+| `espnNflLeagueNotes` | `core_v2` `/football/leagues/nfl/notes` | — | — |
+| `espnNflLeagueRoot` | `core_v2` `/football/leagues/nfl` | — | — |
+| `espnNflNews` | `site_v2` `/football/nfl/news` | — | `limit` |
+| `espnNflPosition` | `core_v2` `/football/leagues/nfl/positions/{position_id}` | `position_id`\* | — |
+| `espnNflPositions` | `core_v2` `/football/leagues/nfl/positions` | — | — |
+| `espnNflScoreboard` | `site_v2` `/football/nfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnNflSeasonAthletes` | `core_v2` `/football/leagues/nfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnNflSeasonAwards` | `core_v2` `/football/leagues/nfl/seasons/{season}/awards` | `season`\* | — |
+| `espnNflSeasonCoaches` | `core_v2` `/football/leagues/nfl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnNflSeasonDraft` | `core_v2` `/football/leagues/nfl/seasons/{season}/draft` | `season`\* | — |
+| `espnNflSeasonDraftRoundPicks` | `core_v2` `/football/leagues/nfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnNflSeasonFreeagents` | `core_v2` `/football/leagues/nfl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnNflSeasonFutures` | `core_v2` `/football/leagues/nfl/seasons/{season}/futures` | `season`\* | — |
+| `espnNflSeasonGroup` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNflSeasonGroupChildren` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNflSeasonGroupTeams` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnNflSeasonGroups` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnNflSeasonInfo` | `core_v2` `/football/leagues/nfl/seasons/{season}` | `season`\* | — |
+| `espnNflSeasonPointer` | `core_v2` `/football/leagues/nfl/season` | — | — |
+| `espnNflSeasonPowerindex` | `core_v2` `/football/leagues/nfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnNflSeasonPowerindexLeaders` | `core_v2` `/football/leagues/nfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnNflSeasonTeam` | `core_v2` `/football/leagues/nfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnNflSeasonTeams` | `core_v2` `/football/leagues/nfl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnNflSeasonType` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnNflSeasonTypeCorrections` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnNflSeasonTypeLeaders` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnNflSeasonTypes` | `core_v2` `/football/leagues/nfl/seasons/{season}/types` | `season`\* | — |
+| `espnNflSeasonWeek` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnNflSeasonWeekEvents` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnNflSeasonWeeks` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnNflSeasons` | `core_v2` `/football/leagues/nfl/seasons` | — | `limit` |
+| `espnNflStandings` | `site_v2_alt` `/football/nfl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnNflStandingsCore` | `core_v2` `/football/leagues/nfl/standings` | — | — |
+| `espnNflStatisticsLeague` | `site_v2` `/football/nfl/statistics` | — | — |
+| `espnNflSummary` | `site_v2` `/football/nfl/summary` | — | `event_id` → `event` |
+| `espnNflTalentpicks` | `core_v2` `/football/leagues/nfl/talentpicks` | — | — |
+| `espnNflTeam` | `site_v2` `/football/nfl/teams/{team_id}` | `team_id`\* | — |
+| `espnNflTeamCore` | `core_v2` `/football/leagues/nfl/teams/{team_id}` | `team_id`\* | — |
+| `espnNflTeamDepthcharts` | `site_v2` `/football/nfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnNflTeamHistory` | `site_v2` `/football/nfl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnNflTeamInjuries` | `site_v2` `/football/nfl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnNflTeamLeaders` | `site_v2` `/football/nfl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnNflTeamNews` | `site_v2` `/football/nfl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnNflTeamRecord` | `site_v2` `/football/nfl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnNflTeamRoster` | `site_v2` `/football/nfl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnNflTeamSchedule` | `site_v2` `/football/nfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnNflTeamTransactions` | `site_v2` `/football/nfl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnNflTeamsCore` | `core_v2` `/football/leagues/nfl/teams` | — | `limit` |
+| `espnNflTeamsSite` | `site_v2` `/football/nfl/teams` | — | `limit` |
+| `espnNflTournaments` | `core_v2` `/football/leagues/nfl/tournaments` | — | — |
+| `espnNflTransactions` | `site_v2` `/football/nfl/transactions` | — | — |
+| `espnNflVenue` | `core_v2` `/football/leagues/nfl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnNflVenues` | `core_v2` `/football/leagues/nfl/venues` | — | `limit` |
 
 ## Football endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_nfl_season_qbr` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}[/groups/{group_id}]/qbr/{split}` | `season`\*, `season_type`, `group_id`, `split` | — |
-| `espn_nfl_season_qbr_week` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}/qbr/{split}` | `season`\*, `week`\*, `season_type`, `split` | — |
+| `espnNflSeasonQbr` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}[/groups/{group_id}]/qbr/{split}` | `season`\*, `season_type`, `group_id`, `split` | — |
+| `espnNflSeasonQbrWeek` | `core_v2` `/football/leagues/nfl/seasons/{season}/types/{season_type}/weeks/{week}/qbr/{split}` | `season`\*, `week`\*, `season_type`, `split` | — |

--- a/docs/docs/reference/nhl.md
+++ b/docs/docs/reference/nhl.md
@@ -14,125 +14,125 @@ sidebar_position: 8
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.nhl.espn_nhl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.nhl.espnNhl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_nhl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.nhl.espn_nhl_scoreboard({});
+await sdv.nhl.espnNhlScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_nhl_athlete_awards` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_nhl_athlete_bio` | `site_v2` `/hockey/nhl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_nhl_athlete_career_stats` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_nhl_athlete_contracts` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_nhl_athlete_core` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nhl_athlete_eventlog` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_nhl_athlete_gamelog` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_nhl_athlete_info` | `site_v2` `/hockey/nhl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nhl_athlete_injuries` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_nhl_athlete_news` | `site_v2` `/hockey/nhl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_nhl_athlete_notes` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_nhl_athlete_overview` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_nhl_athlete_records` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_nhl_athlete_seasons` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_nhl_athlete_splits` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_nhl_athlete_statisticslog` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_nhl_athlete_stats` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_nhl_athlete_vs_athlete` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_nhl_athletes_index` | `core_v2` `/hockey/leagues/nhl/athletes` | — | `active`, `limit`, `page` |
-| `espn_nhl_award` | `core_v2` `/hockey/leagues/nhl/awards/{award_id}` | `award_id`\* | — |
-| `espn_nhl_awards` | `core_v2` `/hockey/leagues/nhl/awards` | — | — |
-| `espn_nhl_calendar` | `site_v2` `/hockey/nhl/calendar` | — | — |
-| `espn_nhl_coach` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_nhl_coach_record` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_nhl_coach_season` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_nhl_conferences` | `site_v2` `/hockey/nhl/groups` | — | — |
-| `espn_nhl_draft` | `site_v2` `/hockey/nhl/draft` | — | — |
-| `espn_nhl_event` | `core_v2` `/hockey/leagues/nhl/events/{event_id}` | `event_id`\* | — |
-| `espn_nhl_event_broadcasts` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_competition` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_competitor` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitor_leaders` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitor_linescores` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitor_record` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitor_roster` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitor_statistics` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nhl_event_competitors` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_leaders` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_odds` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_official_detail` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_nhl_event_officials` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_play` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nhl_event_play_personnel` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nhl_event_plays` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_nhl_event_powerindex` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_predictor` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_probabilities` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_nhl_event_propbets` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_scoringplays` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_situation` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_nhl_event_status` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_nhl_events` | `core_v2` `/hockey/leagues/nhl/events` | — | `dates`, `limit` |
-| `espn_nhl_franchise` | `core_v2` `/hockey/leagues/nhl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_nhl_franchises` | `core_v2` `/hockey/leagues/nhl/franchises` | — | `limit` |
-| `espn_nhl_injuries` | `site_v2` `/hockey/nhl/injuries` | — | — |
-| `espn_nhl_leaders` | `web_v3` `/hockey/nhl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_nhl_leaders_core` | `core_v2` `/hockey/leagues/nhl/leaders` | — | — |
-| `espn_nhl_league_notes` | `core_v2` `/hockey/leagues/nhl/notes` | — | — |
-| `espn_nhl_league_root` | `core_v2` `/hockey/leagues/nhl` | — | — |
-| `espn_nhl_news` | `site_v2` `/hockey/nhl/news` | — | `limit` |
-| `espn_nhl_position` | `core_v2` `/hockey/leagues/nhl/positions/{position_id}` | `position_id`\* | — |
-| `espn_nhl_positions` | `core_v2` `/hockey/leagues/nhl/positions` | — | — |
-| `espn_nhl_scoreboard` | `site_v2` `/hockey/nhl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_nhl_season_athletes` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_nhl_season_awards` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/awards` | `season`\* | — |
-| `espn_nhl_season_coaches` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_nhl_season_draft` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/draft` | `season`\* | — |
-| `espn_nhl_season_draft_round_picks` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_nhl_season_freeagents` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_nhl_season_futures` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/futures` | `season`\* | — |
-| `espn_nhl_season_group` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nhl_season_group_children` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nhl_season_group_teams` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_nhl_season_groups` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_nhl_season_info` | `core_v2` `/hockey/leagues/nhl/seasons/{season}` | `season`\* | — |
-| `espn_nhl_season_pointer` | `core_v2` `/hockey/leagues/nhl/season` | — | — |
-| `espn_nhl_season_powerindex` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_nhl_season_powerindex_leaders` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_nhl_season_team` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_nhl_season_teams` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_nhl_season_type` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_nhl_season_type_corrections` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_nhl_season_type_leaders` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_nhl_season_types` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types` | `season`\* | — |
-| `espn_nhl_season_week` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_nhl_season_week_events` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_nhl_season_weeks` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_nhl_seasons` | `core_v2` `/hockey/leagues/nhl/seasons` | — | `limit` |
-| `espn_nhl_standings` | `site_v2_alt` `/hockey/nhl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_nhl_standings_core` | `core_v2` `/hockey/leagues/nhl/standings` | — | — |
-| `espn_nhl_statistics_league` | `site_v2` `/hockey/nhl/statistics` | — | — |
-| `espn_nhl_summary` | `site_v2` `/hockey/nhl/summary` | — | `event_id` → `event` |
-| `espn_nhl_talentpicks` | `core_v2` `/hockey/leagues/nhl/talentpicks` | — | — |
-| `espn_nhl_team` | `site_v2` `/hockey/nhl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nhl_team_core` | `core_v2` `/hockey/leagues/nhl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nhl_team_depthcharts` | `site_v2` `/hockey/nhl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_nhl_team_history` | `site_v2` `/hockey/nhl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_nhl_team_injuries` | `site_v2` `/hockey/nhl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_nhl_team_leaders` | `site_v2` `/hockey/nhl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_nhl_team_news` | `site_v2` `/hockey/nhl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_nhl_team_record` | `site_v2` `/hockey/nhl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_nhl_team_roster` | `site_v2` `/hockey/nhl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_nhl_team_schedule` | `site_v2` `/hockey/nhl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_nhl_team_transactions` | `site_v2` `/hockey/nhl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_nhl_teams_core` | `core_v2` `/hockey/leagues/nhl/teams` | — | `limit` |
-| `espn_nhl_teams_site` | `site_v2` `/hockey/nhl/teams` | — | `limit` |
-| `espn_nhl_tournaments` | `core_v2` `/hockey/leagues/nhl/tournaments` | — | — |
-| `espn_nhl_transactions` | `site_v2` `/hockey/nhl/transactions` | — | — |
-| `espn_nhl_venue` | `core_v2` `/hockey/leagues/nhl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_nhl_venues` | `core_v2` `/hockey/leagues/nhl/venues` | — | `limit` |
+| `espnNhlAthleteAwards` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnNhlAthleteBio` | `site_v2` `/hockey/nhl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnNhlAthleteCareerStats` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnNhlAthleteContracts` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnNhlAthleteCore` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNhlAthleteEventlog` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnNhlAthleteGamelog` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnNhlAthleteInfo` | `site_v2` `/hockey/nhl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNhlAthleteInjuries` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnNhlAthleteNews` | `site_v2` `/hockey/nhl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnNhlAthleteNotes` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnNhlAthleteOverview` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnNhlAthleteRecords` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnNhlAthleteSeasons` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnNhlAthleteSplits` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnNhlAthleteStatisticslog` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnNhlAthleteStats` | `web_v3` `/hockey/nhl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnNhlAthleteVsAthlete` | `core_v2` `/hockey/leagues/nhl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnNhlAthletesIndex` | `core_v2` `/hockey/leagues/nhl/athletes` | — | `active`, `limit`, `page` |
+| `espnNhlAward` | `core_v2` `/hockey/leagues/nhl/awards/{award_id}` | `award_id`\* | — |
+| `espnNhlAwards` | `core_v2` `/hockey/leagues/nhl/awards` | — | — |
+| `espnNhlCalendar` | `site_v2` `/hockey/nhl/calendar` | — | — |
+| `espnNhlCoach` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnNhlCoachRecord` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnNhlCoachSeason` | `core_v2` `/hockey/leagues/nhl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnNhlConferences` | `site_v2` `/hockey/nhl/groups` | — | — |
+| `espnNhlDraft` | `site_v2` `/hockey/nhl/draft` | — | — |
+| `espnNhlEvent` | `core_v2` `/hockey/leagues/nhl/events/{event_id}` | `event_id`\* | — |
+| `espnNhlEventBroadcasts` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnNhlEventCompetition` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnNhlEventCompetitor` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitorLeaders` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitorLinescores` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitorRecord` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitorRoster` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitorStatistics` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNhlEventCompetitors` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnNhlEventLeaders` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnNhlEventOdds` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnNhlEventOfficialDetail` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnNhlEventOfficials` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnNhlEventPlay` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNhlEventPlayPersonnel` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNhlEventPlays` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnNhlEventPowerindex` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnNhlEventPredictor` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnNhlEventProbabilities` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnNhlEventPropbets` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnNhlEventScoringplays` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnNhlEventSituation` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnNhlEventStatus` | `core_v2` `/hockey/leagues/nhl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnNhlEvents` | `core_v2` `/hockey/leagues/nhl/events` | — | `dates`, `limit` |
+| `espnNhlFranchise` | `core_v2` `/hockey/leagues/nhl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnNhlFranchises` | `core_v2` `/hockey/leagues/nhl/franchises` | — | `limit` |
+| `espnNhlInjuries` | `site_v2` `/hockey/nhl/injuries` | — | — |
+| `espnNhlLeaders` | `web_v3` `/hockey/nhl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnNhlLeadersCore` | `core_v2` `/hockey/leagues/nhl/leaders` | — | — |
+| `espnNhlLeagueNotes` | `core_v2` `/hockey/leagues/nhl/notes` | — | — |
+| `espnNhlLeagueRoot` | `core_v2` `/hockey/leagues/nhl` | — | — |
+| `espnNhlNews` | `site_v2` `/hockey/nhl/news` | — | `limit` |
+| `espnNhlPosition` | `core_v2` `/hockey/leagues/nhl/positions/{position_id}` | `position_id`\* | — |
+| `espnNhlPositions` | `core_v2` `/hockey/leagues/nhl/positions` | — | — |
+| `espnNhlScoreboard` | `site_v2` `/hockey/nhl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnNhlSeasonAthletes` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnNhlSeasonAwards` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/awards` | `season`\* | — |
+| `espnNhlSeasonCoaches` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnNhlSeasonDraft` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/draft` | `season`\* | — |
+| `espnNhlSeasonDraftRoundPicks` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnNhlSeasonFreeagents` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnNhlSeasonFutures` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/futures` | `season`\* | — |
+| `espnNhlSeasonGroup` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNhlSeasonGroupChildren` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNhlSeasonGroupTeams` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnNhlSeasonGroups` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnNhlSeasonInfo` | `core_v2` `/hockey/leagues/nhl/seasons/{season}` | `season`\* | — |
+| `espnNhlSeasonPointer` | `core_v2` `/hockey/leagues/nhl/season` | — | — |
+| `espnNhlSeasonPowerindex` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnNhlSeasonPowerindexLeaders` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnNhlSeasonTeam` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnNhlSeasonTeams` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnNhlSeasonType` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnNhlSeasonTypeCorrections` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnNhlSeasonTypeLeaders` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnNhlSeasonTypes` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types` | `season`\* | — |
+| `espnNhlSeasonWeek` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnNhlSeasonWeekEvents` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnNhlSeasonWeeks` | `core_v2` `/hockey/leagues/nhl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnNhlSeasons` | `core_v2` `/hockey/leagues/nhl/seasons` | — | `limit` |
+| `espnNhlStandings` | `site_v2_alt` `/hockey/nhl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnNhlStandingsCore` | `core_v2` `/hockey/leagues/nhl/standings` | — | — |
+| `espnNhlStatisticsLeague` | `site_v2` `/hockey/nhl/statistics` | — | — |
+| `espnNhlSummary` | `site_v2` `/hockey/nhl/summary` | — | `event_id` → `event` |
+| `espnNhlTalentpicks` | `core_v2` `/hockey/leagues/nhl/talentpicks` | — | — |
+| `espnNhlTeam` | `site_v2` `/hockey/nhl/teams/{team_id}` | `team_id`\* | — |
+| `espnNhlTeamCore` | `core_v2` `/hockey/leagues/nhl/teams/{team_id}` | `team_id`\* | — |
+| `espnNhlTeamDepthcharts` | `site_v2` `/hockey/nhl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnNhlTeamHistory` | `site_v2` `/hockey/nhl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnNhlTeamInjuries` | `site_v2` `/hockey/nhl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnNhlTeamLeaders` | `site_v2` `/hockey/nhl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnNhlTeamNews` | `site_v2` `/hockey/nhl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnNhlTeamRecord` | `site_v2` `/hockey/nhl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnNhlTeamRoster` | `site_v2` `/hockey/nhl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnNhlTeamSchedule` | `site_v2` `/hockey/nhl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnNhlTeamTransactions` | `site_v2` `/hockey/nhl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnNhlTeamsCore` | `core_v2` `/hockey/leagues/nhl/teams` | — | `limit` |
+| `espnNhlTeamsSite` | `site_v2` `/hockey/nhl/teams` | — | `limit` |
+| `espnNhlTournaments` | `core_v2` `/hockey/leagues/nhl/tournaments` | — | — |
+| `espnNhlTransactions` | `site_v2` `/hockey/nhl/transactions` | — | — |
+| `espnNhlVenue` | `core_v2` `/hockey/leagues/nhl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnNhlVenues` | `core_v2` `/hockey/leagues/nhl/venues` | — | `limit` |

--- a/docs/docs/reference/nwsl.md
+++ b/docs/docs/reference/nwsl.md
@@ -14,125 +14,125 @@ sidebar_position: 26
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.nwsl.espn_nwsl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.nwsl.espnNwsl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_nwsl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.nwsl.espn_nwsl_scoreboard({});
+await sdv.nwsl.espnNwslScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_nwsl_athlete_awards` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_bio` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_career_stats` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_nwsl_athlete_contracts` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_core` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_eventlog` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_gamelog` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_nwsl_athlete_info` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_injuries` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_news` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_notes` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_overview` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_records` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_seasons` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_splits` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_nwsl_athlete_statisticslog` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_nwsl_athlete_stats` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_nwsl_athlete_vs_athlete` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_nwsl_athletes_index` | `core_v2` `/soccer/leagues/usa.nwsl/athletes` | — | `active`, `limit`, `page` |
-| `espn_nwsl_award` | `core_v2` `/soccer/leagues/usa.nwsl/awards/{award_id}` | `award_id`\* | — |
-| `espn_nwsl_awards` | `core_v2` `/soccer/leagues/usa.nwsl/awards` | — | — |
-| `espn_nwsl_calendar` | `site_v2` `/soccer/usa.nwsl/calendar` | — | — |
-| `espn_nwsl_coach` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_nwsl_coach_record` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_nwsl_coach_season` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_nwsl_conferences` | `site_v2` `/soccer/usa.nwsl/groups` | — | — |
-| `espn_nwsl_draft` | `site_v2` `/soccer/usa.nwsl/draft` | — | — |
-| `espn_nwsl_event` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}` | `event_id`\* | — |
-| `espn_nwsl_event_broadcasts` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_competition` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor_leaders` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor_linescores` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor_record` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor_roster` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitor_statistics` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_nwsl_event_competitors` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_leaders` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_odds` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_official_detail` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_nwsl_event_officials` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_play` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nwsl_event_play_personnel` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_nwsl_event_plays` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_nwsl_event_powerindex` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_predictor` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_probabilities` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_nwsl_event_propbets` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_scoringplays` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_situation` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_nwsl_event_status` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_nwsl_events` | `core_v2` `/soccer/leagues/usa.nwsl/events` | — | `dates`, `limit` |
-| `espn_nwsl_franchise` | `core_v2` `/soccer/leagues/usa.nwsl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_nwsl_franchises` | `core_v2` `/soccer/leagues/usa.nwsl/franchises` | — | `limit` |
-| `espn_nwsl_injuries` | `site_v2` `/soccer/usa.nwsl/injuries` | — | — |
-| `espn_nwsl_leaders` | `web_v3` `/soccer/usa.nwsl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_nwsl_leaders_core` | `core_v2` `/soccer/leagues/usa.nwsl/leaders` | — | — |
-| `espn_nwsl_league_notes` | `core_v2` `/soccer/leagues/usa.nwsl/notes` | — | — |
-| `espn_nwsl_league_root` | `core_v2` `/soccer/leagues/usa.nwsl` | — | — |
-| `espn_nwsl_news` | `site_v2` `/soccer/usa.nwsl/news` | — | `limit` |
-| `espn_nwsl_position` | `core_v2` `/soccer/leagues/usa.nwsl/positions/{position_id}` | `position_id`\* | — |
-| `espn_nwsl_positions` | `core_v2` `/soccer/leagues/usa.nwsl/positions` | — | — |
-| `espn_nwsl_scoreboard` | `site_v2` `/soccer/usa.nwsl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_nwsl_season_athletes` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_nwsl_season_awards` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/awards` | `season`\* | — |
-| `espn_nwsl_season_coaches` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_nwsl_season_draft` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/draft` | `season`\* | — |
-| `espn_nwsl_season_draft_round_picks` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_nwsl_season_freeagents` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_nwsl_season_futures` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/futures` | `season`\* | — |
-| `espn_nwsl_season_group` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nwsl_season_group_children` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_nwsl_season_group_teams` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_nwsl_season_groups` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_nwsl_season_info` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}` | `season`\* | — |
-| `espn_nwsl_season_pointer` | `core_v2` `/soccer/leagues/usa.nwsl/season` | — | — |
-| `espn_nwsl_season_powerindex` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_nwsl_season_powerindex_leaders` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_nwsl_season_team` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_nwsl_season_teams` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_nwsl_season_type` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_nwsl_season_type_corrections` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_nwsl_season_type_leaders` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_nwsl_season_types` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types` | `season`\* | — |
-| `espn_nwsl_season_week` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_nwsl_season_week_events` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_nwsl_season_weeks` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_nwsl_seasons` | `core_v2` `/soccer/leagues/usa.nwsl/seasons` | — | `limit` |
-| `espn_nwsl_standings` | `site_v2_alt` `/soccer/usa.nwsl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_nwsl_standings_core` | `core_v2` `/soccer/leagues/usa.nwsl/standings` | — | — |
-| `espn_nwsl_statistics_league` | `site_v2` `/soccer/usa.nwsl/statistics` | — | — |
-| `espn_nwsl_summary` | `site_v2` `/soccer/usa.nwsl/summary` | — | `event_id` → `event` |
-| `espn_nwsl_talentpicks` | `core_v2` `/soccer/leagues/usa.nwsl/talentpicks` | — | — |
-| `espn_nwsl_team` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nwsl_team_core` | `core_v2` `/soccer/leagues/usa.nwsl/teams/{team_id}` | `team_id`\* | — |
-| `espn_nwsl_team_depthcharts` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_nwsl_team_history` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_nwsl_team_injuries` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_nwsl_team_leaders` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_nwsl_team_news` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_nwsl_team_record` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_nwsl_team_roster` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_nwsl_team_schedule` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_nwsl_team_transactions` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_nwsl_teams_core` | `core_v2` `/soccer/leagues/usa.nwsl/teams` | — | `limit` |
-| `espn_nwsl_teams_site` | `site_v2` `/soccer/usa.nwsl/teams` | — | `limit` |
-| `espn_nwsl_tournaments` | `core_v2` `/soccer/leagues/usa.nwsl/tournaments` | — | — |
-| `espn_nwsl_transactions` | `site_v2` `/soccer/usa.nwsl/transactions` | — | — |
-| `espn_nwsl_venue` | `core_v2` `/soccer/leagues/usa.nwsl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_nwsl_venues` | `core_v2` `/soccer/leagues/usa.nwsl/venues` | — | `limit` |
+| `espnNwslAthleteAwards` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnNwslAthleteBio` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnNwslAthleteCareerStats` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnNwslAthleteContracts` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnNwslAthleteCore` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNwslAthleteEventlog` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnNwslAthleteGamelog` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnNwslAthleteInfo` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnNwslAthleteInjuries` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnNwslAthleteNews` | `site_v2` `/soccer/usa.nwsl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnNwslAthleteNotes` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnNwslAthleteOverview` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnNwslAthleteRecords` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnNwslAthleteSeasons` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnNwslAthleteSplits` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnNwslAthleteStatisticslog` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnNwslAthleteStats` | `web_v3` `/soccer/usa.nwsl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnNwslAthleteVsAthlete` | `core_v2` `/soccer/leagues/usa.nwsl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnNwslAthletesIndex` | `core_v2` `/soccer/leagues/usa.nwsl/athletes` | — | `active`, `limit`, `page` |
+| `espnNwslAward` | `core_v2` `/soccer/leagues/usa.nwsl/awards/{award_id}` | `award_id`\* | — |
+| `espnNwslAwards` | `core_v2` `/soccer/leagues/usa.nwsl/awards` | — | — |
+| `espnNwslCalendar` | `site_v2` `/soccer/usa.nwsl/calendar` | — | — |
+| `espnNwslCoach` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnNwslCoachRecord` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnNwslCoachSeason` | `core_v2` `/soccer/leagues/usa.nwsl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnNwslConferences` | `site_v2` `/soccer/usa.nwsl/groups` | — | — |
+| `espnNwslDraft` | `site_v2` `/soccer/usa.nwsl/draft` | — | — |
+| `espnNwslEvent` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}` | `event_id`\* | — |
+| `espnNwslEventBroadcasts` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnNwslEventCompetition` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnNwslEventCompetitor` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitorLeaders` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitorLinescores` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitorRecord` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitorRoster` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitorStatistics` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnNwslEventCompetitors` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnNwslEventLeaders` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnNwslEventOdds` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnNwslEventOfficialDetail` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnNwslEventOfficials` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnNwslEventPlay` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNwslEventPlayPersonnel` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnNwslEventPlays` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnNwslEventPowerindex` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnNwslEventPredictor` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnNwslEventProbabilities` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnNwslEventPropbets` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnNwslEventScoringplays` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnNwslEventSituation` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnNwslEventStatus` | `core_v2` `/soccer/leagues/usa.nwsl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnNwslEvents` | `core_v2` `/soccer/leagues/usa.nwsl/events` | — | `dates`, `limit` |
+| `espnNwslFranchise` | `core_v2` `/soccer/leagues/usa.nwsl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnNwslFranchises` | `core_v2` `/soccer/leagues/usa.nwsl/franchises` | — | `limit` |
+| `espnNwslInjuries` | `site_v2` `/soccer/usa.nwsl/injuries` | — | — |
+| `espnNwslLeaders` | `web_v3` `/soccer/usa.nwsl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnNwslLeadersCore` | `core_v2` `/soccer/leagues/usa.nwsl/leaders` | — | — |
+| `espnNwslLeagueNotes` | `core_v2` `/soccer/leagues/usa.nwsl/notes` | — | — |
+| `espnNwslLeagueRoot` | `core_v2` `/soccer/leagues/usa.nwsl` | — | — |
+| `espnNwslNews` | `site_v2` `/soccer/usa.nwsl/news` | — | `limit` |
+| `espnNwslPosition` | `core_v2` `/soccer/leagues/usa.nwsl/positions/{position_id}` | `position_id`\* | — |
+| `espnNwslPositions` | `core_v2` `/soccer/leagues/usa.nwsl/positions` | — | — |
+| `espnNwslScoreboard` | `site_v2` `/soccer/usa.nwsl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnNwslSeasonAthletes` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnNwslSeasonAwards` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/awards` | `season`\* | — |
+| `espnNwslSeasonCoaches` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnNwslSeasonDraft` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/draft` | `season`\* | — |
+| `espnNwslSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnNwslSeasonFreeagents` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnNwslSeasonFutures` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/futures` | `season`\* | — |
+| `espnNwslSeasonGroup` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNwslSeasonGroupChildren` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnNwslSeasonGroupTeams` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnNwslSeasonGroups` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnNwslSeasonInfo` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}` | `season`\* | — |
+| `espnNwslSeasonPointer` | `core_v2` `/soccer/leagues/usa.nwsl/season` | — | — |
+| `espnNwslSeasonPowerindex` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnNwslSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnNwslSeasonTeam` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnNwslSeasonTeams` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnNwslSeasonType` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnNwslSeasonTypeCorrections` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnNwslSeasonTypeLeaders` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnNwslSeasonTypes` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types` | `season`\* | — |
+| `espnNwslSeasonWeek` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnNwslSeasonWeekEvents` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnNwslSeasonWeeks` | `core_v2` `/soccer/leagues/usa.nwsl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnNwslSeasons` | `core_v2` `/soccer/leagues/usa.nwsl/seasons` | — | `limit` |
+| `espnNwslStandings` | `site_v2_alt` `/soccer/usa.nwsl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnNwslStandingsCore` | `core_v2` `/soccer/leagues/usa.nwsl/standings` | — | — |
+| `espnNwslStatisticsLeague` | `site_v2` `/soccer/usa.nwsl/statistics` | — | — |
+| `espnNwslSummary` | `site_v2` `/soccer/usa.nwsl/summary` | — | `event_id` → `event` |
+| `espnNwslTalentpicks` | `core_v2` `/soccer/leagues/usa.nwsl/talentpicks` | — | — |
+| `espnNwslTeam` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}` | `team_id`\* | — |
+| `espnNwslTeamCore` | `core_v2` `/soccer/leagues/usa.nwsl/teams/{team_id}` | `team_id`\* | — |
+| `espnNwslTeamDepthcharts` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnNwslTeamHistory` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnNwslTeamInjuries` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnNwslTeamLeaders` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnNwslTeamNews` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnNwslTeamRecord` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnNwslTeamRoster` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnNwslTeamSchedule` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnNwslTeamTransactions` | `site_v2` `/soccer/usa.nwsl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnNwslTeamsCore` | `core_v2` `/soccer/leagues/usa.nwsl/teams` | — | `limit` |
+| `espnNwslTeamsSite` | `site_v2` `/soccer/usa.nwsl/teams` | — | `limit` |
+| `espnNwslTournaments` | `core_v2` `/soccer/leagues/usa.nwsl/tournaments` | — | — |
+| `espnNwslTransactions` | `site_v2` `/soccer/usa.nwsl/transactions` | — | — |
+| `espnNwslVenue` | `core_v2` `/soccer/leagues/usa.nwsl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnNwslVenues` | `core_v2` `/soccer/leagues/usa.nwsl/venues` | — | `limit` |

--- a/docs/docs/reference/seriea.md
+++ b/docs/docs/reference/seriea.md
@@ -14,125 +14,125 @@ sidebar_position: 20
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.seriea.espn_seriea_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.seriea.espnSeriea<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_seriea_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.seriea.espn_seriea_scoreboard({});
+await sdv.seriea.espnSerieaScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_seriea_athlete_awards` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_seriea_athlete_bio` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_seriea_athlete_career_stats` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_seriea_athlete_contracts` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_seriea_athlete_core` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_seriea_athlete_eventlog` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_seriea_athlete_gamelog` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_seriea_athlete_info` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_seriea_athlete_injuries` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_seriea_athlete_news` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_seriea_athlete_notes` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_seriea_athlete_overview` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_seriea_athlete_records` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_seriea_athlete_seasons` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_seriea_athlete_splits` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_seriea_athlete_statisticslog` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_seriea_athlete_stats` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_seriea_athlete_vs_athlete` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_seriea_athletes_index` | `core_v2` `/soccer/leagues/ita.1/athletes` | — | `active`, `limit`, `page` |
-| `espn_seriea_award` | `core_v2` `/soccer/leagues/ita.1/awards/{award_id}` | `award_id`\* | — |
-| `espn_seriea_awards` | `core_v2` `/soccer/leagues/ita.1/awards` | — | — |
-| `espn_seriea_calendar` | `site_v2` `/soccer/ita.1/calendar` | — | — |
-| `espn_seriea_coach` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_seriea_coach_record` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_seriea_coach_season` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_seriea_conferences` | `site_v2` `/soccer/ita.1/groups` | — | — |
-| `espn_seriea_draft` | `site_v2` `/soccer/ita.1/draft` | — | — |
-| `espn_seriea_event` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}` | `event_id`\* | — |
-| `espn_seriea_event_broadcasts` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_competition` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_competitor` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitor_leaders` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitor_linescores` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitor_record` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitor_roster` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitor_statistics` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_seriea_event_competitors` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_leaders` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_odds` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_official_detail` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_seriea_event_officials` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_play` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_seriea_event_play_personnel` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_seriea_event_plays` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_seriea_event_powerindex` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_predictor` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_probabilities` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_seriea_event_propbets` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_scoringplays` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_situation` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_seriea_event_status` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_seriea_events` | `core_v2` `/soccer/leagues/ita.1/events` | — | `dates`, `limit` |
-| `espn_seriea_franchise` | `core_v2` `/soccer/leagues/ita.1/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_seriea_franchises` | `core_v2` `/soccer/leagues/ita.1/franchises` | — | `limit` |
-| `espn_seriea_injuries` | `site_v2` `/soccer/ita.1/injuries` | — | — |
-| `espn_seriea_leaders` | `web_v3` `/soccer/ita.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_seriea_leaders_core` | `core_v2` `/soccer/leagues/ita.1/leaders` | — | — |
-| `espn_seriea_league_notes` | `core_v2` `/soccer/leagues/ita.1/notes` | — | — |
-| `espn_seriea_league_root` | `core_v2` `/soccer/leagues/ita.1` | — | — |
-| `espn_seriea_news` | `site_v2` `/soccer/ita.1/news` | — | `limit` |
-| `espn_seriea_position` | `core_v2` `/soccer/leagues/ita.1/positions/{position_id}` | `position_id`\* | — |
-| `espn_seriea_positions` | `core_v2` `/soccer/leagues/ita.1/positions` | — | — |
-| `espn_seriea_scoreboard` | `site_v2` `/soccer/ita.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_seriea_season_athletes` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_seriea_season_awards` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/awards` | `season`\* | — |
-| `espn_seriea_season_coaches` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_seriea_season_draft` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/draft` | `season`\* | — |
-| `espn_seriea_season_draft_round_picks` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_seriea_season_freeagents` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_seriea_season_futures` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/futures` | `season`\* | — |
-| `espn_seriea_season_group` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_seriea_season_group_children` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_seriea_season_group_teams` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_seriea_season_groups` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_seriea_season_info` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}` | `season`\* | — |
-| `espn_seriea_season_pointer` | `core_v2` `/soccer/leagues/ita.1/season` | — | — |
-| `espn_seriea_season_powerindex` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_seriea_season_powerindex_leaders` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_seriea_season_team` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_seriea_season_teams` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_seriea_season_type` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_seriea_season_type_corrections` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_seriea_season_type_leaders` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_seriea_season_types` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types` | `season`\* | — |
-| `espn_seriea_season_week` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_seriea_season_week_events` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_seriea_season_weeks` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_seriea_seasons` | `core_v2` `/soccer/leagues/ita.1/seasons` | — | `limit` |
-| `espn_seriea_standings` | `site_v2_alt` `/soccer/ita.1/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_seriea_standings_core` | `core_v2` `/soccer/leagues/ita.1/standings` | — | — |
-| `espn_seriea_statistics_league` | `site_v2` `/soccer/ita.1/statistics` | — | — |
-| `espn_seriea_summary` | `site_v2` `/soccer/ita.1/summary` | — | `event_id` → `event` |
-| `espn_seriea_talentpicks` | `core_v2` `/soccer/leagues/ita.1/talentpicks` | — | — |
-| `espn_seriea_team` | `site_v2` `/soccer/ita.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_seriea_team_core` | `core_v2` `/soccer/leagues/ita.1/teams/{team_id}` | `team_id`\* | — |
-| `espn_seriea_team_depthcharts` | `site_v2` `/soccer/ita.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_seriea_team_history` | `site_v2` `/soccer/ita.1/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_seriea_team_injuries` | `site_v2` `/soccer/ita.1/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_seriea_team_leaders` | `site_v2` `/soccer/ita.1/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_seriea_team_news` | `site_v2` `/soccer/ita.1/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_seriea_team_record` | `site_v2` `/soccer/ita.1/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_seriea_team_roster` | `site_v2` `/soccer/ita.1/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_seriea_team_schedule` | `site_v2` `/soccer/ita.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_seriea_team_transactions` | `site_v2` `/soccer/ita.1/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_seriea_teams_core` | `core_v2` `/soccer/leagues/ita.1/teams` | — | `limit` |
-| `espn_seriea_teams_site` | `site_v2` `/soccer/ita.1/teams` | — | `limit` |
-| `espn_seriea_tournaments` | `core_v2` `/soccer/leagues/ita.1/tournaments` | — | — |
-| `espn_seriea_transactions` | `site_v2` `/soccer/ita.1/transactions` | — | — |
-| `espn_seriea_venue` | `core_v2` `/soccer/leagues/ita.1/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_seriea_venues` | `core_v2` `/soccer/leagues/ita.1/venues` | — | `limit` |
+| `espnSerieaAthleteAwards` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnSerieaAthleteBio` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnSerieaAthleteCareerStats` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnSerieaAthleteContracts` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnSerieaAthleteCore` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnSerieaAthleteEventlog` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnSerieaAthleteGamelog` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnSerieaAthleteInfo` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnSerieaAthleteInjuries` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnSerieaAthleteNews` | `site_v2` `/soccer/ita.1/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnSerieaAthleteNotes` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnSerieaAthleteOverview` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnSerieaAthleteRecords` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnSerieaAthleteSeasons` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnSerieaAthleteSplits` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnSerieaAthleteStatisticslog` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnSerieaAthleteStats` | `web_v3` `/soccer/ita.1/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnSerieaAthleteVsAthlete` | `core_v2` `/soccer/leagues/ita.1/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnSerieaAthletesIndex` | `core_v2` `/soccer/leagues/ita.1/athletes` | — | `active`, `limit`, `page` |
+| `espnSerieaAward` | `core_v2` `/soccer/leagues/ita.1/awards/{award_id}` | `award_id`\* | — |
+| `espnSerieaAwards` | `core_v2` `/soccer/leagues/ita.1/awards` | — | — |
+| `espnSerieaCalendar` | `site_v2` `/soccer/ita.1/calendar` | — | — |
+| `espnSerieaCoach` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnSerieaCoachRecord` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnSerieaCoachSeason` | `core_v2` `/soccer/leagues/ita.1/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnSerieaConferences` | `site_v2` `/soccer/ita.1/groups` | — | — |
+| `espnSerieaDraft` | `site_v2` `/soccer/ita.1/draft` | — | — |
+| `espnSerieaEvent` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}` | `event_id`\* | — |
+| `espnSerieaEventBroadcasts` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnSerieaEventCompetition` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnSerieaEventCompetitor` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitorLeaders` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitorLinescores` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitorRecord` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitorRoster` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitorStatistics` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSerieaEventCompetitors` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnSerieaEventLeaders` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnSerieaEventOdds` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnSerieaEventOfficialDetail` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnSerieaEventOfficials` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnSerieaEventPlay` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnSerieaEventPlayPersonnel` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnSerieaEventPlays` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnSerieaEventPowerindex` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnSerieaEventPredictor` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnSerieaEventProbabilities` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnSerieaEventPropbets` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnSerieaEventScoringplays` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnSerieaEventSituation` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnSerieaEventStatus` | `core_v2` `/soccer/leagues/ita.1/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnSerieaEvents` | `core_v2` `/soccer/leagues/ita.1/events` | — | `dates`, `limit` |
+| `espnSerieaFranchise` | `core_v2` `/soccer/leagues/ita.1/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnSerieaFranchises` | `core_v2` `/soccer/leagues/ita.1/franchises` | — | `limit` |
+| `espnSerieaInjuries` | `site_v2` `/soccer/ita.1/injuries` | — | — |
+| `espnSerieaLeaders` | `web_v3` `/soccer/ita.1/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnSerieaLeadersCore` | `core_v2` `/soccer/leagues/ita.1/leaders` | — | — |
+| `espnSerieaLeagueNotes` | `core_v2` `/soccer/leagues/ita.1/notes` | — | — |
+| `espnSerieaLeagueRoot` | `core_v2` `/soccer/leagues/ita.1` | — | — |
+| `espnSerieaNews` | `site_v2` `/soccer/ita.1/news` | — | `limit` |
+| `espnSerieaPosition` | `core_v2` `/soccer/leagues/ita.1/positions/{position_id}` | `position_id`\* | — |
+| `espnSerieaPositions` | `core_v2` `/soccer/leagues/ita.1/positions` | — | — |
+| `espnSerieaScoreboard` | `site_v2` `/soccer/ita.1/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnSerieaSeasonAthletes` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnSerieaSeasonAwards` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/awards` | `season`\* | — |
+| `espnSerieaSeasonCoaches` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnSerieaSeasonDraft` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/draft` | `season`\* | — |
+| `espnSerieaSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnSerieaSeasonFreeagents` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/freeagents` | `season`\* | — |
+| `espnSerieaSeasonFutures` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/futures` | `season`\* | — |
+| `espnSerieaSeasonGroup` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnSerieaSeasonGroupChildren` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnSerieaSeasonGroupTeams` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnSerieaSeasonGroups` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnSerieaSeasonInfo` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}` | `season`\* | — |
+| `espnSerieaSeasonPointer` | `core_v2` `/soccer/leagues/ita.1/season` | — | — |
+| `espnSerieaSeasonPowerindex` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnSerieaSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnSerieaSeasonTeam` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnSerieaSeasonTeams` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnSerieaSeasonType` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnSerieaSeasonTypeCorrections` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnSerieaSeasonTypeLeaders` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnSerieaSeasonTypes` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types` | `season`\* | — |
+| `espnSerieaSeasonWeek` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnSerieaSeasonWeekEvents` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnSerieaSeasonWeeks` | `core_v2` `/soccer/leagues/ita.1/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnSerieaSeasons` | `core_v2` `/soccer/leagues/ita.1/seasons` | — | `limit` |
+| `espnSerieaStandings` | `site_v2_alt` `/soccer/ita.1/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnSerieaStandingsCore` | `core_v2` `/soccer/leagues/ita.1/standings` | — | — |
+| `espnSerieaStatisticsLeague` | `site_v2` `/soccer/ita.1/statistics` | — | — |
+| `espnSerieaSummary` | `site_v2` `/soccer/ita.1/summary` | — | `event_id` → `event` |
+| `espnSerieaTalentpicks` | `core_v2` `/soccer/leagues/ita.1/talentpicks` | — | — |
+| `espnSerieaTeam` | `site_v2` `/soccer/ita.1/teams/{team_id}` | `team_id`\* | — |
+| `espnSerieaTeamCore` | `core_v2` `/soccer/leagues/ita.1/teams/{team_id}` | `team_id`\* | — |
+| `espnSerieaTeamDepthcharts` | `site_v2` `/soccer/ita.1/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnSerieaTeamHistory` | `site_v2` `/soccer/ita.1/teams/{team_id}/history` | `team_id`\* | — |
+| `espnSerieaTeamInjuries` | `site_v2` `/soccer/ita.1/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnSerieaTeamLeaders` | `site_v2` `/soccer/ita.1/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnSerieaTeamNews` | `site_v2` `/soccer/ita.1/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnSerieaTeamRecord` | `site_v2` `/soccer/ita.1/teams/{team_id}/record` | `team_id`\* | — |
+| `espnSerieaTeamRoster` | `site_v2` `/soccer/ita.1/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnSerieaTeamSchedule` | `site_v2` `/soccer/ita.1/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnSerieaTeamTransactions` | `site_v2` `/soccer/ita.1/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnSerieaTeamsCore` | `core_v2` `/soccer/leagues/ita.1/teams` | — | `limit` |
+| `espnSerieaTeamsSite` | `site_v2` `/soccer/ita.1/teams` | — | `limit` |
+| `espnSerieaTournaments` | `core_v2` `/soccer/leagues/ita.1/tournaments` | — | — |
+| `espnSerieaTransactions` | `site_v2` `/soccer/ita.1/transactions` | — | — |
+| `espnSerieaVenue` | `core_v2` `/soccer/leagues/ita.1/venues/{venue_id}` | `venue_id`\* | — |
+| `espnSerieaVenues` | `core_v2` `/soccer/leagues/ita.1/venues` | — | `limit` |

--- a/docs/docs/reference/soccer.md
+++ b/docs/docs/reference/soccer.md
@@ -14,125 +14,125 @@ sidebar_position: 16
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.soccer.espn_soccer_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.soccer.espnSoccer<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_soccer_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.soccer.espn_soccer_scoreboard({ league: 'eng.1' });
+await sdv.soccer.espnSoccerScoreboard({ league: 'eng.1' });
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_soccer_athlete_awards` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_soccer_athlete_bio` | `site_v2` `/soccer/{league}/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_soccer_athlete_career_stats` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_soccer_athlete_contracts` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_soccer_athlete_core` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_soccer_athlete_eventlog` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_soccer_athlete_gamelog` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_soccer_athlete_info` | `site_v2` `/soccer/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_soccer_athlete_injuries` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_soccer_athlete_news` | `site_v2` `/soccer/{league}/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_soccer_athlete_notes` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_soccer_athlete_overview` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_soccer_athlete_records` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_soccer_athlete_seasons` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_soccer_athlete_splits` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_soccer_athlete_statisticslog` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_soccer_athlete_stats` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_soccer_athlete_vs_athlete` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_soccer_athletes_index` | `core_v2` `/soccer/leagues/{league}/athletes` | — | `active`, `limit`, `page` |
-| `espn_soccer_award` | `core_v2` `/soccer/leagues/{league}/awards/{award_id}` | `award_id`\* | — |
-| `espn_soccer_awards` | `core_v2` `/soccer/leagues/{league}/awards` | — | — |
-| `espn_soccer_calendar` | `site_v2` `/soccer/{league}/calendar` | — | — |
-| `espn_soccer_coach` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_soccer_coach_record` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_soccer_coach_season` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_soccer_conferences` | `site_v2` `/soccer/{league}/groups` | — | — |
-| `espn_soccer_draft` | `site_v2` `/soccer/{league}/draft` | — | — |
-| `espn_soccer_event` | `core_v2` `/soccer/leagues/{league}/events/{event_id}` | `event_id`\* | — |
-| `espn_soccer_event_broadcasts` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_competition` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_competitor` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitor_leaders` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitor_linescores` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitor_record` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitor_roster` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitor_statistics` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_soccer_event_competitors` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_leaders` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_odds` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_official_detail` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_soccer_event_officials` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_play` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_soccer_event_play_personnel` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_soccer_event_plays` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_soccer_event_powerindex` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_predictor` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_probabilities` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_soccer_event_propbets` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_scoringplays` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_situation` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_soccer_event_status` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_soccer_events` | `core_v2` `/soccer/leagues/{league}/events` | — | `dates`, `limit` |
-| `espn_soccer_franchise` | `core_v2` `/soccer/leagues/{league}/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_soccer_franchises` | `core_v2` `/soccer/leagues/{league}/franchises` | — | `limit` |
-| `espn_soccer_injuries` | `site_v2` `/soccer/{league}/injuries` | — | — |
-| `espn_soccer_leaders` | `web_v3` `/soccer/{league}/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_soccer_leaders_core` | `core_v2` `/soccer/leagues/{league}/leaders` | — | — |
-| `espn_soccer_league_notes` | `core_v2` `/soccer/leagues/{league}/notes` | — | — |
-| `espn_soccer_league_root` | `core_v2` `/soccer/leagues/{league}` | — | — |
-| `espn_soccer_news` | `site_v2` `/soccer/{league}/news` | — | `limit` |
-| `espn_soccer_position` | `core_v2` `/soccer/leagues/{league}/positions/{position_id}` | `position_id`\* | — |
-| `espn_soccer_positions` | `core_v2` `/soccer/leagues/{league}/positions` | — | — |
-| `espn_soccer_scoreboard` | `site_v2` `/soccer/{league}/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_soccer_season_athletes` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_soccer_season_awards` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/awards` | `season`\* | — |
-| `espn_soccer_season_coaches` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_soccer_season_draft` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/draft` | `season`\* | — |
-| `espn_soccer_season_draft_round_picks` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_soccer_season_freeagents` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_soccer_season_futures` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/futures` | `season`\* | — |
-| `espn_soccer_season_group` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_soccer_season_group_children` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_soccer_season_group_teams` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_soccer_season_groups` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_soccer_season_info` | `core_v2` `/soccer/leagues/{league}/seasons/{season}` | `season`\* | — |
-| `espn_soccer_season_pointer` | `core_v2` `/soccer/leagues/{league}/season` | — | — |
-| `espn_soccer_season_powerindex` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_soccer_season_powerindex_leaders` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_soccer_season_team` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_soccer_season_teams` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_soccer_season_type` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_soccer_season_type_corrections` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_soccer_season_type_leaders` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_soccer_season_types` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types` | `season`\* | — |
-| `espn_soccer_season_week` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_soccer_season_week_events` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_soccer_season_weeks` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_soccer_seasons` | `core_v2` `/soccer/leagues/{league}/seasons` | — | `limit` |
-| `espn_soccer_standings` | `site_v2_alt` `/soccer/{league}/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_soccer_standings_core` | `core_v2` `/soccer/leagues/{league}/standings` | — | — |
-| `espn_soccer_statistics_league` | `site_v2` `/soccer/{league}/statistics` | — | — |
-| `espn_soccer_summary` | `site_v2` `/soccer/{league}/summary` | — | `event_id` → `event` |
-| `espn_soccer_talentpicks` | `core_v2` `/soccer/leagues/{league}/talentpicks` | — | — |
-| `espn_soccer_team` | `site_v2` `/soccer/{league}/teams/{team_id}` | `team_id`\* | — |
-| `espn_soccer_team_core` | `core_v2` `/soccer/leagues/{league}/teams/{team_id}` | `team_id`\* | — |
-| `espn_soccer_team_depthcharts` | `site_v2` `/soccer/{league}/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_soccer_team_history` | `site_v2` `/soccer/{league}/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_soccer_team_injuries` | `site_v2` `/soccer/{league}/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_soccer_team_leaders` | `site_v2` `/soccer/{league}/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_soccer_team_news` | `site_v2` `/soccer/{league}/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_soccer_team_record` | `site_v2` `/soccer/{league}/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_soccer_team_roster` | `site_v2` `/soccer/{league}/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_soccer_team_schedule` | `site_v2` `/soccer/{league}/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_soccer_team_transactions` | `site_v2` `/soccer/{league}/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_soccer_teams_core` | `core_v2` `/soccer/leagues/{league}/teams` | — | `limit` |
-| `espn_soccer_teams_site` | `site_v2` `/soccer/{league}/teams` | — | `limit` |
-| `espn_soccer_tournaments` | `core_v2` `/soccer/leagues/{league}/tournaments` | — | — |
-| `espn_soccer_transactions` | `site_v2` `/soccer/{league}/transactions` | — | — |
-| `espn_soccer_venue` | `core_v2` `/soccer/leagues/{league}/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_soccer_venues` | `core_v2` `/soccer/leagues/{league}/venues` | — | `limit` |
+| `espnSoccerAthleteAwards` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnSoccerAthleteBio` | `site_v2` `/soccer/{league}/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnSoccerAthleteCareerStats` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnSoccerAthleteContracts` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnSoccerAthleteCore` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnSoccerAthleteEventlog` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnSoccerAthleteGamelog` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnSoccerAthleteInfo` | `site_v2` `/soccer/{league}/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnSoccerAthleteInjuries` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnSoccerAthleteNews` | `site_v2` `/soccer/{league}/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnSoccerAthleteNotes` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnSoccerAthleteOverview` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnSoccerAthleteRecords` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnSoccerAthleteSeasons` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnSoccerAthleteSplits` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnSoccerAthleteStatisticslog` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnSoccerAthleteStats` | `web_v3` `/soccer/{league}/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnSoccerAthleteVsAthlete` | `core_v2` `/soccer/leagues/{league}/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnSoccerAthletesIndex` | `core_v2` `/soccer/leagues/{league}/athletes` | — | `active`, `limit`, `page` |
+| `espnSoccerAward` | `core_v2` `/soccer/leagues/{league}/awards/{award_id}` | `award_id`\* | — |
+| `espnSoccerAwards` | `core_v2` `/soccer/leagues/{league}/awards` | — | — |
+| `espnSoccerCalendar` | `site_v2` `/soccer/{league}/calendar` | — | — |
+| `espnSoccerCoach` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnSoccerCoachRecord` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnSoccerCoachSeason` | `core_v2` `/soccer/leagues/{league}/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnSoccerConferences` | `site_v2` `/soccer/{league}/groups` | — | — |
+| `espnSoccerDraft` | `site_v2` `/soccer/{league}/draft` | — | — |
+| `espnSoccerEvent` | `core_v2` `/soccer/leagues/{league}/events/{event_id}` | `event_id`\* | — |
+| `espnSoccerEventBroadcasts` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnSoccerEventCompetition` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnSoccerEventCompetitor` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitorLeaders` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitorLinescores` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitorRecord` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitorRoster` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitorStatistics` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnSoccerEventCompetitors` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnSoccerEventLeaders` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnSoccerEventOdds` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnSoccerEventOfficialDetail` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnSoccerEventOfficials` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnSoccerEventPlay` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnSoccerEventPlayPersonnel` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnSoccerEventPlays` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnSoccerEventPowerindex` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnSoccerEventPredictor` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnSoccerEventProbabilities` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnSoccerEventPropbets` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnSoccerEventScoringplays` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnSoccerEventSituation` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnSoccerEventStatus` | `core_v2` `/soccer/leagues/{league}/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnSoccerEvents` | `core_v2` `/soccer/leagues/{league}/events` | — | `dates`, `limit` |
+| `espnSoccerFranchise` | `core_v2` `/soccer/leagues/{league}/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnSoccerFranchises` | `core_v2` `/soccer/leagues/{league}/franchises` | — | `limit` |
+| `espnSoccerInjuries` | `site_v2` `/soccer/{league}/injuries` | — | — |
+| `espnSoccerLeaders` | `web_v3` `/soccer/{league}/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnSoccerLeadersCore` | `core_v2` `/soccer/leagues/{league}/leaders` | — | — |
+| `espnSoccerLeagueNotes` | `core_v2` `/soccer/leagues/{league}/notes` | — | — |
+| `espnSoccerLeagueRoot` | `core_v2` `/soccer/leagues/{league}` | — | — |
+| `espnSoccerNews` | `site_v2` `/soccer/{league}/news` | — | `limit` |
+| `espnSoccerPosition` | `core_v2` `/soccer/leagues/{league}/positions/{position_id}` | `position_id`\* | — |
+| `espnSoccerPositions` | `core_v2` `/soccer/leagues/{league}/positions` | — | — |
+| `espnSoccerScoreboard` | `site_v2` `/soccer/{league}/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnSoccerSeasonAthletes` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnSoccerSeasonAwards` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/awards` | `season`\* | — |
+| `espnSoccerSeasonCoaches` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnSoccerSeasonDraft` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/draft` | `season`\* | — |
+| `espnSoccerSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnSoccerSeasonFreeagents` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/freeagents` | `season`\* | — |
+| `espnSoccerSeasonFutures` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/futures` | `season`\* | — |
+| `espnSoccerSeasonGroup` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnSoccerSeasonGroupChildren` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnSoccerSeasonGroupTeams` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnSoccerSeasonGroups` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnSoccerSeasonInfo` | `core_v2` `/soccer/leagues/{league}/seasons/{season}` | `season`\* | — |
+| `espnSoccerSeasonPointer` | `core_v2` `/soccer/leagues/{league}/season` | — | — |
+| `espnSoccerSeasonPowerindex` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnSoccerSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnSoccerSeasonTeam` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnSoccerSeasonTeams` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnSoccerSeasonType` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnSoccerSeasonTypeCorrections` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnSoccerSeasonTypeLeaders` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnSoccerSeasonTypes` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types` | `season`\* | — |
+| `espnSoccerSeasonWeek` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnSoccerSeasonWeekEvents` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnSoccerSeasonWeeks` | `core_v2` `/soccer/leagues/{league}/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnSoccerSeasons` | `core_v2` `/soccer/leagues/{league}/seasons` | — | `limit` |
+| `espnSoccerStandings` | `site_v2_alt` `/soccer/{league}/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnSoccerStandingsCore` | `core_v2` `/soccer/leagues/{league}/standings` | — | — |
+| `espnSoccerStatisticsLeague` | `site_v2` `/soccer/{league}/statistics` | — | — |
+| `espnSoccerSummary` | `site_v2` `/soccer/{league}/summary` | — | `event_id` → `event` |
+| `espnSoccerTalentpicks` | `core_v2` `/soccer/leagues/{league}/talentpicks` | — | — |
+| `espnSoccerTeam` | `site_v2` `/soccer/{league}/teams/{team_id}` | `team_id`\* | — |
+| `espnSoccerTeamCore` | `core_v2` `/soccer/leagues/{league}/teams/{team_id}` | `team_id`\* | — |
+| `espnSoccerTeamDepthcharts` | `site_v2` `/soccer/{league}/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnSoccerTeamHistory` | `site_v2` `/soccer/{league}/teams/{team_id}/history` | `team_id`\* | — |
+| `espnSoccerTeamInjuries` | `site_v2` `/soccer/{league}/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnSoccerTeamLeaders` | `site_v2` `/soccer/{league}/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnSoccerTeamNews` | `site_v2` `/soccer/{league}/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnSoccerTeamRecord` | `site_v2` `/soccer/{league}/teams/{team_id}/record` | `team_id`\* | — |
+| `espnSoccerTeamRoster` | `site_v2` `/soccer/{league}/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnSoccerTeamSchedule` | `site_v2` `/soccer/{league}/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnSoccerTeamTransactions` | `site_v2` `/soccer/{league}/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnSoccerTeamsCore` | `core_v2` `/soccer/leagues/{league}/teams` | — | `limit` |
+| `espnSoccerTeamsSite` | `site_v2` `/soccer/{league}/teams` | — | `limit` |
+| `espnSoccerTournaments` | `core_v2` `/soccer/leagues/{league}/tournaments` | — | — |
+| `espnSoccerTransactions` | `site_v2` `/soccer/{league}/transactions` | — | — |
+| `espnSoccerVenue` | `core_v2` `/soccer/leagues/{league}/venues/{venue_id}` | `venue_id`\* | — |
+| `espnSoccerVenues` | `core_v2` `/soccer/leagues/{league}/venues` | — | `limit` |

--- a/docs/docs/reference/ucl.md
+++ b/docs/docs/reference/ucl.md
@@ -14,125 +14,125 @@ sidebar_position: 24
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.ucl.espn_ucl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.ucl.espnUcl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_ucl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.ucl.espn_ucl_scoreboard({});
+await sdv.ucl.espnUclScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_ucl_athlete_awards` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_ucl_athlete_bio` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_ucl_athlete_career_stats` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_ucl_athlete_contracts` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_ucl_athlete_core` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ucl_athlete_eventlog` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_ucl_athlete_gamelog` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_ucl_athlete_info` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ucl_athlete_injuries` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_ucl_athlete_news` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_ucl_athlete_notes` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_ucl_athlete_overview` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_ucl_athlete_records` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_ucl_athlete_seasons` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_ucl_athlete_splits` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_ucl_athlete_statisticslog` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_ucl_athlete_stats` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_ucl_athlete_vs_athlete` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_ucl_athletes_index` | `core_v2` `/soccer/leagues/uefa.champions/athletes` | — | `active`, `limit`, `page` |
-| `espn_ucl_award` | `core_v2` `/soccer/leagues/uefa.champions/awards/{award_id}` | `award_id`\* | — |
-| `espn_ucl_awards` | `core_v2` `/soccer/leagues/uefa.champions/awards` | — | — |
-| `espn_ucl_calendar` | `site_v2` `/soccer/uefa.champions/calendar` | — | — |
-| `espn_ucl_coach` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_ucl_coach_record` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_ucl_coach_season` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_ucl_conferences` | `site_v2` `/soccer/uefa.champions/groups` | — | — |
-| `espn_ucl_draft` | `site_v2` `/soccer/uefa.champions/draft` | — | — |
-| `espn_ucl_event` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}` | `event_id`\* | — |
-| `espn_ucl_event_broadcasts` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_competition` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_competitor` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitor_leaders` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitor_linescores` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitor_record` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitor_roster` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitor_statistics` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ucl_event_competitors` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_leaders` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_odds` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_official_detail` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_ucl_event_officials` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_play` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ucl_event_play_personnel` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ucl_event_plays` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_ucl_event_powerindex` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_predictor` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_probabilities` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_ucl_event_propbets` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_scoringplays` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_situation` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_ucl_event_status` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_ucl_events` | `core_v2` `/soccer/leagues/uefa.champions/events` | — | `dates`, `limit` |
-| `espn_ucl_franchise` | `core_v2` `/soccer/leagues/uefa.champions/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_ucl_franchises` | `core_v2` `/soccer/leagues/uefa.champions/franchises` | — | `limit` |
-| `espn_ucl_injuries` | `site_v2` `/soccer/uefa.champions/injuries` | — | — |
-| `espn_ucl_leaders` | `web_v3` `/soccer/uefa.champions/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_ucl_leaders_core` | `core_v2` `/soccer/leagues/uefa.champions/leaders` | — | — |
-| `espn_ucl_league_notes` | `core_v2` `/soccer/leagues/uefa.champions/notes` | — | — |
-| `espn_ucl_league_root` | `core_v2` `/soccer/leagues/uefa.champions` | — | — |
-| `espn_ucl_news` | `site_v2` `/soccer/uefa.champions/news` | — | `limit` |
-| `espn_ucl_position` | `core_v2` `/soccer/leagues/uefa.champions/positions/{position_id}` | `position_id`\* | — |
-| `espn_ucl_positions` | `core_v2` `/soccer/leagues/uefa.champions/positions` | — | — |
-| `espn_ucl_scoreboard` | `site_v2` `/soccer/uefa.champions/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_ucl_season_athletes` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_ucl_season_awards` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/awards` | `season`\* | — |
-| `espn_ucl_season_coaches` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_ucl_season_draft` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/draft` | `season`\* | — |
-| `espn_ucl_season_draft_round_picks` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_ucl_season_freeagents` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_ucl_season_futures` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/futures` | `season`\* | — |
-| `espn_ucl_season_group` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ucl_season_group_children` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ucl_season_group_teams` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_ucl_season_groups` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_ucl_season_info` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}` | `season`\* | — |
-| `espn_ucl_season_pointer` | `core_v2` `/soccer/leagues/uefa.champions/season` | — | — |
-| `espn_ucl_season_powerindex` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_ucl_season_powerindex_leaders` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_ucl_season_team` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_ucl_season_teams` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_ucl_season_type` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_ucl_season_type_corrections` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_ucl_season_type_leaders` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_ucl_season_types` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types` | `season`\* | — |
-| `espn_ucl_season_week` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_ucl_season_week_events` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_ucl_season_weeks` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_ucl_seasons` | `core_v2` `/soccer/leagues/uefa.champions/seasons` | — | `limit` |
-| `espn_ucl_standings` | `site_v2_alt` `/soccer/uefa.champions/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_ucl_standings_core` | `core_v2` `/soccer/leagues/uefa.champions/standings` | — | — |
-| `espn_ucl_statistics_league` | `site_v2` `/soccer/uefa.champions/statistics` | — | — |
-| `espn_ucl_summary` | `site_v2` `/soccer/uefa.champions/summary` | — | `event_id` → `event` |
-| `espn_ucl_talentpicks` | `core_v2` `/soccer/leagues/uefa.champions/talentpicks` | — | — |
-| `espn_ucl_team` | `site_v2` `/soccer/uefa.champions/teams/{team_id}` | `team_id`\* | — |
-| `espn_ucl_team_core` | `core_v2` `/soccer/leagues/uefa.champions/teams/{team_id}` | `team_id`\* | — |
-| `espn_ucl_team_depthcharts` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_ucl_team_history` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_ucl_team_injuries` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_ucl_team_leaders` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_ucl_team_news` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_ucl_team_record` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_ucl_team_roster` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_ucl_team_schedule` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_ucl_team_transactions` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_ucl_teams_core` | `core_v2` `/soccer/leagues/uefa.champions/teams` | — | `limit` |
-| `espn_ucl_teams_site` | `site_v2` `/soccer/uefa.champions/teams` | — | `limit` |
-| `espn_ucl_tournaments` | `core_v2` `/soccer/leagues/uefa.champions/tournaments` | — | — |
-| `espn_ucl_transactions` | `site_v2` `/soccer/uefa.champions/transactions` | — | — |
-| `espn_ucl_venue` | `core_v2` `/soccer/leagues/uefa.champions/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_ucl_venues` | `core_v2` `/soccer/leagues/uefa.champions/venues` | — | `limit` |
+| `espnUclAthleteAwards` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnUclAthleteBio` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnUclAthleteCareerStats` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnUclAthleteContracts` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnUclAthleteCore` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUclAthleteEventlog` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnUclAthleteGamelog` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnUclAthleteInfo` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUclAthleteInjuries` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnUclAthleteNews` | `site_v2` `/soccer/uefa.champions/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnUclAthleteNotes` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnUclAthleteOverview` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnUclAthleteRecords` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnUclAthleteSeasons` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnUclAthleteSplits` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnUclAthleteStatisticslog` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnUclAthleteStats` | `web_v3` `/soccer/uefa.champions/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnUclAthleteVsAthlete` | `core_v2` `/soccer/leagues/uefa.champions/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnUclAthletesIndex` | `core_v2` `/soccer/leagues/uefa.champions/athletes` | — | `active`, `limit`, `page` |
+| `espnUclAward` | `core_v2` `/soccer/leagues/uefa.champions/awards/{award_id}` | `award_id`\* | — |
+| `espnUclAwards` | `core_v2` `/soccer/leagues/uefa.champions/awards` | — | — |
+| `espnUclCalendar` | `site_v2` `/soccer/uefa.champions/calendar` | — | — |
+| `espnUclCoach` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnUclCoachRecord` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnUclCoachSeason` | `core_v2` `/soccer/leagues/uefa.champions/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnUclConferences` | `site_v2` `/soccer/uefa.champions/groups` | — | — |
+| `espnUclDraft` | `site_v2` `/soccer/uefa.champions/draft` | — | — |
+| `espnUclEvent` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}` | `event_id`\* | — |
+| `espnUclEventBroadcasts` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnUclEventCompetition` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnUclEventCompetitor` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitorLeaders` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitorLinescores` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitorRecord` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitorRoster` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitorStatistics` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUclEventCompetitors` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnUclEventLeaders` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnUclEventOdds` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnUclEventOfficialDetail` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnUclEventOfficials` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnUclEventPlay` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUclEventPlayPersonnel` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUclEventPlays` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnUclEventPowerindex` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnUclEventPredictor` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnUclEventProbabilities` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnUclEventPropbets` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnUclEventScoringplays` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnUclEventSituation` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnUclEventStatus` | `core_v2` `/soccer/leagues/uefa.champions/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnUclEvents` | `core_v2` `/soccer/leagues/uefa.champions/events` | — | `dates`, `limit` |
+| `espnUclFranchise` | `core_v2` `/soccer/leagues/uefa.champions/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnUclFranchises` | `core_v2` `/soccer/leagues/uefa.champions/franchises` | — | `limit` |
+| `espnUclInjuries` | `site_v2` `/soccer/uefa.champions/injuries` | — | — |
+| `espnUclLeaders` | `web_v3` `/soccer/uefa.champions/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnUclLeadersCore` | `core_v2` `/soccer/leagues/uefa.champions/leaders` | — | — |
+| `espnUclLeagueNotes` | `core_v2` `/soccer/leagues/uefa.champions/notes` | — | — |
+| `espnUclLeagueRoot` | `core_v2` `/soccer/leagues/uefa.champions` | — | — |
+| `espnUclNews` | `site_v2` `/soccer/uefa.champions/news` | — | `limit` |
+| `espnUclPosition` | `core_v2` `/soccer/leagues/uefa.champions/positions/{position_id}` | `position_id`\* | — |
+| `espnUclPositions` | `core_v2` `/soccer/leagues/uefa.champions/positions` | — | — |
+| `espnUclScoreboard` | `site_v2` `/soccer/uefa.champions/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnUclSeasonAthletes` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnUclSeasonAwards` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/awards` | `season`\* | — |
+| `espnUclSeasonCoaches` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnUclSeasonDraft` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/draft` | `season`\* | — |
+| `espnUclSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnUclSeasonFreeagents` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/freeagents` | `season`\* | — |
+| `espnUclSeasonFutures` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/futures` | `season`\* | — |
+| `espnUclSeasonGroup` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUclSeasonGroupChildren` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUclSeasonGroupTeams` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnUclSeasonGroups` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnUclSeasonInfo` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}` | `season`\* | — |
+| `espnUclSeasonPointer` | `core_v2` `/soccer/leagues/uefa.champions/season` | — | — |
+| `espnUclSeasonPowerindex` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnUclSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnUclSeasonTeam` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnUclSeasonTeams` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnUclSeasonType` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnUclSeasonTypeCorrections` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnUclSeasonTypeLeaders` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnUclSeasonTypes` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types` | `season`\* | — |
+| `espnUclSeasonWeek` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnUclSeasonWeekEvents` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnUclSeasonWeeks` | `core_v2` `/soccer/leagues/uefa.champions/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnUclSeasons` | `core_v2` `/soccer/leagues/uefa.champions/seasons` | — | `limit` |
+| `espnUclStandings` | `site_v2_alt` `/soccer/uefa.champions/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnUclStandingsCore` | `core_v2` `/soccer/leagues/uefa.champions/standings` | — | — |
+| `espnUclStatisticsLeague` | `site_v2` `/soccer/uefa.champions/statistics` | — | — |
+| `espnUclSummary` | `site_v2` `/soccer/uefa.champions/summary` | — | `event_id` → `event` |
+| `espnUclTalentpicks` | `core_v2` `/soccer/leagues/uefa.champions/talentpicks` | — | — |
+| `espnUclTeam` | `site_v2` `/soccer/uefa.champions/teams/{team_id}` | `team_id`\* | — |
+| `espnUclTeamCore` | `core_v2` `/soccer/leagues/uefa.champions/teams/{team_id}` | `team_id`\* | — |
+| `espnUclTeamDepthcharts` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnUclTeamHistory` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/history` | `team_id`\* | — |
+| `espnUclTeamInjuries` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnUclTeamLeaders` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnUclTeamNews` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnUclTeamRecord` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/record` | `team_id`\* | — |
+| `espnUclTeamRoster` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnUclTeamSchedule` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnUclTeamTransactions` | `site_v2` `/soccer/uefa.champions/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnUclTeamsCore` | `core_v2` `/soccer/leagues/uefa.champions/teams` | — | `limit` |
+| `espnUclTeamsSite` | `site_v2` `/soccer/uefa.champions/teams` | — | `limit` |
+| `espnUclTournaments` | `core_v2` `/soccer/leagues/uefa.champions/tournaments` | — | — |
+| `espnUclTransactions` | `site_v2` `/soccer/uefa.champions/transactions` | — | — |
+| `espnUclVenue` | `core_v2` `/soccer/leagues/uefa.champions/venues/{venue_id}` | `venue_id`\* | — |
+| `espnUclVenues` | `core_v2` `/soccer/leagues/uefa.champions/venues` | — | `limit` |

--- a/docs/docs/reference/uel.md
+++ b/docs/docs/reference/uel.md
@@ -14,125 +14,125 @@ sidebar_position: 25
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.uel.espn_uel_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.uel.espnUel<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_uel_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.uel.espn_uel_scoreboard({});
+await sdv.uel.espnUelScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_uel_athlete_awards` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_uel_athlete_bio` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_uel_athlete_career_stats` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_uel_athlete_contracts` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_uel_athlete_core` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_uel_athlete_eventlog` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_uel_athlete_gamelog` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_uel_athlete_info` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_uel_athlete_injuries` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_uel_athlete_news` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_uel_athlete_notes` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_uel_athlete_overview` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_uel_athlete_records` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_uel_athlete_seasons` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_uel_athlete_splits` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_uel_athlete_statisticslog` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_uel_athlete_stats` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_uel_athlete_vs_athlete` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_uel_athletes_index` | `core_v2` `/soccer/leagues/uefa.europa/athletes` | — | `active`, `limit`, `page` |
-| `espn_uel_award` | `core_v2` `/soccer/leagues/uefa.europa/awards/{award_id}` | `award_id`\* | — |
-| `espn_uel_awards` | `core_v2` `/soccer/leagues/uefa.europa/awards` | — | — |
-| `espn_uel_calendar` | `site_v2` `/soccer/uefa.europa/calendar` | — | — |
-| `espn_uel_coach` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_uel_coach_record` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_uel_coach_season` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_uel_conferences` | `site_v2` `/soccer/uefa.europa/groups` | — | — |
-| `espn_uel_draft` | `site_v2` `/soccer/uefa.europa/draft` | — | — |
-| `espn_uel_event` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}` | `event_id`\* | — |
-| `espn_uel_event_broadcasts` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_uel_event_competition` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_uel_event_competitor` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitor_leaders` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitor_linescores` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitor_record` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitor_roster` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitor_statistics` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_uel_event_competitors` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_uel_event_leaders` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_uel_event_odds` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_uel_event_official_detail` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_uel_event_officials` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_uel_event_play` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_uel_event_play_personnel` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_uel_event_plays` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_uel_event_powerindex` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_uel_event_predictor` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_uel_event_probabilities` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_uel_event_propbets` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_uel_event_scoringplays` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_uel_event_situation` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_uel_event_status` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_uel_events` | `core_v2` `/soccer/leagues/uefa.europa/events` | — | `dates`, `limit` |
-| `espn_uel_franchise` | `core_v2` `/soccer/leagues/uefa.europa/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_uel_franchises` | `core_v2` `/soccer/leagues/uefa.europa/franchises` | — | `limit` |
-| `espn_uel_injuries` | `site_v2` `/soccer/uefa.europa/injuries` | — | — |
-| `espn_uel_leaders` | `web_v3` `/soccer/uefa.europa/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_uel_leaders_core` | `core_v2` `/soccer/leagues/uefa.europa/leaders` | — | — |
-| `espn_uel_league_notes` | `core_v2` `/soccer/leagues/uefa.europa/notes` | — | — |
-| `espn_uel_league_root` | `core_v2` `/soccer/leagues/uefa.europa` | — | — |
-| `espn_uel_news` | `site_v2` `/soccer/uefa.europa/news` | — | `limit` |
-| `espn_uel_position` | `core_v2` `/soccer/leagues/uefa.europa/positions/{position_id}` | `position_id`\* | — |
-| `espn_uel_positions` | `core_v2` `/soccer/leagues/uefa.europa/positions` | — | — |
-| `espn_uel_scoreboard` | `site_v2` `/soccer/uefa.europa/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_uel_season_athletes` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_uel_season_awards` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/awards` | `season`\* | — |
-| `espn_uel_season_coaches` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_uel_season_draft` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/draft` | `season`\* | — |
-| `espn_uel_season_draft_round_picks` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_uel_season_freeagents` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_uel_season_futures` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/futures` | `season`\* | — |
-| `espn_uel_season_group` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_uel_season_group_children` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_uel_season_group_teams` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_uel_season_groups` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_uel_season_info` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}` | `season`\* | — |
-| `espn_uel_season_pointer` | `core_v2` `/soccer/leagues/uefa.europa/season` | — | — |
-| `espn_uel_season_powerindex` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_uel_season_powerindex_leaders` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_uel_season_team` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_uel_season_teams` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_uel_season_type` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_uel_season_type_corrections` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_uel_season_type_leaders` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_uel_season_types` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types` | `season`\* | — |
-| `espn_uel_season_week` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_uel_season_week_events` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_uel_season_weeks` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_uel_seasons` | `core_v2` `/soccer/leagues/uefa.europa/seasons` | — | `limit` |
-| `espn_uel_standings` | `site_v2_alt` `/soccer/uefa.europa/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_uel_standings_core` | `core_v2` `/soccer/leagues/uefa.europa/standings` | — | — |
-| `espn_uel_statistics_league` | `site_v2` `/soccer/uefa.europa/statistics` | — | — |
-| `espn_uel_summary` | `site_v2` `/soccer/uefa.europa/summary` | — | `event_id` → `event` |
-| `espn_uel_talentpicks` | `core_v2` `/soccer/leagues/uefa.europa/talentpicks` | — | — |
-| `espn_uel_team` | `site_v2` `/soccer/uefa.europa/teams/{team_id}` | `team_id`\* | — |
-| `espn_uel_team_core` | `core_v2` `/soccer/leagues/uefa.europa/teams/{team_id}` | `team_id`\* | — |
-| `espn_uel_team_depthcharts` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_uel_team_history` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_uel_team_injuries` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_uel_team_leaders` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_uel_team_news` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_uel_team_record` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_uel_team_roster` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_uel_team_schedule` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_uel_team_transactions` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_uel_teams_core` | `core_v2` `/soccer/leagues/uefa.europa/teams` | — | `limit` |
-| `espn_uel_teams_site` | `site_v2` `/soccer/uefa.europa/teams` | — | `limit` |
-| `espn_uel_tournaments` | `core_v2` `/soccer/leagues/uefa.europa/tournaments` | — | — |
-| `espn_uel_transactions` | `site_v2` `/soccer/uefa.europa/transactions` | — | — |
-| `espn_uel_venue` | `core_v2` `/soccer/leagues/uefa.europa/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_uel_venues` | `core_v2` `/soccer/leagues/uefa.europa/venues` | — | `limit` |
+| `espnUelAthleteAwards` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnUelAthleteBio` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnUelAthleteCareerStats` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnUelAthleteContracts` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnUelAthleteCore` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUelAthleteEventlog` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnUelAthleteGamelog` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnUelAthleteInfo` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUelAthleteInjuries` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnUelAthleteNews` | `site_v2` `/soccer/uefa.europa/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnUelAthleteNotes` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnUelAthleteOverview` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnUelAthleteRecords` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnUelAthleteSeasons` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnUelAthleteSplits` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnUelAthleteStatisticslog` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnUelAthleteStats` | `web_v3` `/soccer/uefa.europa/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnUelAthleteVsAthlete` | `core_v2` `/soccer/leagues/uefa.europa/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnUelAthletesIndex` | `core_v2` `/soccer/leagues/uefa.europa/athletes` | — | `active`, `limit`, `page` |
+| `espnUelAward` | `core_v2` `/soccer/leagues/uefa.europa/awards/{award_id}` | `award_id`\* | — |
+| `espnUelAwards` | `core_v2` `/soccer/leagues/uefa.europa/awards` | — | — |
+| `espnUelCalendar` | `site_v2` `/soccer/uefa.europa/calendar` | — | — |
+| `espnUelCoach` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnUelCoachRecord` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnUelCoachSeason` | `core_v2` `/soccer/leagues/uefa.europa/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnUelConferences` | `site_v2` `/soccer/uefa.europa/groups` | — | — |
+| `espnUelDraft` | `site_v2` `/soccer/uefa.europa/draft` | — | — |
+| `espnUelEvent` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}` | `event_id`\* | — |
+| `espnUelEventBroadcasts` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnUelEventCompetition` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnUelEventCompetitor` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitorLeaders` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitorLinescores` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitorRecord` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitorRoster` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitorStatistics` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUelEventCompetitors` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnUelEventLeaders` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnUelEventOdds` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnUelEventOfficialDetail` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnUelEventOfficials` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnUelEventPlay` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUelEventPlayPersonnel` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUelEventPlays` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnUelEventPowerindex` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnUelEventPredictor` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnUelEventProbabilities` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnUelEventPropbets` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnUelEventScoringplays` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnUelEventSituation` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnUelEventStatus` | `core_v2` `/soccer/leagues/uefa.europa/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnUelEvents` | `core_v2` `/soccer/leagues/uefa.europa/events` | — | `dates`, `limit` |
+| `espnUelFranchise` | `core_v2` `/soccer/leagues/uefa.europa/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnUelFranchises` | `core_v2` `/soccer/leagues/uefa.europa/franchises` | — | `limit` |
+| `espnUelInjuries` | `site_v2` `/soccer/uefa.europa/injuries` | — | — |
+| `espnUelLeaders` | `web_v3` `/soccer/uefa.europa/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnUelLeadersCore` | `core_v2` `/soccer/leagues/uefa.europa/leaders` | — | — |
+| `espnUelLeagueNotes` | `core_v2` `/soccer/leagues/uefa.europa/notes` | — | — |
+| `espnUelLeagueRoot` | `core_v2` `/soccer/leagues/uefa.europa` | — | — |
+| `espnUelNews` | `site_v2` `/soccer/uefa.europa/news` | — | `limit` |
+| `espnUelPosition` | `core_v2` `/soccer/leagues/uefa.europa/positions/{position_id}` | `position_id`\* | — |
+| `espnUelPositions` | `core_v2` `/soccer/leagues/uefa.europa/positions` | — | — |
+| `espnUelScoreboard` | `site_v2` `/soccer/uefa.europa/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnUelSeasonAthletes` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnUelSeasonAwards` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/awards` | `season`\* | — |
+| `espnUelSeasonCoaches` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnUelSeasonDraft` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/draft` | `season`\* | — |
+| `espnUelSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnUelSeasonFreeagents` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/freeagents` | `season`\* | — |
+| `espnUelSeasonFutures` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/futures` | `season`\* | — |
+| `espnUelSeasonGroup` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUelSeasonGroupChildren` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUelSeasonGroupTeams` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnUelSeasonGroups` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnUelSeasonInfo` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}` | `season`\* | — |
+| `espnUelSeasonPointer` | `core_v2` `/soccer/leagues/uefa.europa/season` | — | — |
+| `espnUelSeasonPowerindex` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnUelSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnUelSeasonTeam` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnUelSeasonTeams` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnUelSeasonType` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnUelSeasonTypeCorrections` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnUelSeasonTypeLeaders` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnUelSeasonTypes` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types` | `season`\* | — |
+| `espnUelSeasonWeek` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnUelSeasonWeekEvents` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnUelSeasonWeeks` | `core_v2` `/soccer/leagues/uefa.europa/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnUelSeasons` | `core_v2` `/soccer/leagues/uefa.europa/seasons` | — | `limit` |
+| `espnUelStandings` | `site_v2_alt` `/soccer/uefa.europa/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnUelStandingsCore` | `core_v2` `/soccer/leagues/uefa.europa/standings` | — | — |
+| `espnUelStatisticsLeague` | `site_v2` `/soccer/uefa.europa/statistics` | — | — |
+| `espnUelSummary` | `site_v2` `/soccer/uefa.europa/summary` | — | `event_id` → `event` |
+| `espnUelTalentpicks` | `core_v2` `/soccer/leagues/uefa.europa/talentpicks` | — | — |
+| `espnUelTeam` | `site_v2` `/soccer/uefa.europa/teams/{team_id}` | `team_id`\* | — |
+| `espnUelTeamCore` | `core_v2` `/soccer/leagues/uefa.europa/teams/{team_id}` | `team_id`\* | — |
+| `espnUelTeamDepthcharts` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnUelTeamHistory` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/history` | `team_id`\* | — |
+| `espnUelTeamInjuries` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnUelTeamLeaders` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnUelTeamNews` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnUelTeamRecord` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/record` | `team_id`\* | — |
+| `espnUelTeamRoster` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnUelTeamSchedule` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnUelTeamTransactions` | `site_v2` `/soccer/uefa.europa/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnUelTeamsCore` | `core_v2` `/soccer/leagues/uefa.europa/teams` | — | `limit` |
+| `espnUelTeamsSite` | `site_v2` `/soccer/uefa.europa/teams` | — | `limit` |
+| `espnUelTournaments` | `core_v2` `/soccer/leagues/uefa.europa/tournaments` | — | — |
+| `espnUelTransactions` | `site_v2` `/soccer/uefa.europa/transactions` | — | — |
+| `espnUelVenue` | `core_v2` `/soccer/leagues/uefa.europa/venues/{venue_id}` | `venue_id`\* | — |
+| `espnUelVenues` | `core_v2` `/soccer/leagues/uefa.europa/venues` | — | `limit` |

--- a/docs/docs/reference/ufl.md
+++ b/docs/docs/reference/ufl.md
@@ -14,125 +14,125 @@ sidebar_position: 13
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.ufl.espn_ufl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.ufl.espnUfl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_ufl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.ufl.espn_ufl_scoreboard({});
+await sdv.ufl.espnUflScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_ufl_athlete_awards` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_ufl_athlete_bio` | `site_v2` `/football/ufl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_ufl_athlete_career_stats` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_ufl_athlete_contracts` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_ufl_athlete_core` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ufl_athlete_eventlog` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_ufl_athlete_gamelog` | `web_v3` `/football/ufl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_ufl_athlete_info` | `site_v2` `/football/ufl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_ufl_athlete_injuries` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_ufl_athlete_news` | `site_v2` `/football/ufl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_ufl_athlete_notes` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_ufl_athlete_overview` | `web_v3` `/football/ufl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_ufl_athlete_records` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_ufl_athlete_seasons` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_ufl_athlete_splits` | `web_v3` `/football/ufl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_ufl_athlete_statisticslog` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_ufl_athlete_stats` | `web_v3` `/football/ufl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_ufl_athlete_vs_athlete` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_ufl_athletes_index` | `core_v2` `/football/leagues/ufl/athletes` | — | `active`, `limit`, `page` |
-| `espn_ufl_award` | `core_v2` `/football/leagues/ufl/awards/{award_id}` | `award_id`\* | — |
-| `espn_ufl_awards` | `core_v2` `/football/leagues/ufl/awards` | — | — |
-| `espn_ufl_calendar` | `site_v2` `/football/ufl/calendar` | — | — |
-| `espn_ufl_coach` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_ufl_coach_record` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_ufl_coach_season` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_ufl_conferences` | `site_v2` `/football/ufl/groups` | — | — |
-| `espn_ufl_draft` | `site_v2` `/football/ufl/draft` | — | — |
-| `espn_ufl_event` | `core_v2` `/football/leagues/ufl/events/{event_id}` | `event_id`\* | — |
-| `espn_ufl_event_broadcasts` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_competition` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_competitor` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitor_leaders` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitor_linescores` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitor_record` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitor_roster` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitor_statistics` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_ufl_event_competitors` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_leaders` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_odds` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_official_detail` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_ufl_event_officials` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_play` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ufl_event_play_personnel` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_ufl_event_plays` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_ufl_event_powerindex` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_predictor` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_probabilities` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_ufl_event_propbets` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_scoringplays` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_situation` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_ufl_event_status` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_ufl_events` | `core_v2` `/football/leagues/ufl/events` | — | `dates`, `limit` |
-| `espn_ufl_franchise` | `core_v2` `/football/leagues/ufl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_ufl_franchises` | `core_v2` `/football/leagues/ufl/franchises` | — | `limit` |
-| `espn_ufl_injuries` | `site_v2` `/football/ufl/injuries` | — | — |
-| `espn_ufl_leaders` | `web_v3` `/football/ufl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_ufl_leaders_core` | `core_v2` `/football/leagues/ufl/leaders` | — | — |
-| `espn_ufl_league_notes` | `core_v2` `/football/leagues/ufl/notes` | — | — |
-| `espn_ufl_league_root` | `core_v2` `/football/leagues/ufl` | — | — |
-| `espn_ufl_news` | `site_v2` `/football/ufl/news` | — | `limit` |
-| `espn_ufl_position` | `core_v2` `/football/leagues/ufl/positions/{position_id}` | `position_id`\* | — |
-| `espn_ufl_positions` | `core_v2` `/football/leagues/ufl/positions` | — | — |
-| `espn_ufl_scoreboard` | `site_v2` `/football/ufl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_ufl_season_athletes` | `core_v2` `/football/leagues/ufl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_ufl_season_awards` | `core_v2` `/football/leagues/ufl/seasons/{season}/awards` | `season`\* | — |
-| `espn_ufl_season_coaches` | `core_v2` `/football/leagues/ufl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_ufl_season_draft` | `core_v2` `/football/leagues/ufl/seasons/{season}/draft` | `season`\* | — |
-| `espn_ufl_season_draft_round_picks` | `core_v2` `/football/leagues/ufl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_ufl_season_freeagents` | `core_v2` `/football/leagues/ufl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_ufl_season_futures` | `core_v2` `/football/leagues/ufl/seasons/{season}/futures` | `season`\* | — |
-| `espn_ufl_season_group` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ufl_season_group_children` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_ufl_season_group_teams` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_ufl_season_groups` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_ufl_season_info` | `core_v2` `/football/leagues/ufl/seasons/{season}` | `season`\* | — |
-| `espn_ufl_season_pointer` | `core_v2` `/football/leagues/ufl/season` | — | — |
-| `espn_ufl_season_powerindex` | `core_v2` `/football/leagues/ufl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_ufl_season_powerindex_leaders` | `core_v2` `/football/leagues/ufl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_ufl_season_team` | `core_v2` `/football/leagues/ufl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_ufl_season_teams` | `core_v2` `/football/leagues/ufl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_ufl_season_type` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_ufl_season_type_corrections` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_ufl_season_type_leaders` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_ufl_season_types` | `core_v2` `/football/leagues/ufl/seasons/{season}/types` | `season`\* | — |
-| `espn_ufl_season_week` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_ufl_season_week_events` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_ufl_season_weeks` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_ufl_seasons` | `core_v2` `/football/leagues/ufl/seasons` | — | `limit` |
-| `espn_ufl_standings` | `site_v2_alt` `/football/ufl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_ufl_standings_core` | `core_v2` `/football/leagues/ufl/standings` | — | — |
-| `espn_ufl_statistics_league` | `site_v2` `/football/ufl/statistics` | — | — |
-| `espn_ufl_summary` | `site_v2` `/football/ufl/summary` | — | `event_id` → `event` |
-| `espn_ufl_talentpicks` | `core_v2` `/football/leagues/ufl/talentpicks` | — | — |
-| `espn_ufl_team` | `site_v2` `/football/ufl/teams/{team_id}` | `team_id`\* | — |
-| `espn_ufl_team_core` | `core_v2` `/football/leagues/ufl/teams/{team_id}` | `team_id`\* | — |
-| `espn_ufl_team_depthcharts` | `site_v2` `/football/ufl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_ufl_team_history` | `site_v2` `/football/ufl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_ufl_team_injuries` | `site_v2` `/football/ufl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_ufl_team_leaders` | `site_v2` `/football/ufl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_ufl_team_news` | `site_v2` `/football/ufl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_ufl_team_record` | `site_v2` `/football/ufl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_ufl_team_roster` | `site_v2` `/football/ufl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_ufl_team_schedule` | `site_v2` `/football/ufl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_ufl_team_transactions` | `site_v2` `/football/ufl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_ufl_teams_core` | `core_v2` `/football/leagues/ufl/teams` | — | `limit` |
-| `espn_ufl_teams_site` | `site_v2` `/football/ufl/teams` | — | `limit` |
-| `espn_ufl_tournaments` | `core_v2` `/football/leagues/ufl/tournaments` | — | — |
-| `espn_ufl_transactions` | `site_v2` `/football/ufl/transactions` | — | — |
-| `espn_ufl_venue` | `core_v2` `/football/leagues/ufl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_ufl_venues` | `core_v2` `/football/leagues/ufl/venues` | — | `limit` |
+| `espnUflAthleteAwards` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnUflAthleteBio` | `site_v2` `/football/ufl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnUflAthleteCareerStats` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnUflAthleteContracts` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnUflAthleteCore` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUflAthleteEventlog` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnUflAthleteGamelog` | `web_v3` `/football/ufl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnUflAthleteInfo` | `site_v2` `/football/ufl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnUflAthleteInjuries` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnUflAthleteNews` | `site_v2` `/football/ufl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnUflAthleteNotes` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnUflAthleteOverview` | `web_v3` `/football/ufl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnUflAthleteRecords` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnUflAthleteSeasons` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnUflAthleteSplits` | `web_v3` `/football/ufl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnUflAthleteStatisticslog` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnUflAthleteStats` | `web_v3` `/football/ufl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnUflAthleteVsAthlete` | `core_v2` `/football/leagues/ufl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnUflAthletesIndex` | `core_v2` `/football/leagues/ufl/athletes` | — | `active`, `limit`, `page` |
+| `espnUflAward` | `core_v2` `/football/leagues/ufl/awards/{award_id}` | `award_id`\* | — |
+| `espnUflAwards` | `core_v2` `/football/leagues/ufl/awards` | — | — |
+| `espnUflCalendar` | `site_v2` `/football/ufl/calendar` | — | — |
+| `espnUflCoach` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnUflCoachRecord` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnUflCoachSeason` | `core_v2` `/football/leagues/ufl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnUflConferences` | `site_v2` `/football/ufl/groups` | — | — |
+| `espnUflDraft` | `site_v2` `/football/ufl/draft` | — | — |
+| `espnUflEvent` | `core_v2` `/football/leagues/ufl/events/{event_id}` | `event_id`\* | — |
+| `espnUflEventBroadcasts` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnUflEventCompetition` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnUflEventCompetitor` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitorLeaders` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitorLinescores` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitorRecord` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitorRoster` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitorStatistics` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnUflEventCompetitors` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnUflEventLeaders` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnUflEventOdds` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnUflEventOfficialDetail` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnUflEventOfficials` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnUflEventPlay` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUflEventPlayPersonnel` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnUflEventPlays` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnUflEventPowerindex` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnUflEventPredictor` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnUflEventProbabilities` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnUflEventPropbets` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnUflEventScoringplays` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnUflEventSituation` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnUflEventStatus` | `core_v2` `/football/leagues/ufl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnUflEvents` | `core_v2` `/football/leagues/ufl/events` | — | `dates`, `limit` |
+| `espnUflFranchise` | `core_v2` `/football/leagues/ufl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnUflFranchises` | `core_v2` `/football/leagues/ufl/franchises` | — | `limit` |
+| `espnUflInjuries` | `site_v2` `/football/ufl/injuries` | — | — |
+| `espnUflLeaders` | `web_v3` `/football/ufl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnUflLeadersCore` | `core_v2` `/football/leagues/ufl/leaders` | — | — |
+| `espnUflLeagueNotes` | `core_v2` `/football/leagues/ufl/notes` | — | — |
+| `espnUflLeagueRoot` | `core_v2` `/football/leagues/ufl` | — | — |
+| `espnUflNews` | `site_v2` `/football/ufl/news` | — | `limit` |
+| `espnUflPosition` | `core_v2` `/football/leagues/ufl/positions/{position_id}` | `position_id`\* | — |
+| `espnUflPositions` | `core_v2` `/football/leagues/ufl/positions` | — | — |
+| `espnUflScoreboard` | `site_v2` `/football/ufl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnUflSeasonAthletes` | `core_v2` `/football/leagues/ufl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnUflSeasonAwards` | `core_v2` `/football/leagues/ufl/seasons/{season}/awards` | `season`\* | — |
+| `espnUflSeasonCoaches` | `core_v2` `/football/leagues/ufl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnUflSeasonDraft` | `core_v2` `/football/leagues/ufl/seasons/{season}/draft` | `season`\* | — |
+| `espnUflSeasonDraftRoundPicks` | `core_v2` `/football/leagues/ufl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnUflSeasonFreeagents` | `core_v2` `/football/leagues/ufl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnUflSeasonFutures` | `core_v2` `/football/leagues/ufl/seasons/{season}/futures` | `season`\* | — |
+| `espnUflSeasonGroup` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUflSeasonGroupChildren` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnUflSeasonGroupTeams` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnUflSeasonGroups` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnUflSeasonInfo` | `core_v2` `/football/leagues/ufl/seasons/{season}` | `season`\* | — |
+| `espnUflSeasonPointer` | `core_v2` `/football/leagues/ufl/season` | — | — |
+| `espnUflSeasonPowerindex` | `core_v2` `/football/leagues/ufl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnUflSeasonPowerindexLeaders` | `core_v2` `/football/leagues/ufl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnUflSeasonTeam` | `core_v2` `/football/leagues/ufl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnUflSeasonTeams` | `core_v2` `/football/leagues/ufl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnUflSeasonType` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnUflSeasonTypeCorrections` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnUflSeasonTypeLeaders` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnUflSeasonTypes` | `core_v2` `/football/leagues/ufl/seasons/{season}/types` | `season`\* | — |
+| `espnUflSeasonWeek` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnUflSeasonWeekEvents` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnUflSeasonWeeks` | `core_v2` `/football/leagues/ufl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnUflSeasons` | `core_v2` `/football/leagues/ufl/seasons` | — | `limit` |
+| `espnUflStandings` | `site_v2_alt` `/football/ufl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnUflStandingsCore` | `core_v2` `/football/leagues/ufl/standings` | — | — |
+| `espnUflStatisticsLeague` | `site_v2` `/football/ufl/statistics` | — | — |
+| `espnUflSummary` | `site_v2` `/football/ufl/summary` | — | `event_id` → `event` |
+| `espnUflTalentpicks` | `core_v2` `/football/leagues/ufl/talentpicks` | — | — |
+| `espnUflTeam` | `site_v2` `/football/ufl/teams/{team_id}` | `team_id`\* | — |
+| `espnUflTeamCore` | `core_v2` `/football/leagues/ufl/teams/{team_id}` | `team_id`\* | — |
+| `espnUflTeamDepthcharts` | `site_v2` `/football/ufl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnUflTeamHistory` | `site_v2` `/football/ufl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnUflTeamInjuries` | `site_v2` `/football/ufl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnUflTeamLeaders` | `site_v2` `/football/ufl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnUflTeamNews` | `site_v2` `/football/ufl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnUflTeamRecord` | `site_v2` `/football/ufl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnUflTeamRoster` | `site_v2` `/football/ufl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnUflTeamSchedule` | `site_v2` `/football/ufl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnUflTeamTransactions` | `site_v2` `/football/ufl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnUflTeamsCore` | `core_v2` `/football/leagues/ufl/teams` | — | `limit` |
+| `espnUflTeamsSite` | `site_v2` `/football/ufl/teams` | — | `limit` |
+| `espnUflTournaments` | `core_v2` `/football/leagues/ufl/tournaments` | — | — |
+| `espnUflTransactions` | `site_v2` `/football/ufl/transactions` | — | — |
+| `espnUflVenue` | `core_v2` `/football/leagues/ufl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnUflVenues` | `core_v2` `/football/leagues/ufl/venues` | — | `limit` |

--- a/docs/docs/reference/wbb.md
+++ b/docs/docs/reference/wbb.md
@@ -14,133 +14,133 @@ sidebar_position: 4
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.wbb.espn_wbb_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.wbb.espnWbb<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_wbb_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.wbb.espn_wbb_scoreboard({});
+await sdv.wbb.espnWbbScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wbb_athlete_awards` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_wbb_athlete_bio` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_wbb_athlete_career_stats` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_wbb_athlete_contracts` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_wbb_athlete_core` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wbb_athlete_eventlog` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_wbb_athlete_gamelog` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_wbb_athlete_info` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wbb_athlete_injuries` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_wbb_athlete_news` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_wbb_athlete_notes` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_wbb_athlete_overview` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_wbb_athlete_records` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_wbb_athlete_seasons` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_wbb_athlete_splits` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_wbb_athlete_statisticslog` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_wbb_athlete_stats` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_wbb_athlete_vs_athlete` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_wbb_athletes_index` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes` | — | `active`, `limit`, `page` |
-| `espn_wbb_award` | `core_v2` `/basketball/leagues/womens-college-basketball/awards/{award_id}` | `award_id`\* | — |
-| `espn_wbb_awards` | `core_v2` `/basketball/leagues/womens-college-basketball/awards` | — | — |
-| `espn_wbb_calendar` | `site_v2` `/basketball/womens-college-basketball/calendar` | — | — |
-| `espn_wbb_coach` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_wbb_coach_record` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_wbb_coach_season` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_wbb_conferences` | `site_v2` `/basketball/womens-college-basketball/groups` | — | — |
-| `espn_wbb_draft` | `site_v2` `/basketball/womens-college-basketball/draft` | — | — |
-| `espn_wbb_event` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}` | `event_id`\* | — |
-| `espn_wbb_event_broadcasts` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_competition` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_competitor` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitor_leaders` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitor_linescores` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitor_record` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitor_roster` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitor_statistics` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wbb_event_competitors` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_leaders` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_odds` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_official_detail` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_wbb_event_officials` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_play` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wbb_event_play_personnel` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wbb_event_plays` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_wbb_event_powerindex` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_predictor` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_probabilities` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_wbb_event_propbets` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_scoringplays` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_situation` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_wbb_event_status` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_wbb_events` | `core_v2` `/basketball/leagues/womens-college-basketball/events` | — | `dates`, `limit` |
-| `espn_wbb_franchise` | `core_v2` `/basketball/leagues/womens-college-basketball/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_wbb_franchises` | `core_v2` `/basketball/leagues/womens-college-basketball/franchises` | — | `limit` |
-| `espn_wbb_injuries` | `site_v2` `/basketball/womens-college-basketball/injuries` | — | — |
-| `espn_wbb_leaders` | `web_v3` `/basketball/womens-college-basketball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_wbb_leaders_core` | `core_v2` `/basketball/leagues/womens-college-basketball/leaders` | — | — |
-| `espn_wbb_league_notes` | `core_v2` `/basketball/leagues/womens-college-basketball/notes` | — | — |
-| `espn_wbb_league_root` | `core_v2` `/basketball/leagues/womens-college-basketball` | — | — |
-| `espn_wbb_news` | `site_v2` `/basketball/womens-college-basketball/news` | — | `limit` |
-| `espn_wbb_position` | `core_v2` `/basketball/leagues/womens-college-basketball/positions/{position_id}` | `position_id`\* | — |
-| `espn_wbb_positions` | `core_v2` `/basketball/leagues/womens-college-basketball/positions` | — | — |
-| `espn_wbb_scoreboard` | `site_v2` `/basketball/womens-college-basketball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_wbb_season_athletes` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_wbb_season_awards` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/awards` | `season`\* | — |
-| `espn_wbb_season_coaches` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_wbb_season_draft` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/draft` | `season`\* | — |
-| `espn_wbb_season_draft_round_picks` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_wbb_season_freeagents` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_wbb_season_futures` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/futures` | `season`\* | — |
-| `espn_wbb_season_group` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wbb_season_group_children` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wbb_season_group_teams` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_wbb_season_groups` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_wbb_season_info` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}` | `season`\* | — |
-| `espn_wbb_season_pointer` | `core_v2` `/basketball/leagues/womens-college-basketball/season` | — | — |
-| `espn_wbb_season_powerindex` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_wbb_season_powerindex_leaders` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_wbb_season_team` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_wbb_season_teams` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_wbb_season_type` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_wbb_season_type_corrections` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_wbb_season_type_leaders` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_wbb_season_types` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types` | `season`\* | — |
-| `espn_wbb_season_week` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_wbb_season_week_events` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_wbb_season_weeks` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_wbb_seasons` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons` | — | `limit` |
-| `espn_wbb_standings` | `site_v2_alt` `/basketball/womens-college-basketball/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_wbb_standings_core` | `core_v2` `/basketball/leagues/womens-college-basketball/standings` | — | — |
-| `espn_wbb_statistics_league` | `site_v2` `/basketball/womens-college-basketball/statistics` | — | — |
-| `espn_wbb_summary` | `site_v2` `/basketball/womens-college-basketball/summary` | — | `event_id` → `event` |
-| `espn_wbb_talentpicks` | `core_v2` `/basketball/leagues/womens-college-basketball/talentpicks` | — | — |
-| `espn_wbb_team` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}` | `team_id`\* | — |
-| `espn_wbb_team_core` | `core_v2` `/basketball/leagues/womens-college-basketball/teams/{team_id}` | `team_id`\* | — |
-| `espn_wbb_team_depthcharts` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_wbb_team_history` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_wbb_team_injuries` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_wbb_team_leaders` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_wbb_team_news` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_wbb_team_record` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_wbb_team_roster` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_wbb_team_schedule` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_wbb_team_transactions` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_wbb_teams_core` | `core_v2` `/basketball/leagues/womens-college-basketball/teams` | — | `limit` |
-| `espn_wbb_teams_site` | `site_v2` `/basketball/womens-college-basketball/teams` | — | `limit` |
-| `espn_wbb_tournaments` | `core_v2` `/basketball/leagues/womens-college-basketball/tournaments` | — | — |
-| `espn_wbb_transactions` | `site_v2` `/basketball/womens-college-basketball/transactions` | — | — |
-| `espn_wbb_venue` | `core_v2` `/basketball/leagues/womens-college-basketball/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_wbb_venues` | `core_v2` `/basketball/leagues/womens-college-basketball/venues` | — | `limit` |
+| `espnWbbAthleteAwards` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnWbbAthleteBio` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnWbbAthleteCareerStats` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnWbbAthleteContracts` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnWbbAthleteCore` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWbbAthleteEventlog` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnWbbAthleteGamelog` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnWbbAthleteInfo` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWbbAthleteInjuries` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnWbbAthleteNews` | `site_v2` `/basketball/womens-college-basketball/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnWbbAthleteNotes` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnWbbAthleteOverview` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnWbbAthleteRecords` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnWbbAthleteSeasons` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnWbbAthleteSplits` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnWbbAthleteStatisticslog` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnWbbAthleteStats` | `web_v3` `/basketball/womens-college-basketball/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnWbbAthleteVsAthlete` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnWbbAthletesIndex` | `core_v2` `/basketball/leagues/womens-college-basketball/athletes` | — | `active`, `limit`, `page` |
+| `espnWbbAward` | `core_v2` `/basketball/leagues/womens-college-basketball/awards/{award_id}` | `award_id`\* | — |
+| `espnWbbAwards` | `core_v2` `/basketball/leagues/womens-college-basketball/awards` | — | — |
+| `espnWbbCalendar` | `site_v2` `/basketball/womens-college-basketball/calendar` | — | — |
+| `espnWbbCoach` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnWbbCoachRecord` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnWbbCoachSeason` | `core_v2` `/basketball/leagues/womens-college-basketball/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnWbbConferences` | `site_v2` `/basketball/womens-college-basketball/groups` | — | — |
+| `espnWbbDraft` | `site_v2` `/basketball/womens-college-basketball/draft` | — | — |
+| `espnWbbEvent` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}` | `event_id`\* | — |
+| `espnWbbEventBroadcasts` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnWbbEventCompetition` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnWbbEventCompetitor` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitorLeaders` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitorLinescores` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitorRecord` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitorRoster` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitorStatistics` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWbbEventCompetitors` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnWbbEventLeaders` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnWbbEventOdds` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnWbbEventOfficialDetail` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnWbbEventOfficials` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnWbbEventPlay` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWbbEventPlayPersonnel` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWbbEventPlays` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnWbbEventPowerindex` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnWbbEventPredictor` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnWbbEventProbabilities` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnWbbEventPropbets` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnWbbEventScoringplays` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnWbbEventSituation` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnWbbEventStatus` | `core_v2` `/basketball/leagues/womens-college-basketball/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnWbbEvents` | `core_v2` `/basketball/leagues/womens-college-basketball/events` | — | `dates`, `limit` |
+| `espnWbbFranchise` | `core_v2` `/basketball/leagues/womens-college-basketball/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnWbbFranchises` | `core_v2` `/basketball/leagues/womens-college-basketball/franchises` | — | `limit` |
+| `espnWbbInjuries` | `site_v2` `/basketball/womens-college-basketball/injuries` | — | — |
+| `espnWbbLeaders` | `web_v3` `/basketball/womens-college-basketball/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnWbbLeadersCore` | `core_v2` `/basketball/leagues/womens-college-basketball/leaders` | — | — |
+| `espnWbbLeagueNotes` | `core_v2` `/basketball/leagues/womens-college-basketball/notes` | — | — |
+| `espnWbbLeagueRoot` | `core_v2` `/basketball/leagues/womens-college-basketball` | — | — |
+| `espnWbbNews` | `site_v2` `/basketball/womens-college-basketball/news` | — | `limit` |
+| `espnWbbPosition` | `core_v2` `/basketball/leagues/womens-college-basketball/positions/{position_id}` | `position_id`\* | — |
+| `espnWbbPositions` | `core_v2` `/basketball/leagues/womens-college-basketball/positions` | — | — |
+| `espnWbbScoreboard` | `site_v2` `/basketball/womens-college-basketball/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnWbbSeasonAthletes` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnWbbSeasonAwards` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/awards` | `season`\* | — |
+| `espnWbbSeasonCoaches` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnWbbSeasonDraft` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/draft` | `season`\* | — |
+| `espnWbbSeasonDraftRoundPicks` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnWbbSeasonFreeagents` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/freeagents` | `season`\* | — |
+| `espnWbbSeasonFutures` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/futures` | `season`\* | — |
+| `espnWbbSeasonGroup` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWbbSeasonGroupChildren` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWbbSeasonGroupTeams` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnWbbSeasonGroups` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnWbbSeasonInfo` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}` | `season`\* | — |
+| `espnWbbSeasonPointer` | `core_v2` `/basketball/leagues/womens-college-basketball/season` | — | — |
+| `espnWbbSeasonPowerindex` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnWbbSeasonPowerindexLeaders` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnWbbSeasonTeam` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnWbbSeasonTeams` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnWbbSeasonType` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnWbbSeasonTypeCorrections` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnWbbSeasonTypeLeaders` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnWbbSeasonTypes` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types` | `season`\* | — |
+| `espnWbbSeasonWeek` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWbbSeasonWeekEvents` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnWbbSeasonWeeks` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnWbbSeasons` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons` | — | `limit` |
+| `espnWbbStandings` | `site_v2_alt` `/basketball/womens-college-basketball/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnWbbStandingsCore` | `core_v2` `/basketball/leagues/womens-college-basketball/standings` | — | — |
+| `espnWbbStatisticsLeague` | `site_v2` `/basketball/womens-college-basketball/statistics` | — | — |
+| `espnWbbSummary` | `site_v2` `/basketball/womens-college-basketball/summary` | — | `event_id` → `event` |
+| `espnWbbTalentpicks` | `core_v2` `/basketball/leagues/womens-college-basketball/talentpicks` | — | — |
+| `espnWbbTeam` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}` | `team_id`\* | — |
+| `espnWbbTeamCore` | `core_v2` `/basketball/leagues/womens-college-basketball/teams/{team_id}` | `team_id`\* | — |
+| `espnWbbTeamDepthcharts` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnWbbTeamHistory` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/history` | `team_id`\* | — |
+| `espnWbbTeamInjuries` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnWbbTeamLeaders` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnWbbTeamNews` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnWbbTeamRecord` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/record` | `team_id`\* | — |
+| `espnWbbTeamRoster` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnWbbTeamSchedule` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnWbbTeamTransactions` | `site_v2` `/basketball/womens-college-basketball/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnWbbTeamsCore` | `core_v2` `/basketball/leagues/womens-college-basketball/teams` | — | `limit` |
+| `espnWbbTeamsSite` | `site_v2` `/basketball/womens-college-basketball/teams` | — | `limit` |
+| `espnWbbTournaments` | `core_v2` `/basketball/leagues/womens-college-basketball/tournaments` | — | — |
+| `espnWbbTransactions` | `site_v2` `/basketball/womens-college-basketball/transactions` | — | — |
+| `espnWbbVenue` | `core_v2` `/basketball/leagues/womens-college-basketball/venues/{venue_id}` | `venue_id`\* | — |
+| `espnWbbVenues` | `core_v2` `/basketball/leagues/womens-college-basketball/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wbb_rankings` | `site_v2` `/basketball/womens-college-basketball/rankings` | — | — |
-| `espn_wbb_season_recruits` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_wbb_season_week_rankings` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWbbRankings` | `site_v2` `/basketball/womens-college-basketball/rankings` | — | — |
+| `espnWbbSeasonRecruits` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnWbbSeasonWeekRankings` | `core_v2` `/basketball/leagues/womens-college-basketball/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/wc.md
+++ b/docs/docs/reference/wc.md
@@ -14,125 +14,125 @@ sidebar_position: 28
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.wc.espn_wc_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.wc.espnWc<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_wc_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.wc.espn_wc_scoreboard({});
+await sdv.wc.espnWcScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wc_athlete_awards` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_wc_athlete_bio` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_wc_athlete_career_stats` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_wc_athlete_contracts` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_wc_athlete_core` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wc_athlete_eventlog` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_wc_athlete_gamelog` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_wc_athlete_info` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wc_athlete_injuries` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_wc_athlete_news` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_wc_athlete_notes` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_wc_athlete_overview` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_wc_athlete_records` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_wc_athlete_seasons` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_wc_athlete_splits` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_wc_athlete_statisticslog` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_wc_athlete_stats` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_wc_athlete_vs_athlete` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_wc_athletes_index` | `core_v2` `/soccer/leagues/fifa.world/athletes` | — | `active`, `limit`, `page` |
-| `espn_wc_award` | `core_v2` `/soccer/leagues/fifa.world/awards/{award_id}` | `award_id`\* | — |
-| `espn_wc_awards` | `core_v2` `/soccer/leagues/fifa.world/awards` | — | — |
-| `espn_wc_calendar` | `site_v2` `/soccer/fifa.world/calendar` | — | — |
-| `espn_wc_coach` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_wc_coach_record` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_wc_coach_season` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_wc_conferences` | `site_v2` `/soccer/fifa.world/groups` | — | — |
-| `espn_wc_draft` | `site_v2` `/soccer/fifa.world/draft` | — | — |
-| `espn_wc_event` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}` | `event_id`\* | — |
-| `espn_wc_event_broadcasts` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_wc_event_competition` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_wc_event_competitor` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitor_leaders` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitor_linescores` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitor_record` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitor_roster` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitor_statistics` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wc_event_competitors` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_wc_event_leaders` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_wc_event_odds` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_wc_event_official_detail` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_wc_event_officials` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_wc_event_play` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wc_event_play_personnel` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wc_event_plays` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_wc_event_powerindex` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_wc_event_predictor` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_wc_event_probabilities` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_wc_event_propbets` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_wc_event_scoringplays` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_wc_event_situation` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_wc_event_status` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_wc_events` | `core_v2` `/soccer/leagues/fifa.world/events` | — | `dates`, `limit` |
-| `espn_wc_franchise` | `core_v2` `/soccer/leagues/fifa.world/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_wc_franchises` | `core_v2` `/soccer/leagues/fifa.world/franchises` | — | `limit` |
-| `espn_wc_injuries` | `site_v2` `/soccer/fifa.world/injuries` | — | — |
-| `espn_wc_leaders` | `web_v3` `/soccer/fifa.world/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_wc_leaders_core` | `core_v2` `/soccer/leagues/fifa.world/leaders` | — | — |
-| `espn_wc_league_notes` | `core_v2` `/soccer/leagues/fifa.world/notes` | — | — |
-| `espn_wc_league_root` | `core_v2` `/soccer/leagues/fifa.world` | — | — |
-| `espn_wc_news` | `site_v2` `/soccer/fifa.world/news` | — | `limit` |
-| `espn_wc_position` | `core_v2` `/soccer/leagues/fifa.world/positions/{position_id}` | `position_id`\* | — |
-| `espn_wc_positions` | `core_v2` `/soccer/leagues/fifa.world/positions` | — | — |
-| `espn_wc_scoreboard` | `site_v2` `/soccer/fifa.world/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_wc_season_athletes` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_wc_season_awards` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/awards` | `season`\* | — |
-| `espn_wc_season_coaches` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_wc_season_draft` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/draft` | `season`\* | — |
-| `espn_wc_season_draft_round_picks` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_wc_season_freeagents` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_wc_season_futures` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/futures` | `season`\* | — |
-| `espn_wc_season_group` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wc_season_group_children` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wc_season_group_teams` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_wc_season_groups` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_wc_season_info` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}` | `season`\* | — |
-| `espn_wc_season_pointer` | `core_v2` `/soccer/leagues/fifa.world/season` | — | — |
-| `espn_wc_season_powerindex` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_wc_season_powerindex_leaders` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_wc_season_team` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_wc_season_teams` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_wc_season_type` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_wc_season_type_corrections` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_wc_season_type_leaders` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_wc_season_types` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types` | `season`\* | — |
-| `espn_wc_season_week` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_wc_season_week_events` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_wc_season_weeks` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_wc_seasons` | `core_v2` `/soccer/leagues/fifa.world/seasons` | — | `limit` |
-| `espn_wc_standings` | `site_v2_alt` `/soccer/fifa.world/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_wc_standings_core` | `core_v2` `/soccer/leagues/fifa.world/standings` | — | — |
-| `espn_wc_statistics_league` | `site_v2` `/soccer/fifa.world/statistics` | — | — |
-| `espn_wc_summary` | `site_v2` `/soccer/fifa.world/summary` | — | `event_id` → `event` |
-| `espn_wc_talentpicks` | `core_v2` `/soccer/leagues/fifa.world/talentpicks` | — | — |
-| `espn_wc_team` | `site_v2` `/soccer/fifa.world/teams/{team_id}` | `team_id`\* | — |
-| `espn_wc_team_core` | `core_v2` `/soccer/leagues/fifa.world/teams/{team_id}` | `team_id`\* | — |
-| `espn_wc_team_depthcharts` | `site_v2` `/soccer/fifa.world/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_wc_team_history` | `site_v2` `/soccer/fifa.world/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_wc_team_injuries` | `site_v2` `/soccer/fifa.world/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_wc_team_leaders` | `site_v2` `/soccer/fifa.world/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_wc_team_news` | `site_v2` `/soccer/fifa.world/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_wc_team_record` | `site_v2` `/soccer/fifa.world/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_wc_team_roster` | `site_v2` `/soccer/fifa.world/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_wc_team_schedule` | `site_v2` `/soccer/fifa.world/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_wc_team_transactions` | `site_v2` `/soccer/fifa.world/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_wc_teams_core` | `core_v2` `/soccer/leagues/fifa.world/teams` | — | `limit` |
-| `espn_wc_teams_site` | `site_v2` `/soccer/fifa.world/teams` | — | `limit` |
-| `espn_wc_tournaments` | `core_v2` `/soccer/leagues/fifa.world/tournaments` | — | — |
-| `espn_wc_transactions` | `site_v2` `/soccer/fifa.world/transactions` | — | — |
-| `espn_wc_venue` | `core_v2` `/soccer/leagues/fifa.world/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_wc_venues` | `core_v2` `/soccer/leagues/fifa.world/venues` | — | `limit` |
+| `espnWcAthleteAwards` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnWcAthleteBio` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnWcAthleteCareerStats` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnWcAthleteContracts` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnWcAthleteCore` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWcAthleteEventlog` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnWcAthleteGamelog` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnWcAthleteInfo` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWcAthleteInjuries` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnWcAthleteNews` | `site_v2` `/soccer/fifa.world/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnWcAthleteNotes` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnWcAthleteOverview` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnWcAthleteRecords` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnWcAthleteSeasons` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnWcAthleteSplits` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnWcAthleteStatisticslog` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnWcAthleteStats` | `web_v3` `/soccer/fifa.world/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnWcAthleteVsAthlete` | `core_v2` `/soccer/leagues/fifa.world/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnWcAthletesIndex` | `core_v2` `/soccer/leagues/fifa.world/athletes` | — | `active`, `limit`, `page` |
+| `espnWcAward` | `core_v2` `/soccer/leagues/fifa.world/awards/{award_id}` | `award_id`\* | — |
+| `espnWcAwards` | `core_v2` `/soccer/leagues/fifa.world/awards` | — | — |
+| `espnWcCalendar` | `site_v2` `/soccer/fifa.world/calendar` | — | — |
+| `espnWcCoach` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnWcCoachRecord` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnWcCoachSeason` | `core_v2` `/soccer/leagues/fifa.world/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnWcConferences` | `site_v2` `/soccer/fifa.world/groups` | — | — |
+| `espnWcDraft` | `site_v2` `/soccer/fifa.world/draft` | — | — |
+| `espnWcEvent` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}` | `event_id`\* | — |
+| `espnWcEventBroadcasts` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnWcEventCompetition` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnWcEventCompetitor` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitorLeaders` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitorLinescores` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitorRecord` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitorRoster` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitorStatistics` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWcEventCompetitors` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnWcEventLeaders` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnWcEventOdds` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnWcEventOfficialDetail` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnWcEventOfficials` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnWcEventPlay` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWcEventPlayPersonnel` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWcEventPlays` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnWcEventPowerindex` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnWcEventPredictor` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnWcEventProbabilities` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnWcEventPropbets` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnWcEventScoringplays` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnWcEventSituation` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnWcEventStatus` | `core_v2` `/soccer/leagues/fifa.world/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnWcEvents` | `core_v2` `/soccer/leagues/fifa.world/events` | — | `dates`, `limit` |
+| `espnWcFranchise` | `core_v2` `/soccer/leagues/fifa.world/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnWcFranchises` | `core_v2` `/soccer/leagues/fifa.world/franchises` | — | `limit` |
+| `espnWcInjuries` | `site_v2` `/soccer/fifa.world/injuries` | — | — |
+| `espnWcLeaders` | `web_v3` `/soccer/fifa.world/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnWcLeadersCore` | `core_v2` `/soccer/leagues/fifa.world/leaders` | — | — |
+| `espnWcLeagueNotes` | `core_v2` `/soccer/leagues/fifa.world/notes` | — | — |
+| `espnWcLeagueRoot` | `core_v2` `/soccer/leagues/fifa.world` | — | — |
+| `espnWcNews` | `site_v2` `/soccer/fifa.world/news` | — | `limit` |
+| `espnWcPosition` | `core_v2` `/soccer/leagues/fifa.world/positions/{position_id}` | `position_id`\* | — |
+| `espnWcPositions` | `core_v2` `/soccer/leagues/fifa.world/positions` | — | — |
+| `espnWcScoreboard` | `site_v2` `/soccer/fifa.world/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnWcSeasonAthletes` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnWcSeasonAwards` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/awards` | `season`\* | — |
+| `espnWcSeasonCoaches` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnWcSeasonDraft` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/draft` | `season`\* | — |
+| `espnWcSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnWcSeasonFreeagents` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/freeagents` | `season`\* | — |
+| `espnWcSeasonFutures` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/futures` | `season`\* | — |
+| `espnWcSeasonGroup` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWcSeasonGroupChildren` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWcSeasonGroupTeams` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnWcSeasonGroups` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnWcSeasonInfo` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}` | `season`\* | — |
+| `espnWcSeasonPointer` | `core_v2` `/soccer/leagues/fifa.world/season` | — | — |
+| `espnWcSeasonPowerindex` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnWcSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnWcSeasonTeam` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnWcSeasonTeams` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnWcSeasonType` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnWcSeasonTypeCorrections` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnWcSeasonTypeLeaders` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnWcSeasonTypes` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types` | `season`\* | — |
+| `espnWcSeasonWeek` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWcSeasonWeekEvents` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnWcSeasonWeeks` | `core_v2` `/soccer/leagues/fifa.world/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnWcSeasons` | `core_v2` `/soccer/leagues/fifa.world/seasons` | — | `limit` |
+| `espnWcStandings` | `site_v2_alt` `/soccer/fifa.world/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnWcStandingsCore` | `core_v2` `/soccer/leagues/fifa.world/standings` | — | — |
+| `espnWcStatisticsLeague` | `site_v2` `/soccer/fifa.world/statistics` | — | — |
+| `espnWcSummary` | `site_v2` `/soccer/fifa.world/summary` | — | `event_id` → `event` |
+| `espnWcTalentpicks` | `core_v2` `/soccer/leagues/fifa.world/talentpicks` | — | — |
+| `espnWcTeam` | `site_v2` `/soccer/fifa.world/teams/{team_id}` | `team_id`\* | — |
+| `espnWcTeamCore` | `core_v2` `/soccer/leagues/fifa.world/teams/{team_id}` | `team_id`\* | — |
+| `espnWcTeamDepthcharts` | `site_v2` `/soccer/fifa.world/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnWcTeamHistory` | `site_v2` `/soccer/fifa.world/teams/{team_id}/history` | `team_id`\* | — |
+| `espnWcTeamInjuries` | `site_v2` `/soccer/fifa.world/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnWcTeamLeaders` | `site_v2` `/soccer/fifa.world/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnWcTeamNews` | `site_v2` `/soccer/fifa.world/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnWcTeamRecord` | `site_v2` `/soccer/fifa.world/teams/{team_id}/record` | `team_id`\* | — |
+| `espnWcTeamRoster` | `site_v2` `/soccer/fifa.world/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnWcTeamSchedule` | `site_v2` `/soccer/fifa.world/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnWcTeamTransactions` | `site_v2` `/soccer/fifa.world/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnWcTeamsCore` | `core_v2` `/soccer/leagues/fifa.world/teams` | — | `limit` |
+| `espnWcTeamsSite` | `site_v2` `/soccer/fifa.world/teams` | — | `limit` |
+| `espnWcTournaments` | `core_v2` `/soccer/leagues/fifa.world/tournaments` | — | — |
+| `espnWcTransactions` | `site_v2` `/soccer/fifa.world/transactions` | — | — |
+| `espnWcVenue` | `core_v2` `/soccer/leagues/fifa.world/venues/{venue_id}` | `venue_id`\* | — |
+| `espnWcVenues` | `core_v2` `/soccer/leagues/fifa.world/venues` | — | `limit` |

--- a/docs/docs/reference/wch.md
+++ b/docs/docs/reference/wch.md
@@ -14,133 +14,133 @@ sidebar_position: 10
 - **scopes:** `universal`, `ncaa`
 - **wrappers:** 113
 
-Every endpoint is called as `sdv.wch.espn_wch_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.wch.espnWch<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_wch_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.wch.espn_wch_scoreboard({});
+await sdv.wch.espnWchScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wch_athlete_awards` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_wch_athlete_bio` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_wch_athlete_career_stats` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_wch_athlete_contracts` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_wch_athlete_core` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wch_athlete_eventlog` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_wch_athlete_gamelog` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_wch_athlete_info` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wch_athlete_injuries` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_wch_athlete_news` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_wch_athlete_notes` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_wch_athlete_overview` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_wch_athlete_records` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_wch_athlete_seasons` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_wch_athlete_splits` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_wch_athlete_statisticslog` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_wch_athlete_stats` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_wch_athlete_vs_athlete` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_wch_athletes_index` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes` | — | `active`, `limit`, `page` |
-| `espn_wch_award` | `core_v2` `/hockey/leagues/womens-college-hockey/awards/{award_id}` | `award_id`\* | — |
-| `espn_wch_awards` | `core_v2` `/hockey/leagues/womens-college-hockey/awards` | — | — |
-| `espn_wch_calendar` | `site_v2` `/hockey/womens-college-hockey/calendar` | — | — |
-| `espn_wch_coach` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_wch_coach_record` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_wch_coach_season` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_wch_conferences` | `site_v2` `/hockey/womens-college-hockey/groups` | — | — |
-| `espn_wch_draft` | `site_v2` `/hockey/womens-college-hockey/draft` | — | — |
-| `espn_wch_event` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}` | `event_id`\* | — |
-| `espn_wch_event_broadcasts` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_wch_event_competition` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_wch_event_competitor` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitor_leaders` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitor_linescores` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitor_record` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitor_roster` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitor_statistics` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wch_event_competitors` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_wch_event_leaders` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_wch_event_odds` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_wch_event_official_detail` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_wch_event_officials` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_wch_event_play` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wch_event_play_personnel` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wch_event_plays` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_wch_event_powerindex` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_wch_event_predictor` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_wch_event_probabilities` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_wch_event_propbets` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_wch_event_scoringplays` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_wch_event_situation` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_wch_event_status` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_wch_events` | `core_v2` `/hockey/leagues/womens-college-hockey/events` | — | `dates`, `limit` |
-| `espn_wch_franchise` | `core_v2` `/hockey/leagues/womens-college-hockey/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_wch_franchises` | `core_v2` `/hockey/leagues/womens-college-hockey/franchises` | — | `limit` |
-| `espn_wch_injuries` | `site_v2` `/hockey/womens-college-hockey/injuries` | — | — |
-| `espn_wch_leaders` | `web_v3` `/hockey/womens-college-hockey/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_wch_leaders_core` | `core_v2` `/hockey/leagues/womens-college-hockey/leaders` | — | — |
-| `espn_wch_league_notes` | `core_v2` `/hockey/leagues/womens-college-hockey/notes` | — | — |
-| `espn_wch_league_root` | `core_v2` `/hockey/leagues/womens-college-hockey` | — | — |
-| `espn_wch_news` | `site_v2` `/hockey/womens-college-hockey/news` | — | `limit` |
-| `espn_wch_position` | `core_v2` `/hockey/leagues/womens-college-hockey/positions/{position_id}` | `position_id`\* | — |
-| `espn_wch_positions` | `core_v2` `/hockey/leagues/womens-college-hockey/positions` | — | — |
-| `espn_wch_scoreboard` | `site_v2` `/hockey/womens-college-hockey/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_wch_season_athletes` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_wch_season_awards` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/awards` | `season`\* | — |
-| `espn_wch_season_coaches` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_wch_season_draft` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/draft` | `season`\* | — |
-| `espn_wch_season_draft_round_picks` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_wch_season_freeagents` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_wch_season_futures` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/futures` | `season`\* | — |
-| `espn_wch_season_group` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wch_season_group_children` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wch_season_group_teams` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_wch_season_groups` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_wch_season_info` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}` | `season`\* | — |
-| `espn_wch_season_pointer` | `core_v2` `/hockey/leagues/womens-college-hockey/season` | — | — |
-| `espn_wch_season_powerindex` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_wch_season_powerindex_leaders` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_wch_season_team` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_wch_season_teams` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_wch_season_type` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_wch_season_type_corrections` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_wch_season_type_leaders` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_wch_season_types` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types` | `season`\* | — |
-| `espn_wch_season_week` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_wch_season_week_events` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_wch_season_weeks` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_wch_seasons` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons` | — | `limit` |
-| `espn_wch_standings` | `site_v2_alt` `/hockey/womens-college-hockey/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_wch_standings_core` | `core_v2` `/hockey/leagues/womens-college-hockey/standings` | — | — |
-| `espn_wch_statistics_league` | `site_v2` `/hockey/womens-college-hockey/statistics` | — | — |
-| `espn_wch_summary` | `site_v2` `/hockey/womens-college-hockey/summary` | — | `event_id` → `event` |
-| `espn_wch_talentpicks` | `core_v2` `/hockey/leagues/womens-college-hockey/talentpicks` | — | — |
-| `espn_wch_team` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}` | `team_id`\* | — |
-| `espn_wch_team_core` | `core_v2` `/hockey/leagues/womens-college-hockey/teams/{team_id}` | `team_id`\* | — |
-| `espn_wch_team_depthcharts` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_wch_team_history` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_wch_team_injuries` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_wch_team_leaders` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_wch_team_news` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_wch_team_record` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_wch_team_roster` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_wch_team_schedule` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_wch_team_transactions` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_wch_teams_core` | `core_v2` `/hockey/leagues/womens-college-hockey/teams` | — | `limit` |
-| `espn_wch_teams_site` | `site_v2` `/hockey/womens-college-hockey/teams` | — | `limit` |
-| `espn_wch_tournaments` | `core_v2` `/hockey/leagues/womens-college-hockey/tournaments` | — | — |
-| `espn_wch_transactions` | `site_v2` `/hockey/womens-college-hockey/transactions` | — | — |
-| `espn_wch_venue` | `core_v2` `/hockey/leagues/womens-college-hockey/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_wch_venues` | `core_v2` `/hockey/leagues/womens-college-hockey/venues` | — | `limit` |
+| `espnWchAthleteAwards` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnWchAthleteBio` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnWchAthleteCareerStats` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnWchAthleteContracts` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnWchAthleteCore` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWchAthleteEventlog` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnWchAthleteGamelog` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnWchAthleteInfo` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWchAthleteInjuries` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnWchAthleteNews` | `site_v2` `/hockey/womens-college-hockey/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnWchAthleteNotes` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnWchAthleteOverview` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnWchAthleteRecords` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnWchAthleteSeasons` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnWchAthleteSplits` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnWchAthleteStatisticslog` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnWchAthleteStats` | `web_v3` `/hockey/womens-college-hockey/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnWchAthleteVsAthlete` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnWchAthletesIndex` | `core_v2` `/hockey/leagues/womens-college-hockey/athletes` | — | `active`, `limit`, `page` |
+| `espnWchAward` | `core_v2` `/hockey/leagues/womens-college-hockey/awards/{award_id}` | `award_id`\* | — |
+| `espnWchAwards` | `core_v2` `/hockey/leagues/womens-college-hockey/awards` | — | — |
+| `espnWchCalendar` | `site_v2` `/hockey/womens-college-hockey/calendar` | — | — |
+| `espnWchCoach` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnWchCoachRecord` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnWchCoachSeason` | `core_v2` `/hockey/leagues/womens-college-hockey/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnWchConferences` | `site_v2` `/hockey/womens-college-hockey/groups` | — | — |
+| `espnWchDraft` | `site_v2` `/hockey/womens-college-hockey/draft` | — | — |
+| `espnWchEvent` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}` | `event_id`\* | — |
+| `espnWchEventBroadcasts` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnWchEventCompetition` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnWchEventCompetitor` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitorLeaders` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitorLinescores` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitorRecord` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitorRoster` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitorStatistics` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWchEventCompetitors` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnWchEventLeaders` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnWchEventOdds` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnWchEventOfficialDetail` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnWchEventOfficials` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnWchEventPlay` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWchEventPlayPersonnel` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWchEventPlays` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnWchEventPowerindex` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnWchEventPredictor` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnWchEventProbabilities` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnWchEventPropbets` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnWchEventScoringplays` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnWchEventSituation` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnWchEventStatus` | `core_v2` `/hockey/leagues/womens-college-hockey/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnWchEvents` | `core_v2` `/hockey/leagues/womens-college-hockey/events` | — | `dates`, `limit` |
+| `espnWchFranchise` | `core_v2` `/hockey/leagues/womens-college-hockey/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnWchFranchises` | `core_v2` `/hockey/leagues/womens-college-hockey/franchises` | — | `limit` |
+| `espnWchInjuries` | `site_v2` `/hockey/womens-college-hockey/injuries` | — | — |
+| `espnWchLeaders` | `web_v3` `/hockey/womens-college-hockey/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnWchLeadersCore` | `core_v2` `/hockey/leagues/womens-college-hockey/leaders` | — | — |
+| `espnWchLeagueNotes` | `core_v2` `/hockey/leagues/womens-college-hockey/notes` | — | — |
+| `espnWchLeagueRoot` | `core_v2` `/hockey/leagues/womens-college-hockey` | — | — |
+| `espnWchNews` | `site_v2` `/hockey/womens-college-hockey/news` | — | `limit` |
+| `espnWchPosition` | `core_v2` `/hockey/leagues/womens-college-hockey/positions/{position_id}` | `position_id`\* | — |
+| `espnWchPositions` | `core_v2` `/hockey/leagues/womens-college-hockey/positions` | — | — |
+| `espnWchScoreboard` | `site_v2` `/hockey/womens-college-hockey/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnWchSeasonAthletes` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnWchSeasonAwards` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/awards` | `season`\* | — |
+| `espnWchSeasonCoaches` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnWchSeasonDraft` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/draft` | `season`\* | — |
+| `espnWchSeasonDraftRoundPicks` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnWchSeasonFreeagents` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/freeagents` | `season`\* | — |
+| `espnWchSeasonFutures` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/futures` | `season`\* | — |
+| `espnWchSeasonGroup` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWchSeasonGroupChildren` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWchSeasonGroupTeams` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnWchSeasonGroups` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnWchSeasonInfo` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}` | `season`\* | — |
+| `espnWchSeasonPointer` | `core_v2` `/hockey/leagues/womens-college-hockey/season` | — | — |
+| `espnWchSeasonPowerindex` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnWchSeasonPowerindexLeaders` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnWchSeasonTeam` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnWchSeasonTeams` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnWchSeasonType` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnWchSeasonTypeCorrections` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnWchSeasonTypeLeaders` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnWchSeasonTypes` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types` | `season`\* | — |
+| `espnWchSeasonWeek` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWchSeasonWeekEvents` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnWchSeasonWeeks` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnWchSeasons` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons` | — | `limit` |
+| `espnWchStandings` | `site_v2_alt` `/hockey/womens-college-hockey/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnWchStandingsCore` | `core_v2` `/hockey/leagues/womens-college-hockey/standings` | — | — |
+| `espnWchStatisticsLeague` | `site_v2` `/hockey/womens-college-hockey/statistics` | — | — |
+| `espnWchSummary` | `site_v2` `/hockey/womens-college-hockey/summary` | — | `event_id` → `event` |
+| `espnWchTalentpicks` | `core_v2` `/hockey/leagues/womens-college-hockey/talentpicks` | — | — |
+| `espnWchTeam` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}` | `team_id`\* | — |
+| `espnWchTeamCore` | `core_v2` `/hockey/leagues/womens-college-hockey/teams/{team_id}` | `team_id`\* | — |
+| `espnWchTeamDepthcharts` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnWchTeamHistory` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/history` | `team_id`\* | — |
+| `espnWchTeamInjuries` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnWchTeamLeaders` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnWchTeamNews` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnWchTeamRecord` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/record` | `team_id`\* | — |
+| `espnWchTeamRoster` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnWchTeamSchedule` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnWchTeamTransactions` | `site_v2` `/hockey/womens-college-hockey/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnWchTeamsCore` | `core_v2` `/hockey/leagues/womens-college-hockey/teams` | — | `limit` |
+| `espnWchTeamsSite` | `site_v2` `/hockey/womens-college-hockey/teams` | — | `limit` |
+| `espnWchTournaments` | `core_v2` `/hockey/leagues/womens-college-hockey/tournaments` | — | — |
+| `espnWchTransactions` | `site_v2` `/hockey/womens-college-hockey/transactions` | — | — |
+| `espnWchVenue` | `core_v2` `/hockey/leagues/womens-college-hockey/venues/{venue_id}` | `venue_id`\* | — |
+| `espnWchVenues` | `core_v2` `/hockey/leagues/womens-college-hockey/venues` | — | `limit` |
 
 ## NCAA endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wch_rankings` | `site_v2` `/hockey/womens-college-hockey/rankings` | — | — |
-| `espn_wch_season_recruits` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/recruits` | `season`\* | `limit` |
-| `espn_wch_season_week_rankings` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWchRankings` | `site_v2` `/hockey/womens-college-hockey/rankings` | — | — |
+| `espnWchSeasonRecruits` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/recruits` | `season`\* | `limit` |
+| `espnWchSeasonWeekRankings` | `core_v2` `/hockey/leagues/womens-college-hockey/seasons/{season}/types/{season_type}/weeks/{week}/rankings` | `season`\*, `season_type`\*, `week`\* | — |

--- a/docs/docs/reference/wnba.md
+++ b/docs/docs/reference/wnba.md
@@ -14,125 +14,125 @@ sidebar_position: 2
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.wnba.espn_wnba_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.wnba.espnWnba<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_wnba_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.wnba.espn_wnba_scoreboard({});
+await sdv.wnba.espnWnbaScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wnba_athlete_awards` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_wnba_athlete_bio` | `site_v2` `/basketball/wnba/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_wnba_athlete_career_stats` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_wnba_athlete_contracts` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_wnba_athlete_core` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wnba_athlete_eventlog` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_wnba_athlete_gamelog` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_wnba_athlete_info` | `site_v2` `/basketball/wnba/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wnba_athlete_injuries` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_wnba_athlete_news` | `site_v2` `/basketball/wnba/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_wnba_athlete_notes` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_wnba_athlete_overview` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_wnba_athlete_records` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_wnba_athlete_seasons` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_wnba_athlete_splits` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_wnba_athlete_statisticslog` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_wnba_athlete_stats` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_wnba_athlete_vs_athlete` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_wnba_athletes_index` | `core_v2` `/basketball/leagues/wnba/athletes` | — | `active`, `limit`, `page` |
-| `espn_wnba_award` | `core_v2` `/basketball/leagues/wnba/awards/{award_id}` | `award_id`\* | — |
-| `espn_wnba_awards` | `core_v2` `/basketball/leagues/wnba/awards` | — | — |
-| `espn_wnba_calendar` | `site_v2` `/basketball/wnba/calendar` | — | — |
-| `espn_wnba_coach` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_wnba_coach_record` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_wnba_coach_season` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_wnba_conferences` | `site_v2` `/basketball/wnba/groups` | — | — |
-| `espn_wnba_draft` | `site_v2` `/basketball/wnba/draft` | — | — |
-| `espn_wnba_event` | `core_v2` `/basketball/leagues/wnba/events/{event_id}` | `event_id`\* | — |
-| `espn_wnba_event_broadcasts` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_competition` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_competitor` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitor_leaders` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitor_linescores` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitor_record` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitor_roster` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitor_statistics` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wnba_event_competitors` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_leaders` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_odds` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_official_detail` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_wnba_event_officials` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_play` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wnba_event_play_personnel` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wnba_event_plays` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_wnba_event_powerindex` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_predictor` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_probabilities` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_wnba_event_propbets` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_scoringplays` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_situation` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_wnba_event_status` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_wnba_events` | `core_v2` `/basketball/leagues/wnba/events` | — | `dates`, `limit` |
-| `espn_wnba_franchise` | `core_v2` `/basketball/leagues/wnba/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_wnba_franchises` | `core_v2` `/basketball/leagues/wnba/franchises` | — | `limit` |
-| `espn_wnba_injuries` | `site_v2` `/basketball/wnba/injuries` | — | — |
-| `espn_wnba_leaders` | `web_v3` `/basketball/wnba/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_wnba_leaders_core` | `core_v2` `/basketball/leagues/wnba/leaders` | — | — |
-| `espn_wnba_league_notes` | `core_v2` `/basketball/leagues/wnba/notes` | — | — |
-| `espn_wnba_league_root` | `core_v2` `/basketball/leagues/wnba` | — | — |
-| `espn_wnba_news` | `site_v2` `/basketball/wnba/news` | — | `limit` |
-| `espn_wnba_position` | `core_v2` `/basketball/leagues/wnba/positions/{position_id}` | `position_id`\* | — |
-| `espn_wnba_positions` | `core_v2` `/basketball/leagues/wnba/positions` | — | — |
-| `espn_wnba_scoreboard` | `site_v2` `/basketball/wnba/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_wnba_season_athletes` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_wnba_season_awards` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/awards` | `season`\* | — |
-| `espn_wnba_season_coaches` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_wnba_season_draft` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/draft` | `season`\* | — |
-| `espn_wnba_season_draft_round_picks` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_wnba_season_freeagents` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_wnba_season_futures` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/futures` | `season`\* | — |
-| `espn_wnba_season_group` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wnba_season_group_children` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wnba_season_group_teams` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_wnba_season_groups` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_wnba_season_info` | `core_v2` `/basketball/leagues/wnba/seasons/{season}` | `season`\* | — |
-| `espn_wnba_season_pointer` | `core_v2` `/basketball/leagues/wnba/season` | — | — |
-| `espn_wnba_season_powerindex` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_wnba_season_powerindex_leaders` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_wnba_season_team` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_wnba_season_teams` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_wnba_season_type` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_wnba_season_type_corrections` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_wnba_season_type_leaders` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_wnba_season_types` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types` | `season`\* | — |
-| `espn_wnba_season_week` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_wnba_season_week_events` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_wnba_season_weeks` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_wnba_seasons` | `core_v2` `/basketball/leagues/wnba/seasons` | — | `limit` |
-| `espn_wnba_standings` | `site_v2_alt` `/basketball/wnba/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_wnba_standings_core` | `core_v2` `/basketball/leagues/wnba/standings` | — | — |
-| `espn_wnba_statistics_league` | `site_v2` `/basketball/wnba/statistics` | — | — |
-| `espn_wnba_summary` | `site_v2` `/basketball/wnba/summary` | — | `event_id` → `event` |
-| `espn_wnba_talentpicks` | `core_v2` `/basketball/leagues/wnba/talentpicks` | — | — |
-| `espn_wnba_team` | `site_v2` `/basketball/wnba/teams/{team_id}` | `team_id`\* | — |
-| `espn_wnba_team_core` | `core_v2` `/basketball/leagues/wnba/teams/{team_id}` | `team_id`\* | — |
-| `espn_wnba_team_depthcharts` | `site_v2` `/basketball/wnba/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_wnba_team_history` | `site_v2` `/basketball/wnba/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_wnba_team_injuries` | `site_v2` `/basketball/wnba/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_wnba_team_leaders` | `site_v2` `/basketball/wnba/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_wnba_team_news` | `site_v2` `/basketball/wnba/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_wnba_team_record` | `site_v2` `/basketball/wnba/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_wnba_team_roster` | `site_v2` `/basketball/wnba/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_wnba_team_schedule` | `site_v2` `/basketball/wnba/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_wnba_team_transactions` | `site_v2` `/basketball/wnba/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_wnba_teams_core` | `core_v2` `/basketball/leagues/wnba/teams` | — | `limit` |
-| `espn_wnba_teams_site` | `site_v2` `/basketball/wnba/teams` | — | `limit` |
-| `espn_wnba_tournaments` | `core_v2` `/basketball/leagues/wnba/tournaments` | — | — |
-| `espn_wnba_transactions` | `site_v2` `/basketball/wnba/transactions` | — | — |
-| `espn_wnba_venue` | `core_v2` `/basketball/leagues/wnba/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_wnba_venues` | `core_v2` `/basketball/leagues/wnba/venues` | — | `limit` |
+| `espnWnbaAthleteAwards` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnWnbaAthleteBio` | `site_v2` `/basketball/wnba/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnWnbaAthleteCareerStats` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnWnbaAthleteContracts` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnWnbaAthleteCore` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWnbaAthleteEventlog` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnWnbaAthleteGamelog` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnWnbaAthleteInfo` | `site_v2` `/basketball/wnba/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWnbaAthleteInjuries` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnWnbaAthleteNews` | `site_v2` `/basketball/wnba/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnWnbaAthleteNotes` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnWnbaAthleteOverview` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnWnbaAthleteRecords` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnWnbaAthleteSeasons` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnWnbaAthleteSplits` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnWnbaAthleteStatisticslog` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnWnbaAthleteStats` | `web_v3` `/basketball/wnba/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnWnbaAthleteVsAthlete` | `core_v2` `/basketball/leagues/wnba/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnWnbaAthletesIndex` | `core_v2` `/basketball/leagues/wnba/athletes` | — | `active`, `limit`, `page` |
+| `espnWnbaAward` | `core_v2` `/basketball/leagues/wnba/awards/{award_id}` | `award_id`\* | — |
+| `espnWnbaAwards` | `core_v2` `/basketball/leagues/wnba/awards` | — | — |
+| `espnWnbaCalendar` | `site_v2` `/basketball/wnba/calendar` | — | — |
+| `espnWnbaCoach` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnWnbaCoachRecord` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnWnbaCoachSeason` | `core_v2` `/basketball/leagues/wnba/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnWnbaConferences` | `site_v2` `/basketball/wnba/groups` | — | — |
+| `espnWnbaDraft` | `site_v2` `/basketball/wnba/draft` | — | — |
+| `espnWnbaEvent` | `core_v2` `/basketball/leagues/wnba/events/{event_id}` | `event_id`\* | — |
+| `espnWnbaEventBroadcasts` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnWnbaEventCompetition` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnWnbaEventCompetitor` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitorLeaders` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitorLinescores` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitorRecord` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitorRoster` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitorStatistics` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWnbaEventCompetitors` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnWnbaEventLeaders` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnWnbaEventOdds` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnWnbaEventOfficialDetail` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnWnbaEventOfficials` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnWnbaEventPlay` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWnbaEventPlayPersonnel` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWnbaEventPlays` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnWnbaEventPowerindex` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnWnbaEventPredictor` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnWnbaEventProbabilities` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnWnbaEventPropbets` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnWnbaEventScoringplays` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnWnbaEventSituation` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnWnbaEventStatus` | `core_v2` `/basketball/leagues/wnba/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnWnbaEvents` | `core_v2` `/basketball/leagues/wnba/events` | — | `dates`, `limit` |
+| `espnWnbaFranchise` | `core_v2` `/basketball/leagues/wnba/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnWnbaFranchises` | `core_v2` `/basketball/leagues/wnba/franchises` | — | `limit` |
+| `espnWnbaInjuries` | `site_v2` `/basketball/wnba/injuries` | — | — |
+| `espnWnbaLeaders` | `web_v3` `/basketball/wnba/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnWnbaLeadersCore` | `core_v2` `/basketball/leagues/wnba/leaders` | — | — |
+| `espnWnbaLeagueNotes` | `core_v2` `/basketball/leagues/wnba/notes` | — | — |
+| `espnWnbaLeagueRoot` | `core_v2` `/basketball/leagues/wnba` | — | — |
+| `espnWnbaNews` | `site_v2` `/basketball/wnba/news` | — | `limit` |
+| `espnWnbaPosition` | `core_v2` `/basketball/leagues/wnba/positions/{position_id}` | `position_id`\* | — |
+| `espnWnbaPositions` | `core_v2` `/basketball/leagues/wnba/positions` | — | — |
+| `espnWnbaScoreboard` | `site_v2` `/basketball/wnba/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnWnbaSeasonAthletes` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnWnbaSeasonAwards` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/awards` | `season`\* | — |
+| `espnWnbaSeasonCoaches` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnWnbaSeasonDraft` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/draft` | `season`\* | — |
+| `espnWnbaSeasonDraftRoundPicks` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnWnbaSeasonFreeagents` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/freeagents` | `season`\* | — |
+| `espnWnbaSeasonFutures` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/futures` | `season`\* | — |
+| `espnWnbaSeasonGroup` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWnbaSeasonGroupChildren` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWnbaSeasonGroupTeams` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnWnbaSeasonGroups` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnWnbaSeasonInfo` | `core_v2` `/basketball/leagues/wnba/seasons/{season}` | `season`\* | — |
+| `espnWnbaSeasonPointer` | `core_v2` `/basketball/leagues/wnba/season` | — | — |
+| `espnWnbaSeasonPowerindex` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnWnbaSeasonPowerindexLeaders` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnWnbaSeasonTeam` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnWnbaSeasonTeams` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnWnbaSeasonType` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnWnbaSeasonTypeCorrections` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnWnbaSeasonTypeLeaders` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnWnbaSeasonTypes` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types` | `season`\* | — |
+| `espnWnbaSeasonWeek` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWnbaSeasonWeekEvents` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnWnbaSeasonWeeks` | `core_v2` `/basketball/leagues/wnba/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnWnbaSeasons` | `core_v2` `/basketball/leagues/wnba/seasons` | — | `limit` |
+| `espnWnbaStandings` | `site_v2_alt` `/basketball/wnba/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnWnbaStandingsCore` | `core_v2` `/basketball/leagues/wnba/standings` | — | — |
+| `espnWnbaStatisticsLeague` | `site_v2` `/basketball/wnba/statistics` | — | — |
+| `espnWnbaSummary` | `site_v2` `/basketball/wnba/summary` | — | `event_id` → `event` |
+| `espnWnbaTalentpicks` | `core_v2` `/basketball/leagues/wnba/talentpicks` | — | — |
+| `espnWnbaTeam` | `site_v2` `/basketball/wnba/teams/{team_id}` | `team_id`\* | — |
+| `espnWnbaTeamCore` | `core_v2` `/basketball/leagues/wnba/teams/{team_id}` | `team_id`\* | — |
+| `espnWnbaTeamDepthcharts` | `site_v2` `/basketball/wnba/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnWnbaTeamHistory` | `site_v2` `/basketball/wnba/teams/{team_id}/history` | `team_id`\* | — |
+| `espnWnbaTeamInjuries` | `site_v2` `/basketball/wnba/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnWnbaTeamLeaders` | `site_v2` `/basketball/wnba/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnWnbaTeamNews` | `site_v2` `/basketball/wnba/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnWnbaTeamRecord` | `site_v2` `/basketball/wnba/teams/{team_id}/record` | `team_id`\* | — |
+| `espnWnbaTeamRoster` | `site_v2` `/basketball/wnba/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnWnbaTeamSchedule` | `site_v2` `/basketball/wnba/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnWnbaTeamTransactions` | `site_v2` `/basketball/wnba/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnWnbaTeamsCore` | `core_v2` `/basketball/leagues/wnba/teams` | — | `limit` |
+| `espnWnbaTeamsSite` | `site_v2` `/basketball/wnba/teams` | — | `limit` |
+| `espnWnbaTournaments` | `core_v2` `/basketball/leagues/wnba/tournaments` | — | — |
+| `espnWnbaTransactions` | `site_v2` `/basketball/wnba/transactions` | — | — |
+| `espnWnbaVenue` | `core_v2` `/basketball/leagues/wnba/venues/{venue_id}` | `venue_id`\* | — |
+| `espnWnbaVenues` | `core_v2` `/basketball/leagues/wnba/venues` | — | `limit` |

--- a/docs/docs/reference/wwc.md
+++ b/docs/docs/reference/wwc.md
@@ -14,125 +14,125 @@ sidebar_position: 27
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.wwc.espn_wwc_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.wwc.espnWwc<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_wwc_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.wwc.espn_wwc_scoreboard({});
+await sdv.wwc.espnWwcScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_wwc_athlete_awards` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_wwc_athlete_bio` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_wwc_athlete_career_stats` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_wwc_athlete_contracts` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_wwc_athlete_core` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wwc_athlete_eventlog` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_wwc_athlete_gamelog` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_wwc_athlete_info` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_wwc_athlete_injuries` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_wwc_athlete_news` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_wwc_athlete_notes` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_wwc_athlete_overview` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_wwc_athlete_records` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_wwc_athlete_seasons` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_wwc_athlete_splits` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_wwc_athlete_statisticslog` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_wwc_athlete_stats` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_wwc_athlete_vs_athlete` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_wwc_athletes_index` | `core_v2` `/soccer/leagues/fifa.wwc/athletes` | — | `active`, `limit`, `page` |
-| `espn_wwc_award` | `core_v2` `/soccer/leagues/fifa.wwc/awards/{award_id}` | `award_id`\* | — |
-| `espn_wwc_awards` | `core_v2` `/soccer/leagues/fifa.wwc/awards` | — | — |
-| `espn_wwc_calendar` | `site_v2` `/soccer/fifa.wwc/calendar` | — | — |
-| `espn_wwc_coach` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_wwc_coach_record` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_wwc_coach_season` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_wwc_conferences` | `site_v2` `/soccer/fifa.wwc/groups` | — | — |
-| `espn_wwc_draft` | `site_v2` `/soccer/fifa.wwc/draft` | — | — |
-| `espn_wwc_event` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}` | `event_id`\* | — |
-| `espn_wwc_event_broadcasts` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_competition` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_competitor` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitor_leaders` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitor_linescores` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitor_record` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitor_roster` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitor_statistics` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_wwc_event_competitors` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_leaders` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_odds` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_official_detail` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_wwc_event_officials` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_play` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wwc_event_play_personnel` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_wwc_event_plays` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_wwc_event_powerindex` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_predictor` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_probabilities` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_wwc_event_propbets` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_scoringplays` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_situation` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_wwc_event_status` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_wwc_events` | `core_v2` `/soccer/leagues/fifa.wwc/events` | — | `dates`, `limit` |
-| `espn_wwc_franchise` | `core_v2` `/soccer/leagues/fifa.wwc/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_wwc_franchises` | `core_v2` `/soccer/leagues/fifa.wwc/franchises` | — | `limit` |
-| `espn_wwc_injuries` | `site_v2` `/soccer/fifa.wwc/injuries` | — | — |
-| `espn_wwc_leaders` | `web_v3` `/soccer/fifa.wwc/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_wwc_leaders_core` | `core_v2` `/soccer/leagues/fifa.wwc/leaders` | — | — |
-| `espn_wwc_league_notes` | `core_v2` `/soccer/leagues/fifa.wwc/notes` | — | — |
-| `espn_wwc_league_root` | `core_v2` `/soccer/leagues/fifa.wwc` | — | — |
-| `espn_wwc_news` | `site_v2` `/soccer/fifa.wwc/news` | — | `limit` |
-| `espn_wwc_position` | `core_v2` `/soccer/leagues/fifa.wwc/positions/{position_id}` | `position_id`\* | — |
-| `espn_wwc_positions` | `core_v2` `/soccer/leagues/fifa.wwc/positions` | — | — |
-| `espn_wwc_scoreboard` | `site_v2` `/soccer/fifa.wwc/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_wwc_season_athletes` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_wwc_season_awards` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/awards` | `season`\* | — |
-| `espn_wwc_season_coaches` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_wwc_season_draft` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/draft` | `season`\* | — |
-| `espn_wwc_season_draft_round_picks` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_wwc_season_freeagents` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_wwc_season_futures` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/futures` | `season`\* | — |
-| `espn_wwc_season_group` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wwc_season_group_children` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_wwc_season_group_teams` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_wwc_season_groups` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_wwc_season_info` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}` | `season`\* | — |
-| `espn_wwc_season_pointer` | `core_v2` `/soccer/leagues/fifa.wwc/season` | — | — |
-| `espn_wwc_season_powerindex` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_wwc_season_powerindex_leaders` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_wwc_season_team` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_wwc_season_teams` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_wwc_season_type` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_wwc_season_type_corrections` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_wwc_season_type_leaders` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_wwc_season_types` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types` | `season`\* | — |
-| `espn_wwc_season_week` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_wwc_season_week_events` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_wwc_season_weeks` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_wwc_seasons` | `core_v2` `/soccer/leagues/fifa.wwc/seasons` | — | `limit` |
-| `espn_wwc_standings` | `site_v2_alt` `/soccer/fifa.wwc/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_wwc_standings_core` | `core_v2` `/soccer/leagues/fifa.wwc/standings` | — | — |
-| `espn_wwc_statistics_league` | `site_v2` `/soccer/fifa.wwc/statistics` | — | — |
-| `espn_wwc_summary` | `site_v2` `/soccer/fifa.wwc/summary` | — | `event_id` → `event` |
-| `espn_wwc_talentpicks` | `core_v2` `/soccer/leagues/fifa.wwc/talentpicks` | — | — |
-| `espn_wwc_team` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}` | `team_id`\* | — |
-| `espn_wwc_team_core` | `core_v2` `/soccer/leagues/fifa.wwc/teams/{team_id}` | `team_id`\* | — |
-| `espn_wwc_team_depthcharts` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_wwc_team_history` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_wwc_team_injuries` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_wwc_team_leaders` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_wwc_team_news` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_wwc_team_record` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_wwc_team_roster` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_wwc_team_schedule` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_wwc_team_transactions` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_wwc_teams_core` | `core_v2` `/soccer/leagues/fifa.wwc/teams` | — | `limit` |
-| `espn_wwc_teams_site` | `site_v2` `/soccer/fifa.wwc/teams` | — | `limit` |
-| `espn_wwc_tournaments` | `core_v2` `/soccer/leagues/fifa.wwc/tournaments` | — | — |
-| `espn_wwc_transactions` | `site_v2` `/soccer/fifa.wwc/transactions` | — | — |
-| `espn_wwc_venue` | `core_v2` `/soccer/leagues/fifa.wwc/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_wwc_venues` | `core_v2` `/soccer/leagues/fifa.wwc/venues` | — | `limit` |
+| `espnWwcAthleteAwards` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnWwcAthleteBio` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnWwcAthleteCareerStats` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnWwcAthleteContracts` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnWwcAthleteCore` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWwcAthleteEventlog` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnWwcAthleteGamelog` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnWwcAthleteInfo` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnWwcAthleteInjuries` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnWwcAthleteNews` | `site_v2` `/soccer/fifa.wwc/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnWwcAthleteNotes` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnWwcAthleteOverview` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnWwcAthleteRecords` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnWwcAthleteSeasons` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnWwcAthleteSplits` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnWwcAthleteStatisticslog` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnWwcAthleteStats` | `web_v3` `/soccer/fifa.wwc/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnWwcAthleteVsAthlete` | `core_v2` `/soccer/leagues/fifa.wwc/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnWwcAthletesIndex` | `core_v2` `/soccer/leagues/fifa.wwc/athletes` | — | `active`, `limit`, `page` |
+| `espnWwcAward` | `core_v2` `/soccer/leagues/fifa.wwc/awards/{award_id}` | `award_id`\* | — |
+| `espnWwcAwards` | `core_v2` `/soccer/leagues/fifa.wwc/awards` | — | — |
+| `espnWwcCalendar` | `site_v2` `/soccer/fifa.wwc/calendar` | — | — |
+| `espnWwcCoach` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnWwcCoachRecord` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnWwcCoachSeason` | `core_v2` `/soccer/leagues/fifa.wwc/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnWwcConferences` | `site_v2` `/soccer/fifa.wwc/groups` | — | — |
+| `espnWwcDraft` | `site_v2` `/soccer/fifa.wwc/draft` | — | — |
+| `espnWwcEvent` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}` | `event_id`\* | — |
+| `espnWwcEventBroadcasts` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnWwcEventCompetition` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnWwcEventCompetitor` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitorLeaders` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitorLinescores` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitorRecord` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitorRoster` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitorStatistics` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnWwcEventCompetitors` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnWwcEventLeaders` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnWwcEventOdds` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnWwcEventOfficialDetail` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnWwcEventOfficials` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnWwcEventPlay` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWwcEventPlayPersonnel` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnWwcEventPlays` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnWwcEventPowerindex` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnWwcEventPredictor` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnWwcEventProbabilities` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnWwcEventPropbets` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnWwcEventScoringplays` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnWwcEventSituation` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnWwcEventStatus` | `core_v2` `/soccer/leagues/fifa.wwc/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnWwcEvents` | `core_v2` `/soccer/leagues/fifa.wwc/events` | — | `dates`, `limit` |
+| `espnWwcFranchise` | `core_v2` `/soccer/leagues/fifa.wwc/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnWwcFranchises` | `core_v2` `/soccer/leagues/fifa.wwc/franchises` | — | `limit` |
+| `espnWwcInjuries` | `site_v2` `/soccer/fifa.wwc/injuries` | — | — |
+| `espnWwcLeaders` | `web_v3` `/soccer/fifa.wwc/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnWwcLeadersCore` | `core_v2` `/soccer/leagues/fifa.wwc/leaders` | — | — |
+| `espnWwcLeagueNotes` | `core_v2` `/soccer/leagues/fifa.wwc/notes` | — | — |
+| `espnWwcLeagueRoot` | `core_v2` `/soccer/leagues/fifa.wwc` | — | — |
+| `espnWwcNews` | `site_v2` `/soccer/fifa.wwc/news` | — | `limit` |
+| `espnWwcPosition` | `core_v2` `/soccer/leagues/fifa.wwc/positions/{position_id}` | `position_id`\* | — |
+| `espnWwcPositions` | `core_v2` `/soccer/leagues/fifa.wwc/positions` | — | — |
+| `espnWwcScoreboard` | `site_v2` `/soccer/fifa.wwc/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnWwcSeasonAthletes` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnWwcSeasonAwards` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/awards` | `season`\* | — |
+| `espnWwcSeasonCoaches` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnWwcSeasonDraft` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/draft` | `season`\* | — |
+| `espnWwcSeasonDraftRoundPicks` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnWwcSeasonFreeagents` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/freeagents` | `season`\* | — |
+| `espnWwcSeasonFutures` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/futures` | `season`\* | — |
+| `espnWwcSeasonGroup` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWwcSeasonGroupChildren` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnWwcSeasonGroupTeams` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnWwcSeasonGroups` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnWwcSeasonInfo` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}` | `season`\* | — |
+| `espnWwcSeasonPointer` | `core_v2` `/soccer/leagues/fifa.wwc/season` | — | — |
+| `espnWwcSeasonPowerindex` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnWwcSeasonPowerindexLeaders` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnWwcSeasonTeam` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnWwcSeasonTeams` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnWwcSeasonType` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnWwcSeasonTypeCorrections` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnWwcSeasonTypeLeaders` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnWwcSeasonTypes` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types` | `season`\* | — |
+| `espnWwcSeasonWeek` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnWwcSeasonWeekEvents` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnWwcSeasonWeeks` | `core_v2` `/soccer/leagues/fifa.wwc/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnWwcSeasons` | `core_v2` `/soccer/leagues/fifa.wwc/seasons` | — | `limit` |
+| `espnWwcStandings` | `site_v2_alt` `/soccer/fifa.wwc/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnWwcStandingsCore` | `core_v2` `/soccer/leagues/fifa.wwc/standings` | — | — |
+| `espnWwcStatisticsLeague` | `site_v2` `/soccer/fifa.wwc/statistics` | — | — |
+| `espnWwcSummary` | `site_v2` `/soccer/fifa.wwc/summary` | — | `event_id` → `event` |
+| `espnWwcTalentpicks` | `core_v2` `/soccer/leagues/fifa.wwc/talentpicks` | — | — |
+| `espnWwcTeam` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}` | `team_id`\* | — |
+| `espnWwcTeamCore` | `core_v2` `/soccer/leagues/fifa.wwc/teams/{team_id}` | `team_id`\* | — |
+| `espnWwcTeamDepthcharts` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnWwcTeamHistory` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/history` | `team_id`\* | — |
+| `espnWwcTeamInjuries` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnWwcTeamLeaders` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnWwcTeamNews` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnWwcTeamRecord` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/record` | `team_id`\* | — |
+| `espnWwcTeamRoster` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnWwcTeamSchedule` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnWwcTeamTransactions` | `site_v2` `/soccer/fifa.wwc/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnWwcTeamsCore` | `core_v2` `/soccer/leagues/fifa.wwc/teams` | — | `limit` |
+| `espnWwcTeamsSite` | `site_v2` `/soccer/fifa.wwc/teams` | — | `limit` |
+| `espnWwcTournaments` | `core_v2` `/soccer/leagues/fifa.wwc/tournaments` | — | — |
+| `espnWwcTransactions` | `site_v2` `/soccer/fifa.wwc/transactions` | — | — |
+| `espnWwcVenue` | `core_v2` `/soccer/leagues/fifa.wwc/venues/{venue_id}` | `venue_id`\* | — |
+| `espnWwcVenues` | `core_v2` `/soccer/leagues/fifa.wwc/venues` | — | `limit` |

--- a/docs/docs/reference/xfl.md
+++ b/docs/docs/reference/xfl.md
@@ -14,125 +14,125 @@ sidebar_position: 14
 - **scopes:** `universal`
 - **wrappers:** 110
 
-Every endpoint is called as `sdv.xfl.espn_xfl_<endpoint>(params)`. Parameters accept snake_case or camelCase. Required path params are marked \*.
+Every endpoint is called as `sdv.xfl.espnXfl<Endpoint>(params)`. Each method is also available under its snake_case name (`espn_xfl_<endpoint>`) for parity with the Python / R packages. Parameters accept snake_case or camelCase. Required path params are marked \*.
 
 ```js
 import sdv from 'sportsdataverse';
 
-await sdv.xfl.espn_xfl_scoreboard({});
+await sdv.xfl.espnXflScoreboard({});
 ```
 
 ## Universal endpoints
 
 | Method | HTTP | Path params | Query params |
 |---|---|---|---|
-| `espn_xfl_athlete_awards` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
-| `espn_xfl_athlete_bio` | `site_v2` `/football/xfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
-| `espn_xfl_athlete_career_stats` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
-| `espn_xfl_athlete_contracts` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
-| `espn_xfl_athlete_core` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_xfl_athlete_eventlog` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
-| `espn_xfl_athlete_gamelog` | `web_v3` `/football/xfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
-| `espn_xfl_athlete_info` | `site_v2` `/football/xfl/athletes/{athlete_id}` | `athlete_id`\* | — |
-| `espn_xfl_athlete_injuries` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
-| `espn_xfl_athlete_news` | `site_v2` `/football/xfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
-| `espn_xfl_athlete_notes` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
-| `espn_xfl_athlete_overview` | `web_v3` `/football/xfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
-| `espn_xfl_athlete_records` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
-| `espn_xfl_athlete_seasons` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
-| `espn_xfl_athlete_splits` | `web_v3` `/football/xfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
-| `espn_xfl_athlete_statisticslog` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
-| `espn_xfl_athlete_stats` | `web_v3` `/football/xfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
-| `espn_xfl_athlete_vs_athlete` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
-| `espn_xfl_athletes_index` | `core_v2` `/football/leagues/xfl/athletes` | — | `active`, `limit`, `page` |
-| `espn_xfl_award` | `core_v2` `/football/leagues/xfl/awards/{award_id}` | `award_id`\* | — |
-| `espn_xfl_awards` | `core_v2` `/football/leagues/xfl/awards` | — | — |
-| `espn_xfl_calendar` | `site_v2` `/football/xfl/calendar` | — | — |
-| `espn_xfl_coach` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}` | `coach_id`\* | — |
-| `espn_xfl_coach_record` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
-| `espn_xfl_coach_season` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
-| `espn_xfl_conferences` | `site_v2` `/football/xfl/groups` | — | — |
-| `espn_xfl_draft` | `site_v2` `/football/xfl/draft` | — | — |
-| `espn_xfl_event` | `core_v2` `/football/leagues/xfl/events/{event_id}` | `event_id`\* | — |
-| `espn_xfl_event_broadcasts` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_competition` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_competitor` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitor_leaders` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitor_linescores` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitor_record` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitor_roster` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitor_statistics` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
-| `espn_xfl_event_competitors` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_leaders` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_odds` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_official_detail` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
-| `espn_xfl_event_officials` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_play` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_xfl_event_play_personnel` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
-| `espn_xfl_event_plays` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
-| `espn_xfl_event_powerindex` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_predictor` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_probabilities` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
-| `espn_xfl_event_propbets` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_scoringplays` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_situation` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
-| `espn_xfl_event_status` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
-| `espn_xfl_events` | `core_v2` `/football/leagues/xfl/events` | — | `dates`, `limit` |
-| `espn_xfl_franchise` | `core_v2` `/football/leagues/xfl/franchises/{franchise_id}` | `franchise_id`\* | — |
-| `espn_xfl_franchises` | `core_v2` `/football/leagues/xfl/franchises` | — | `limit` |
-| `espn_xfl_injuries` | `site_v2` `/football/xfl/injuries` | — | — |
-| `espn_xfl_leaders` | `web_v3` `/football/xfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
-| `espn_xfl_leaders_core` | `core_v2` `/football/leagues/xfl/leaders` | — | — |
-| `espn_xfl_league_notes` | `core_v2` `/football/leagues/xfl/notes` | — | — |
-| `espn_xfl_league_root` | `core_v2` `/football/leagues/xfl` | — | — |
-| `espn_xfl_news` | `site_v2` `/football/xfl/news` | — | `limit` |
-| `espn_xfl_position` | `core_v2` `/football/leagues/xfl/positions/{position_id}` | `position_id`\* | — |
-| `espn_xfl_positions` | `core_v2` `/football/leagues/xfl/positions` | — | — |
-| `espn_xfl_scoreboard` | `site_v2` `/football/xfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
-| `espn_xfl_season_athletes` | `core_v2` `/football/leagues/xfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
-| `espn_xfl_season_awards` | `core_v2` `/football/leagues/xfl/seasons/{season}/awards` | `season`\* | — |
-| `espn_xfl_season_coaches` | `core_v2` `/football/leagues/xfl/seasons/{season}/coaches` | `season`\* | `limit` |
-| `espn_xfl_season_draft` | `core_v2` `/football/leagues/xfl/seasons/{season}/draft` | `season`\* | — |
-| `espn_xfl_season_draft_round_picks` | `core_v2` `/football/leagues/xfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
-| `espn_xfl_season_freeagents` | `core_v2` `/football/leagues/xfl/seasons/{season}/freeagents` | `season`\* | — |
-| `espn_xfl_season_futures` | `core_v2` `/football/leagues/xfl/seasons/{season}/futures` | `season`\* | — |
-| `espn_xfl_season_group` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_xfl_season_group_children` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
-| `espn_xfl_season_group_teams` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
-| `espn_xfl_season_groups` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
-| `espn_xfl_season_info` | `core_v2` `/football/leagues/xfl/seasons/{season}` | `season`\* | — |
-| `espn_xfl_season_pointer` | `core_v2` `/football/leagues/xfl/season` | — | — |
-| `espn_xfl_season_powerindex` | `core_v2` `/football/leagues/xfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
-| `espn_xfl_season_powerindex_leaders` | `core_v2` `/football/leagues/xfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
-| `espn_xfl_season_team` | `core_v2` `/football/leagues/xfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
-| `espn_xfl_season_teams` | `core_v2` `/football/leagues/xfl/seasons/{season}/teams` | `season`\* | `limit` |
-| `espn_xfl_season_type` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
-| `espn_xfl_season_type_corrections` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
-| `espn_xfl_season_type_leaders` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
-| `espn_xfl_season_types` | `core_v2` `/football/leagues/xfl/seasons/{season}/types` | `season`\* | — |
-| `espn_xfl_season_week` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
-| `espn_xfl_season_week_events` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
-| `espn_xfl_season_weeks` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
-| `espn_xfl_seasons` | `core_v2` `/football/leagues/xfl/seasons` | — | `limit` |
-| `espn_xfl_standings` | `site_v2_alt` `/football/xfl/standings` | — | `season`, `group`, `standings_type` → `type` |
-| `espn_xfl_standings_core` | `core_v2` `/football/leagues/xfl/standings` | — | — |
-| `espn_xfl_statistics_league` | `site_v2` `/football/xfl/statistics` | — | — |
-| `espn_xfl_summary` | `site_v2` `/football/xfl/summary` | — | `event_id` → `event` |
-| `espn_xfl_talentpicks` | `core_v2` `/football/leagues/xfl/talentpicks` | — | — |
-| `espn_xfl_team` | `site_v2` `/football/xfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_xfl_team_core` | `core_v2` `/football/leagues/xfl/teams/{team_id}` | `team_id`\* | — |
-| `espn_xfl_team_depthcharts` | `site_v2` `/football/xfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
-| `espn_xfl_team_history` | `site_v2` `/football/xfl/teams/{team_id}/history` | `team_id`\* | — |
-| `espn_xfl_team_injuries` | `site_v2` `/football/xfl/teams/{team_id}/injuries` | `team_id`\* | — |
-| `espn_xfl_team_leaders` | `site_v2` `/football/xfl/teams/{team_id}/leaders` | `team_id`\* | — |
-| `espn_xfl_team_news` | `site_v2` `/football/xfl/teams/{team_id}/news` | `team_id`\* | `limit` |
-| `espn_xfl_team_record` | `site_v2` `/football/xfl/teams/{team_id}/record` | `team_id`\* | — |
-| `espn_xfl_team_roster` | `site_v2` `/football/xfl/teams/{team_id}/roster` | `team_id`\* | — |
-| `espn_xfl_team_schedule` | `site_v2` `/football/xfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
-| `espn_xfl_team_transactions` | `site_v2` `/football/xfl/teams/{team_id}/transactions` | `team_id`\* | — |
-| `espn_xfl_teams_core` | `core_v2` `/football/leagues/xfl/teams` | — | `limit` |
-| `espn_xfl_teams_site` | `site_v2` `/football/xfl/teams` | — | `limit` |
-| `espn_xfl_tournaments` | `core_v2` `/football/leagues/xfl/tournaments` | — | — |
-| `espn_xfl_transactions` | `site_v2` `/football/xfl/transactions` | — | — |
-| `espn_xfl_venue` | `core_v2` `/football/leagues/xfl/venues/{venue_id}` | `venue_id`\* | — |
-| `espn_xfl_venues` | `core_v2` `/football/leagues/xfl/venues` | — | `limit` |
+| `espnXflAthleteAwards` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/awards` | `athlete_id`\* | — |
+| `espnXflAthleteBio` | `site_v2` `/football/xfl/athletes/{athlete_id}/bio` | `athlete_id`\* | — |
+| `espnXflAthleteCareerStats` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/statistics[/{stat_type}]` | `athlete_id`\*, `stat_type` | — |
+| `espnXflAthleteContracts` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/contracts` | `athlete_id`\* | — |
+| `espnXflAthleteCore` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnXflAthleteEventlog` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/eventlog` | `athlete_id`\* | — |
+| `espnXflAthleteGamelog` | `web_v3` `/football/xfl/athletes/{athlete_id}/gamelog` | `athlete_id`\* | `season` |
+| `espnXflAthleteInfo` | `site_v2` `/football/xfl/athletes/{athlete_id}` | `athlete_id`\* | — |
+| `espnXflAthleteInjuries` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/injuries` | `athlete_id`\* | — |
+| `espnXflAthleteNews` | `site_v2` `/football/xfl/athletes/{athlete_id}/news` | `athlete_id`\* | — |
+| `espnXflAthleteNotes` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/notes` | `athlete_id`\* | — |
+| `espnXflAthleteOverview` | `web_v3` `/football/xfl/athletes/{athlete_id}/overview` | `athlete_id`\* | — |
+| `espnXflAthleteRecords` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/records` | `athlete_id`\* | — |
+| `espnXflAthleteSeasons` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/seasons` | `athlete_id`\* | — |
+| `espnXflAthleteSplits` | `web_v3` `/football/xfl/athletes/{athlete_id}/splits` | `athlete_id`\* | `season` |
+| `espnXflAthleteStatisticslog` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/statisticslog` | `athlete_id`\* | — |
+| `espnXflAthleteStats` | `web_v3` `/football/xfl/athletes/{athlete_id}/stats` | `athlete_id`\* | `season` |
+| `espnXflAthleteVsAthlete` | `core_v2` `/football/leagues/xfl/athletes/{athlete_id}/vsathlete/{opp_id}` | `athlete_id`\*, `opp_id`\* | — |
+| `espnXflAthletesIndex` | `core_v2` `/football/leagues/xfl/athletes` | — | `active`, `limit`, `page` |
+| `espnXflAward` | `core_v2` `/football/leagues/xfl/awards/{award_id}` | `award_id`\* | — |
+| `espnXflAwards` | `core_v2` `/football/leagues/xfl/awards` | — | — |
+| `espnXflCalendar` | `site_v2` `/football/xfl/calendar` | — | — |
+| `espnXflCoach` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}` | `coach_id`\* | — |
+| `espnXflCoachRecord` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}/record/{record_type}` | `coach_id`\*, `record_type` | — |
+| `espnXflCoachSeason` | `core_v2` `/football/leagues/xfl/coaches/{coach_id}/seasons/{season}` | `coach_id`\*, `season`\* | — |
+| `espnXflConferences` | `site_v2` `/football/xfl/groups` | — | — |
+| `espnXflDraft` | `site_v2` `/football/xfl/draft` | — | — |
+| `espnXflEvent` | `core_v2` `/football/leagues/xfl/events/{event_id}` | `event_id`\* | — |
+| `espnXflEventBroadcasts` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/broadcasts` | `event_id`\*, `cid` | — |
+| `espnXflEventCompetition` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}` | `event_id`\*, `cid` | — |
+| `espnXflEventCompetitor` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitorLeaders` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/leaders` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitorLinescores` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/linescores` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitorRecord` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/record` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitorRoster` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/roster` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitorStatistics` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors/{team_id}/statistics` | `event_id`\*, `team_id`\*, `cid` | — |
+| `espnXflEventCompetitors` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/competitors` | `event_id`\*, `cid` | — |
+| `espnXflEventLeaders` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/leaders` | `event_id`\*, `cid` | — |
+| `espnXflEventOdds` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/odds` | `event_id`\*, `cid` | — |
+| `espnXflEventOfficialDetail` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/officials/{official_id}` | `event_id`\*, `official_id`\*, `cid` | — |
+| `espnXflEventOfficials` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/officials` | `event_id`\*, `cid` | — |
+| `espnXflEventPlay` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays/{play_id}` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnXflEventPlayPersonnel` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays/{play_id}/personnel` | `event_id`\*, `play_id`\*, `cid` | — |
+| `espnXflEventPlays` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/plays` | `event_id`\*, `cid` | `limit` |
+| `espnXflEventPowerindex` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/powerindex` | `event_id`\*, `cid` | — |
+| `espnXflEventPredictor` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/predictor` | `event_id`\*, `cid` | — |
+| `espnXflEventProbabilities` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/probabilities` | `event_id`\*, `cid` | `limit` |
+| `espnXflEventPropbets` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/propbets` | `event_id`\*, `cid` | — |
+| `espnXflEventScoringplays` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/scoringplays` | `event_id`\*, `cid` | — |
+| `espnXflEventSituation` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/situation` | `event_id`\*, `cid` | — |
+| `espnXflEventStatus` | `core_v2` `/football/leagues/xfl/events/{event_id}/competitions/{cid}/status` | `event_id`\*, `cid` | — |
+| `espnXflEvents` | `core_v2` `/football/leagues/xfl/events` | — | `dates`, `limit` |
+| `espnXflFranchise` | `core_v2` `/football/leagues/xfl/franchises/{franchise_id}` | `franchise_id`\* | — |
+| `espnXflFranchises` | `core_v2` `/football/leagues/xfl/franchises` | — | `limit` |
+| `espnXflInjuries` | `site_v2` `/football/xfl/injuries` | — | — |
+| `espnXflLeaders` | `web_v3` `/football/xfl/statistics/byathlete` | — | `category`, `season`, `season_type` → `seasontype`, `limit`, `page`, `sort` |
+| `espnXflLeadersCore` | `core_v2` `/football/leagues/xfl/leaders` | — | — |
+| `espnXflLeagueNotes` | `core_v2` `/football/leagues/xfl/notes` | — | — |
+| `espnXflLeagueRoot` | `core_v2` `/football/leagues/xfl` | — | — |
+| `espnXflNews` | `site_v2` `/football/xfl/news` | — | `limit` |
+| `espnXflPosition` | `core_v2` `/football/leagues/xfl/positions/{position_id}` | `position_id`\* | — |
+| `espnXflPositions` | `core_v2` `/football/leagues/xfl/positions` | — | — |
+| `espnXflScoreboard` | `site_v2` `/football/xfl/scoreboard` | — | `dates`, `week`, `season_type` → `seasontype`, `groups`, `limit` |
+| `espnXflSeasonAthletes` | `core_v2` `/football/leagues/xfl/seasons/{season}/athletes` | `season`\* | `limit`, `page` |
+| `espnXflSeasonAwards` | `core_v2` `/football/leagues/xfl/seasons/{season}/awards` | `season`\* | — |
+| `espnXflSeasonCoaches` | `core_v2` `/football/leagues/xfl/seasons/{season}/coaches` | `season`\* | `limit` |
+| `espnXflSeasonDraft` | `core_v2` `/football/leagues/xfl/seasons/{season}/draft` | `season`\* | — |
+| `espnXflSeasonDraftRoundPicks` | `core_v2` `/football/leagues/xfl/seasons/{season}/draft/rounds/{round_num}/picks` | `season`\*, `round_num`\* | — |
+| `espnXflSeasonFreeagents` | `core_v2` `/football/leagues/xfl/seasons/{season}/freeagents` | `season`\* | — |
+| `espnXflSeasonFutures` | `core_v2` `/football/leagues/xfl/seasons/{season}/futures` | `season`\* | — |
+| `espnXflSeasonGroup` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnXflSeasonGroupChildren` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/children` | `season`\*, `season_type`\*, `group_id`\* | — |
+| `espnXflSeasonGroupTeams` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups/{group_id}/teams` | `season`\*, `season_type`\*, `group_id`\* | `limit` |
+| `espnXflSeasonGroups` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/groups` | `season`\*, `season_type`\* | — |
+| `espnXflSeasonInfo` | `core_v2` `/football/leagues/xfl/seasons/{season}` | `season`\* | — |
+| `espnXflSeasonPointer` | `core_v2` `/football/leagues/xfl/season` | — | — |
+| `espnXflSeasonPowerindex` | `core_v2` `/football/leagues/xfl/seasons/{season}/powerindex[/{team_id}]` | `season`\*, `team_id` | — |
+| `espnXflSeasonPowerindexLeaders` | `core_v2` `/football/leagues/xfl/seasons/{season}/powerindex/leaders` | `season`\* | — |
+| `espnXflSeasonTeam` | `core_v2` `/football/leagues/xfl/seasons/{season}/teams/{team_id}` | `season`\*, `team_id`\* | — |
+| `espnXflSeasonTeams` | `core_v2` `/football/leagues/xfl/seasons/{season}/teams` | `season`\* | `limit` |
+| `espnXflSeasonType` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}` | `season`\*, `season_type`\* | — |
+| `espnXflSeasonTypeCorrections` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/corrections` | `season`\*, `season_type`\* | — |
+| `espnXflSeasonTypeLeaders` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/leaders` | `season`\*, `season_type`\* | — |
+| `espnXflSeasonTypes` | `core_v2` `/football/leagues/xfl/seasons/{season}/types` | `season`\* | — |
+| `espnXflSeasonWeek` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks/{week}` | `season`\*, `season_type`\*, `week`\* | — |
+| `espnXflSeasonWeekEvents` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks/{week}/events` | `season`\*, `season_type`\*, `week`\* | `limit` |
+| `espnXflSeasonWeeks` | `core_v2` `/football/leagues/xfl/seasons/{season}/types/{season_type}/weeks` | `season`\*, `season_type`\* | — |
+| `espnXflSeasons` | `core_v2` `/football/leagues/xfl/seasons` | — | `limit` |
+| `espnXflStandings` | `site_v2_alt` `/football/xfl/standings` | — | `season`, `group`, `standings_type` → `type` |
+| `espnXflStandingsCore` | `core_v2` `/football/leagues/xfl/standings` | — | — |
+| `espnXflStatisticsLeague` | `site_v2` `/football/xfl/statistics` | — | — |
+| `espnXflSummary` | `site_v2` `/football/xfl/summary` | — | `event_id` → `event` |
+| `espnXflTalentpicks` | `core_v2` `/football/leagues/xfl/talentpicks` | — | — |
+| `espnXflTeam` | `site_v2` `/football/xfl/teams/{team_id}` | `team_id`\* | — |
+| `espnXflTeamCore` | `core_v2` `/football/leagues/xfl/teams/{team_id}` | `team_id`\* | — |
+| `espnXflTeamDepthcharts` | `site_v2` `/football/xfl/teams/{team_id}/depthcharts` | `team_id`\* | — |
+| `espnXflTeamHistory` | `site_v2` `/football/xfl/teams/{team_id}/history` | `team_id`\* | — |
+| `espnXflTeamInjuries` | `site_v2` `/football/xfl/teams/{team_id}/injuries` | `team_id`\* | — |
+| `espnXflTeamLeaders` | `site_v2` `/football/xfl/teams/{team_id}/leaders` | `team_id`\* | — |
+| `espnXflTeamNews` | `site_v2` `/football/xfl/teams/{team_id}/news` | `team_id`\* | `limit` |
+| `espnXflTeamRecord` | `site_v2` `/football/xfl/teams/{team_id}/record` | `team_id`\* | — |
+| `espnXflTeamRoster` | `site_v2` `/football/xfl/teams/{team_id}/roster` | `team_id`\* | — |
+| `espnXflTeamSchedule` | `site_v2` `/football/xfl/teams/{team_id}/schedule` | `team_id`\* | `season` |
+| `espnXflTeamTransactions` | `site_v2` `/football/xfl/teams/{team_id}/transactions` | `team_id`\* | — |
+| `espnXflTeamsCore` | `core_v2` `/football/leagues/xfl/teams` | — | `limit` |
+| `espnXflTeamsSite` | `site_v2` `/football/xfl/teams` | — | `limit` |
+| `espnXflTournaments` | `core_v2` `/football/leagues/xfl/tournaments` | — | — |
+| `espnXflTransactions` | `site_v2` `/football/xfl/transactions` | — | — |
+| `espnXflVenue` | `core_v2` `/football/leagues/xfl/venues/{venue_id}` | `venue_id`\* | — |
+| `espnXflVenues` | `core_v2` `/football/leagues/xfl/venues` | — | `limit` |

--- a/docs/docs/tutorials/cross-league.md
+++ b/docs/docs/tutorials/cross-league.md
@@ -17,14 +17,15 @@ the same:
 ```js
 import sdv from "sportsdataverse";
 
-await sdv.nba.espn_nba_scoreboard({});
-await sdv.nfl.espn_nfl_scoreboard({ week: 1, season_type: 2 });
-await sdv.nhl.espn_nhl_scoreboard({});
-await sdv.mlb.espn_mlb_scoreboard({});
-await sdv.wnba.espn_wnba_scoreboard({});
+await sdv.nba.espnNbaScoreboard({});
+await sdv.nfl.espnNflScoreboard({ week: 1, season_type: 2 });
+await sdv.nhl.espnNhlScoreboard({});
+await sdv.mlb.espnMlbScoreboard({});
+await sdv.wnba.espnWnbaScoreboard({});
 ```
 
-That makes it trivial to write league-agnostic helpers:
+That makes it trivial to write league-agnostic helpers. The snake_case alias is
+handy here — it composes cleanly from the league string:
 
 ```js
 async function gamesToday(league) {
@@ -49,12 +50,12 @@ league exposes an endpoint only when the scope matches:
 | `football` | NFL, CFB, UFL | drive/play detail, betting endpoints |
 | `mlb` | MLB | baseball-specific feeds |
 
-So `espn_cfb_rankings` exists (CFB carries the `ncaa` scope) but `espn_nba_rankings`
+So `espnCfbRankings` exists (CFB carries the `ncaa` scope) but `espnNbaRankings`
 does not:
 
 ```js
-typeof sdv.cfb.espn_cfb_rankings;   // 'function'
-typeof sdv.nba.espn_nba_rankings;   // 'undefined'
+typeof sdv.cfb.espnCfbRankings;   // 'function'
+typeof sdv.nba.espnNbaRankings;   // 'undefined'
 ```
 
 ## Multi-league sports: soccer & cricket
@@ -63,16 +64,16 @@ Soccer and cricket cover many competitions under one namespace, so they take an
 extra **`league`** slug:
 
 ```js
-await sdv.soccer.espn_soccer_scoreboard({ league: "eng.1" });  // Premier League
-await sdv.soccer.espn_soccer_scoreboard({ league: "esp.1" });  // La Liga
-await sdv.soccer.espn_soccer_standings({ league: "ita.1" });   // Serie A
+await sdv.soccer.espnSoccerScoreboard({ league: "eng.1" });  // Premier League
+await sdv.soccer.espnSoccerScoreboard({ league: "esp.1" });  // La Liga
+await sdv.soccer.espnSoccerStandings({ league: "ita.1" });   // Serie A
 ```
 
 There are also convenience namespaces for the big competitions (`epl`, `laliga`,
 `seriea`, `bundesliga`, `ligue1`, `ucl`, …) that pin the slug for you:
 
 ```js
-await sdv.epl.espn_epl_scoreboard({});      // same as soccer + { league: 'eng.1' }
+await sdv.epl.espnEplScoreboard({});      // same as soccer + { league: 'eng.1' }
 ```
 
 ## Introspecting the surface at runtime
@@ -89,8 +90,8 @@ LEAGUES.map((l) => ({ prefix: l.prefix, sport: l.sport, league: l.league }));
 // Every endpoint definition (116 of them)
 WRAPPERS.map((w) => w.short);
 
-// Every endpoint available on a given league
-Object.keys(sdv.nfl).filter((k) => k.startsWith("espn_nfl_"));
+// Every endpoint available on a given league (camelCase canonical names)
+Object.keys(sdv.nfl).filter((k) => k.startsWith("espnNfl"));
 ```
 
 ## Next steps

--- a/docs/docs/tutorials/quickstart.md
+++ b/docs/docs/tutorials/quickstart.md
@@ -27,7 +27,7 @@ Create `demo.js`:
 ```js
 import sdv from "sportsdataverse";
 
-const board = await sdv.nba.espn_nba_scoreboard({});
+const board = await sdv.nba.espnNbaScoreboard({});
 console.log(`${board.events?.length ?? 0} NBA games on the board today`);
 ```
 
@@ -40,26 +40,27 @@ it however you like (or hand it straight to your own parser).
 
 ## 3. The one naming rule
 
-Cross-league endpoints are always **`espn_<league>_<endpoint>`** on the league's
-namespace:
+Cross-league endpoints are always **`espn<League><Endpoint>`** (camelCase) on the
+league's namespace:
 
 ```js
-await sdv.nba.espn_nba_scoreboard({});
-await sdv.nfl.espn_nfl_summary({ event_id: 401671789 });
-await sdv.nhl.espn_nhl_team_roster({ team_id: 10 });
+await sdv.nba.espnNbaScoreboard({});
+await sdv.nfl.espnNflSummary({ event_id: 401671789 });
+await sdv.nhl.espnNhlTeamRoster({ team_id: 10 });
 ```
 
-`<league>` is the namespace (`nba`, `nfl`, `nhl`, `mlb`, `wnba`, `mbb`, `wbb`,
-`cfb`, plus soccer/cricket/UFL and more). `<endpoint>` is the data you want
-(`scoreboard`, `summary`, `team_roster`, `standings`, …).
+`<League>` is the namespace (`nba`, `nfl`, `nhl`, `mlb`, `wnba`, `mbb`, `wbb`,
+`cfb`, plus soccer/cricket/UFL and more). `<Endpoint>` is the data you want
+(`Scoreboard`, `Summary`, `TeamRoster`, `Standings`, …). Every method also has a
+snake_case alias (`espn_nfl_summary`) for parity with the Python / R packages.
 
 ## 4. Parameters
 
 Pass parameters as a single object. Both **snake_case and camelCase** work:
 
 ```js
-await sdv.nfl.espn_nfl_team_schedule({ team_id: 12, season: 2024 });
-await sdv.nfl.espn_nfl_team_schedule({ teamId: 12, season: 2024 });  // identical
+await sdv.nfl.espnNflTeamSchedule({ team_id: 12, season: 2024 });
+await sdv.nfl.espnNflTeamSchedule({ teamId: 12, season: 2024 });  // identical
 ```
 
 Required path parameters (like `team_id` above) throw a clear error if missing;

--- a/docs/docs/tutorials/scoreboard-to-table.md
+++ b/docs/docs/tutorials/scoreboard-to-table.md
@@ -39,7 +39,7 @@ function tidyGames(board) {
   });
 }
 
-const board = await sdv.nba.espn_nba_scoreboard({});
+const board = await sdv.nba.espnNbaScoreboard({});
 const games = tidyGames(board);
 console.table(games);
 ```
@@ -56,8 +56,8 @@ console.table(games);
 ```
 
 Because the extractor only touches `events`, the **exact same function works for
-any league** — swap `espn_nba_scoreboard` for `espn_nfl_scoreboard`,
-`espn_nhl_scoreboard`, etc.
+any league** — swap `espnNbaScoreboard` for `espnNflScoreboard`,
+`espnNhlScoreboard`, etc.
 
 ## 2. Drill into one game
 
@@ -65,7 +65,7 @@ Take an `id` from the table and pull the full game summary (box score, plays, wi
 probability, leaders, …):
 
 ```js
-const game = await sdv.nba.espn_nba_summary({ event_id: games[0].id });
+const game = await sdv.nba.espnNbaSummary({ event_id: games[0].id });
 
 // Team box-score totals
 for (const team of game.boxscore?.teams ?? []) {
@@ -84,12 +84,12 @@ Combine endpoints: get a team's schedule, then summarize each game. Be a polite
 ESPN client — these are public endpoints, so keep concurrency modest.
 
 ```js
-const schedule = await sdv.nfl.espn_nfl_team_schedule({ team_id: 12, season: 2024 });
+const schedule = await sdv.nfl.espnNflTeamSchedule({ team_id: 12, season: 2024 });
 const eventIds = (schedule.events ?? []).map((e) => e.id);
 
 const results = [];
 for (const id of eventIds) {
-  const summary = await sdv.nfl.espn_nfl_summary({ event_id: id });
+  const summary = await sdv.nfl.espnNflSummary({ event_id: id });
   const header = summary.header?.competitions?.[0]?.competitors ?? [];
   results.push({
     id,

--- a/docs/src/components/Playground/index.jsx
+++ b/docs/src/components/Playground/index.jsx
@@ -6,6 +6,10 @@ import styles from './styles.module.css';
 
 const LEAGUES = [...endpoints.leagues].sort((a, b) => a.prefix.localeCompare(b.prefix));
 
+/** Canonical camelCase method name (espn_nba_scoreboard -> espnNbaScoreboard). */
+const methodName = (prefix, short) =>
+  `espn_${prefix}_${short}`.replace(/_([a-z0-9])/g, (_m, c) => c.toUpperCase());
+
 /** Endpoints applicable to a league = those whose scope is in the league's scopes. */
 function endpointsFor(league) {
   const scopes = new Set(league.scopes);
@@ -83,7 +87,7 @@ export default function Playground() {
       .filter(([, v]) => v !== '' && v != null)
       .map(([k, v]) => `${k}: ${/^\d+$/.test(v) ? v : `'${v}'`}`)
       .join(', ');
-    return `await sdv.${prefix}.espn_${prefix}_${short}({ ${args} });`;
+    return `await sdv.${prefix}.${methodName(prefix, short)}({ ${args} });`;
   }, [prefix, short, params]);
 
   async function run() {
@@ -134,7 +138,7 @@ export default function Playground() {
           <select value={short} onChange={(e) => setShort(e.target.value)} className={styles.select}>
             {applicable.map((e) => (
               <option key={e.short} value={e.short}>
-                espn_{prefix}_{e.short}
+                {methodName(prefix, e.short)}
               </option>
             ))}
           </select>

--- a/src/core/espn.ts
+++ b/src/core/espn.ts
@@ -2,8 +2,8 @@ import { HOSTS, get } from "./client.js";
 import type { LeagueConfig, Scope, WrapperDef } from "./types.js";
 import { WRAPPERS } from "../generated/wrappers.js";
 
-/** snake_case -> camelCase (e.g. `event_id` -> `eventId`). */
-function toCamel(s: string): string {
+/** snake_case -> camelCase (e.g. `event_id` -> `eventId`, `espn_nba_scoreboard` -> `espnNbaScoreboard`). */
+export function toCamel(s: string): string {
   return s.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
 }
 
@@ -83,7 +83,7 @@ function buildPath(
     if (v === undefined || v === null) {
       if (byName.get(name)?.required === false) return "";
       throw new Error(
-        `espn_${cfg.prefix}_${def.short}: missing required path parameter "${name}"`
+        `${toCamel(`espn_${cfg.prefix}_${def.short}`)}: missing required path parameter "${name}"`
       );
     }
     return String(v);

--- a/src/leagues/_make.ts
+++ b/src/leagues/_make.ts
@@ -1,10 +1,13 @@
-import { WRAPPER_TABLES, callWrapper } from "../core/espn.js";
+import { WRAPPER_TABLES, callWrapper, toCamel } from "../core/espn.js";
 import type { LeagueConfig, WrapperFn } from "../core/types.js";
 
 /**
  * Build a league's cross-league ESPN surface: for each wrapper in the league's
- * scopes, expose `espn_<prefix>_<short>(params)`. The JS analogue of sdv-py's
- * `make_league_module`.
+ * scopes, expose it under BOTH names, resolving to the same function:
+ *   - `espnNbaScoreboard(params)` — camelCase, the idiomatic JS canonical name
+ *   - `espn_nba_scoreboard(params)` — snake_case alias, for parity with the
+ *     `sportsdataverse-py` / R packages.
+ * The JS analogue of sdv-py's `make_league_module`.
  */
 export function makeLeagueModule(
   cfg: LeagueConfig
@@ -12,8 +15,10 @@ export function makeLeagueModule(
   const mod: Record<string, WrapperFn> = {};
   for (const scope of cfg.scopes) {
     for (const def of WRAPPER_TABLES[scope] ?? []) {
-      mod[`espn_${cfg.prefix}_${def.short}`] = (params = {}) =>
-        callWrapper(def, cfg, params);
+      const snake = `espn_${cfg.prefix}_${def.short}`;
+      const fn: WrapperFn = (params = {}) => callWrapper(def, cfg, params);
+      mod[snake] = fn; // py/R-parity alias
+      mod[toCamel(snake)] = fn; // espnNbaScoreboard — idiomatic JS canonical
     }
   }
   return mod;

--- a/test/espn-core.test.js
+++ b/test/espn-core.test.js
@@ -14,26 +14,31 @@ describe('ESPN cross-league core (generated from YAML)', () => {
         sdv.should.have.properties(['epl', 'soccer', 'cricket', 'ufl', 'mch']);
     });
 
-    it('merges espn_<prefix>_* wrappers onto legacy namespaces without clobbering them', () => {
+    it('exposes each wrapper as camelCase canonical + snake_case alias (same fn) without clobbering legacy', () => {
         // legacy method preserved
         (typeof sdv.nba.getPlayByPlay).should.equal('function');
-        // generated wrappers added alongside it
+        // generated wrappers added alongside it — camelCase canonical name
+        (typeof sdv.nba.espnNbaScoreboard).should.equal('function');
+        (typeof sdv.nba.espnNbaSummary).should.equal('function');
+        // snake_case alias (py/R parity) exists and is the SAME function
         (typeof sdv.nba.espn_nba_scoreboard).should.equal('function');
-        (typeof sdv.nba.espn_nba_summary).should.equal('function');
-        Object.keys(sdv.nba).filter((k) => k.startsWith('espn_nba_')).length.should.be.above(50);
+        sdv.nba.espnNbaScoreboard.should.equal(sdv.nba.espn_nba_scoreboard);
+        Object.keys(sdv.nba).filter((k) => k.startsWith('espnNba')).length.should.be.above(50);
     });
 
     it('applies scope tables: ncaa/football wrappers only where scoped', () => {
         // cfb carries [universal, ncaa, football] -> more wrappers than universal-only nba
-        const cfbCount = Object.keys(sdv.cfb).filter((k) => k.startsWith('espn_cfb_')).length;
-        const nbaCount = Object.keys(sdv.nba).filter((k) => k.startsWith('espn_nba_')).length;
+        const cfbCount = Object.keys(sdv.cfb).filter((k) => k.startsWith('espnCfb')).length;
+        const nbaCount = Object.keys(sdv.nba).filter((k) => k.startsWith('espnNba')).length;
         cfbCount.should.be.above(nbaCount);
-        // ncaa-scope rankings on college, not on the pro league
+        // ncaa-scope rankings on college, not on the pro league (both name styles)
+        (typeof sdv.mbb.espnMbbRankings).should.equal('function');
         (typeof sdv.mbb.espn_mbb_rankings).should.equal('function');
+        (typeof sdv.nba.espnNbaRankings).should.equal('undefined');
         (typeof sdv.nba.espn_nba_rankings).should.equal('undefined');
     });
 
-    it('makeLeagueModule binds (sport, league) and prefixes every wrapper', () => {
+    it('makeLeagueModule binds (sport, league) and exposes both name styles', () => {
         const mod = makeLeagueModule({
             prefix: 'test',
             sport: 'basketball',
@@ -41,7 +46,10 @@ describe('ESPN cross-league core (generated from YAML)', () => {
             scopes: ['universal']
         });
         Object.keys(mod).length.should.be.above(0);
-        Object.keys(mod).every((k) => k.startsWith('espn_test_')).should.be.true();
+        // every key is an espn wrapper (camelCase canonical or snake_case alias)
+        Object.keys(mod).every((k) => k.startsWith('espn')).should.be.true();
+        (typeof mod.espnTestScoreboard).should.equal('function');
+        (typeof mod.espn_test_scoreboard).should.equal('function');
     });
 
     it('exposes the full generated wrapper table + families', () => {

--- a/tools/codegen/generate.mjs
+++ b/tools/codegen/generate.mjs
@@ -137,11 +137,17 @@ function queryParamsCell(wrapper) {
     .join(", ");
 }
 
+/** Canonical camelCase wrapper name (espn_nba_scoreboard -> espnNbaScoreboard). */
+function wrapperName(prefix, short) {
+  return `espn_${prefix}_${short}`.replace(/_([a-z0-9])/g, (_m, c) => c.toUpperCase());
+}
+
 function renderLeaguePage(league, wrappers, position) {
   const applicable = wrappersForLeague(league, wrappers);
+  const scoreboard = wrapperName(league.prefix, "scoreboard");
   const callExample = league.leagueParam
-    ? `await sdv.${league.prefix}.espn_${league.prefix}_scoreboard({ league: '${league.league}' });`
-    : `await sdv.${league.prefix}.espn_${league.prefix}_scoreboard({});`;
+    ? `await sdv.${league.prefix}.${scoreboard}({ league: '${league.league}' });`
+    : `await sdv.${league.prefix}.${scoreboard}({});`;
 
   let body =
     `---\n` +
@@ -155,7 +161,9 @@ function renderLeaguePage(league, wrappers, position) {
     `- **league slug:** \`${league.league}\`${league.leagueParam ? " *(default; override with a `league` param)*" : ""}\n` +
     `- **scopes:** ${league.scopes.map((s) => `\`${s}\``).join(", ")}\n` +
     `- **wrappers:** ${applicable.length}\n\n` +
-    `Every endpoint is called as \`sdv.${league.prefix}.espn_${league.prefix}_<endpoint>(params)\`. ` +
+    `Every endpoint is called as \`sdv.${league.prefix}.${scoreboard.replace("Scoreboard", "<Endpoint>")}(params)\`. ` +
+    `Each method is also available under its snake_case name ` +
+    `(\`espn_${league.prefix}_<endpoint>\`) for parity with the Python / R packages. ` +
     `Parameters accept snake_case or camelCase. Required path params are marked \\*.\n\n` +
     "```js\n" +
     `import sdv from 'sportsdataverse';\n\n` +
@@ -170,7 +178,7 @@ function renderLeaguePage(league, wrappers, position) {
     body += `| Method | HTTP | Path params | Query params |\n`;
     body += `|---|---|---|---|\n`;
     for (const w of rows.sort((a, b) => a.short.localeCompare(b.short))) {
-      const method = `\`espn_${league.prefix}_${w.short}\``;
+      const method = `\`${wrapperName(league.prefix, w.short)}\``;
       const http = `\`${w.family}\` \`${displayPath(w, league)}\``;
       body += `| ${method} | ${http} | ${pathParamsCell(w)} | ${queryParamsCell(w)} |\n`;
     }
@@ -188,9 +196,11 @@ function renderReferenceIndex(leagues, wrappers) {
     `---\n\n` +
     DOCS_NOTE +
     `\n# ESPN cross-league reference\n\n` +
-    `Every league below exposes the same generated \`espn_<league>_<endpoint>\` ` +
-    `surface, bound from a single YAML source of truth. Pick a league for its full ` +
-    `endpoint table, or try any call live in the [playground](/playground).\n\n` +
+    `Every league below exposes the same generated \`espn<League><Endpoint>\` ` +
+    `surface (e.g. \`espnNbaScoreboard\`), bound from a single YAML source of truth. ` +
+    `Each method is also available under its snake_case name (\`espn_nba_scoreboard\`) ` +
+    `for parity with the Python / R packages. Pick a league for its full endpoint ` +
+    `table, or try any call live in the [playground](/playground).\n\n` +
     `| League | sport | ESPN slug | scopes | wrappers |\n` +
     `|---|---|---|---|---:|\n`;
   for (const l of leagues) {
@@ -201,9 +211,9 @@ function renderReferenceIndex(leagues, wrappers) {
   body +=
     `\n:::tip Same call, every league\n` +
     "```js\n" +
-    `await sdv.nba.espn_nba_scoreboard({});\n` +
-    `await sdv.nfl.espn_nfl_scoreboard({ week: 1, season_type: 2 });\n` +
-    `await sdv.soccer.espn_soccer_scoreboard({ league: 'eng.1' });\n` +
+    `await sdv.nba.espnNbaScoreboard({});\n` +
+    `await sdv.nfl.espnNflScoreboard({ week: 1, seasonType: 2 });\n` +
+    `await sdv.soccer.espnSoccerScoreboard({ league: 'eng.1' });\n` +
     "```\n" +
     `:::\n`;
   return body;


### PR DESCRIPTION
Makes the generated ESPN wrappers **camelCase** (idiomatic JS/TS) while keeping the snake_case names as aliases.

## Why
The package's own legacy methods are camelCase (`sdv.nba.getPlayByPlay`), but the v3.0.0 generated wrappers were snake_case (`espn_nba_scoreboard`) — internally inconsistent and un-idiomatic for a JS library. v3.0.0 is **unreleased** (npm latest = 2.0.0), so this is the free moment to fix the canonical naming.

## What
Every wrapper is now registered under **both** names, resolving to the same function:

```js
await sdv.nba.espnNbaScoreboard({});      // camelCase — canonical
await sdv.nba.espn_nba_scoreboard({});     // snake_case — alias (py/R parity)
sdv.nba.espnNbaScoreboard === sdv.nba.espn_nba_scoreboard;  // true
```

- **`src/leagues/_make.ts`** registers `toCamel(snake)` alongside the snake name (same fn ref); `toCamel` is exported from `src/core/espn.ts`.
- **Codegen** (`tools/codegen/generate.mjs`): the per-league reference lists camelCase method names, with a note that the snake_case alias exists. All 29 reference pages regenerated.
- **README / intro / tutorials**: camelCase examples; the naming rule is now `espn<League><Endpoint>`, alias noted. The cross-league tutorial keeps the snake form in one spot to show clean dynamic dispatch (`sdv[league][\`espn_${league}_scoreboard\`]`).
- **Playground**: camelCase call string + endpoint labels.
- **Tests**: assert both names exist and are the identical function.

## Verification
- `npm run build` ✅ · `npm run typecheck` ✅ · `npm run codegen:check` ✅ (in sync)
- structural tests ✅ (7/7, incl. the both-names-same-fn assertion)
- `cd docs && npm run build` ✅ — clean, zero broken links
- Runtime check: `espnNbaScoreboard`/`espnNflTeamRoster`/`espnCollegeBaseballScoreboard` resolve; snake aliases resolve to the same fn (110 + 110 keys per NBA namespace).

Breaking-marked (`!`) since it changes the v3.0.0 canonical naming, but no published surface breaks (2.0.0 is current; both names work regardless).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all ESPN endpoint references to use camelCase naming (e.g., `espnNbaScoreboard` instead of `espn_nba_scoreboard`)
  * Clarified that snake_case method aliases remain available for backward compatibility
  * Refreshed code examples across tutorials and reference guides to reflect new naming convention

* **Features**
  * ESPN wrapper methods now support camelCase canonical names alongside existing snake_case aliases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->