### PR TITLE
test: deterministic contract coverage for the full surface + run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Verify the build output exists
         run: |
           node -e "import('./dist/index.js').then(m => { const s = Object.keys(m.default); if (s.length < 29 || !s.includes('nba') || !s.includes('soccer')) { throw new Error('unexpected namespaces ' + s.length); } console.log('OK', s.length, 'namespaces'); })"
+      # No-network suite: contract tests for every generated wrapper + core +
+      # legacy surface + playground resolver/proxy. Live-API suites are gated
+      # behind SDV_LIVE (not set here), so this stays deterministic.
+      - name: Test
+        run: npm test
 
   docs:
     name: docs build (Docusaurus + TypeDoc)

--- a/test/cfb.test.js
+++ b/test/cfb.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('CFB Games', () => {
+live('CFB Games', () => {
     var gameId = 401256194;
 
     it('should populate play by play data for the given game id', async () => {
@@ -55,7 +56,7 @@ describe('CFB Games', () => {
     });
 });
 
-describe('CFB Rankings', () => {
+live('CFB Rankings', () => {
     it('should populate rankings for the current week and year', async () => {
         const data = await app.cfb.getRankings({})
         should(data).exist;
@@ -95,7 +96,7 @@ describe('CFB Rankings', () => {
     });
 });
 
-describe('CFB Scoreboard', () => {
+live('CFB Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.cfb.getScoreboard({})
@@ -139,7 +140,7 @@ describe('CFB Scoreboard', () => {
     });
 });
 
-describe('CFB Standings', () => {
+live('CFB Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.cfb.getStandings({
@@ -161,7 +162,7 @@ describe('CFB Standings', () => {
 
     });
 });
-describe('CFB Teams', () => {
+live('CFB Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.cfb.getTeamList({})
@@ -188,7 +189,7 @@ describe('CFB Teams', () => {
 
     });
 });
-describe('CFB Recruiting', () => {
+live('CFB Recruiting', () => {
 
     it('should return a promise for a list of individual rankings for the given year', async () => {
         const data = await app.cfb.getPlayerRankings({

--- a/test/espn-contract.test.js
+++ b/test/espn-contract.test.js
@@ -100,16 +100,29 @@ describe('path-param resolution rules', () => {
     (() => resolveRequest(def, league, base)).should.throw(/missing required path parameter/);
   });
 
-  it('honours camelCase aliases for path + query params', () => {
+  it('honours camelCase aliases for path params', () => {
     const def = WRAPPERS.find(
       (w) => (w.pathParams || []).some((p) => p.name.includes('_'))
     );
     should(def).be.ok();
     const league = LEAGUES.find((l) => l.scopes.includes(def.scope) && !l.leagueParam);
     const snakeKey = def.pathParams.find((p) => p.name.includes('_')).name;
-    const camelKey = toCamel(snakeKey);
     const a = resolveRequest(def, league, { [snakeKey]: 7 }).url;
-    const b = resolveRequest(def, league, { [camelKey]: 7 }).url;
+    const b = resolveRequest(def, league, { [toCamel(snakeKey)]: 7 }).url;
     a.should.equal(b);
+  });
+
+  it('honours camelCase aliases for query params (and maps to the ESPN key)', () => {
+    const def = WRAPPERS.find(
+      (w) => (w.queryParams || []).some((p) => p.name.includes('_'))
+    );
+    should(def).be.ok();
+    const league = LEAGUES.find((l) => l.scopes.includes(def.scope) && !l.leagueParam);
+    const qp = def.queryParams.find((p) => p.name.includes('_'));
+    const snakeQuery = resolveRequest(def, league, { [qp.name]: 2 }).query;
+    const camelQuery = resolveRequest(def, league, { [toCamel(qp.name)]: 2 }).query;
+    JSON.stringify(snakeQuery).should.equal(JSON.stringify(camelQuery));
+    // resolved under the ESPN query key, not the call-param name
+    snakeQuery[qp.queryKey].should.equal(2);
   });
 });

--- a/test/espn-contract.test.js
+++ b/test/espn-contract.test.js
@@ -1,0 +1,115 @@
+import should from 'should';
+import sdv, { LEAGUES, WRAPPERS } from '../dist/index.js';
+// deep imports (not public API) — exercise request building + hosts w/o network
+import { resolveRequest } from '../dist/core/espn.js';
+import { HOSTS } from '../dist/core/client.js';
+
+// Exhaustive, no-network contract tests for the full generated ESPN surface:
+// every wrapper, on every league it applies to, is exposed under both names and
+// builds a well-formed ESPN URL. ~819 wrappers across 29 leagues.
+
+const toCamel = (s) => s.replace(/_([a-z0-9])/g, (_m, c) => c.toUpperCase());
+const FAMILIES = new Set(['site_v2', 'site_v2_alt', 'web_v3', 'core_v2']);
+const SCOPES = new Set(['universal', 'ncaa', 'football', 'mlb']);
+
+/** Wrappers applicable to a league = those whose scope is in the league's scopes. */
+function applicable(league) {
+  const scopes = new Set(league.scopes);
+  return WRAPPERS.filter((w) => scopes.has(w.scope));
+}
+
+/** Fill every path param that has no other resolution source, so URLs fully resolve. */
+function minimalParams(league, def) {
+  const params = {};
+  if (league.leagueParam) params.league = league.league;
+  for (const p of def.pathParams || []) {
+    if (p.default === undefined && p.defaultFrom === undefined) params[p.name] = 12345;
+  }
+  return params;
+}
+
+describe('ESPN wrapper metadata invariants', () => {
+  it('exposes a non-trivial, unique wrapper table', () => {
+    WRAPPERS.length.should.be.above(100);
+    const shorts = WRAPPERS.map((w) => w.short);
+    new Set(shorts).size.should.equal(shorts.length, 'duplicate wrapper short names');
+  });
+
+  it('every wrapper has a valid family, scope, and sport-templated absolute path', () => {
+    for (const w of WRAPPERS) {
+      FAMILIES.has(w.family).should.be.true(`bad family on ${w.short}: ${w.family}`);
+      SCOPES.has(w.scope).should.be.true(`bad scope on ${w.short}: ${w.scope}`);
+      w.path.startsWith('/').should.be.true(`path not absolute on ${w.short}: ${w.path}`);
+      w.path.includes('{sport}').should.be.true(`path lacks {sport} on ${w.short}`);
+      Array.isArray(w.pathParams).should.be.true(`pathParams not an array on ${w.short}`);
+      Array.isArray(w.queryParams).should.be.true(`queryParams not an array on ${w.short}`);
+    }
+  });
+
+  it('HOSTS provides an https base for every family in use', () => {
+    for (const fam of new Set(WRAPPERS.map((w) => w.family))) {
+      (typeof HOSTS[fam]).should.equal('string', `no host for family ${fam}`);
+      HOSTS[fam].startsWith('https://').should.be.true(`host not https for ${fam}`);
+    }
+  });
+});
+
+describe('every wrapper is exposed under both names on every applicable league', () => {
+  for (const league of LEAGUES) {
+    const wrappers = applicable(league);
+    it(`${league.prefix}: ${wrappers.length} wrappers present as camelCase + snake (same fn)`, () => {
+      const ns = sdv[league.prefix];
+      should(ns).be.an.Object();
+      for (const w of wrappers) {
+        const snake = `espn_${league.prefix}_${w.short}`;
+        const camel = toCamel(snake);
+        (typeof ns[snake]).should.equal('function', `missing ${snake}`);
+        (typeof ns[camel]).should.equal('function', `missing ${camel}`);
+        ns[camel].should.equal(ns[snake], `${camel} and ${snake} differ`);
+      }
+    });
+  }
+});
+
+describe('every wrapper builds a well-formed ESPN URL (no network)', () => {
+  for (const league of LEAGUES) {
+    it(`${league.prefix}: all wrappers resolve to a valid URL`, () => {
+      for (const w of applicable(league)) {
+        const { url } = resolveRequest(w, league, minimalParams(league, w));
+        url.should.startWith(HOSTS[w.family], `${w.short}: wrong host`);
+        url.should.containEql(`/${league.sport}/`, `${w.short}: missing sport slug`);
+        if (!league.leagueParam) {
+          url.should.containEql(`/${league.league}`, `${w.short}: missing league slug`);
+        }
+        url.should.not.match(/[{}]/, `${w.short}: unresolved token in ${url}`);
+      }
+    });
+  }
+});
+
+describe('path-param resolution rules', () => {
+  it('throws when a required path param is missing', () => {
+    const def = WRAPPERS.find((w) =>
+      (w.pathParams || []).some(
+        (p) => p.required !== false && p.default === undefined && p.defaultFrom === undefined
+      )
+    );
+    should(def).be.ok();
+    const league = LEAGUES.find((l) => l.scopes.includes(def.scope));
+    const base = league.leagueParam ? { league: league.league } : {};
+    (() => resolveRequest(def, league, base)).should.throw(/missing required path parameter/);
+  });
+
+  it('honours camelCase aliases for path + query params', () => {
+    const def = WRAPPERS.find(
+      (w) => (w.pathParams || []).some((p) => p.name.includes('_'))
+    );
+    should(def).be.ok();
+    const league = LEAGUES.find((l) => l.scopes.includes(def.scope) && !l.leagueParam);
+    const snakeKey = def.pathParams.find((p) => p.name.includes('_')).name;
+    const camelKey = toCamel(snakeKey);
+    const a = resolveRequest(def, league, { [snakeKey]: 7 }).url;
+    const b = resolveRequest(def, league, { [camelKey]: 7 }).url;
+    a.should.equal(b);
+  });
+});

--- a/test/helpers/live.mjs
+++ b/test/helpers/live.mjs
@@ -1,0 +1,10 @@
+// Gate for live-network test suites. They hit the real ESPN API (slow, flaky,
+// dependent on specific game ids staying alive), so they only run when
+// SDV_LIVE is set — keeping the default `npm test` deterministic and CI-safe.
+//
+//   SDV_LIVE=1 npm test
+//
+// `describe` is a Mocha global, available by the time a spec file imports this.
+export const live = ['1', 'true', 'yes'].includes(process.env.SDV_LIVE)
+  ? describe
+  : describe.skip;

--- a/test/legacy-surface.test.js
+++ b/test/legacy-surface.test.js
@@ -1,0 +1,30 @@
+import should from 'should';
+import sdv from '../dist/index.js';
+
+// No-network coverage of the hand-written legacy services: every method each
+// service module exports must still be callable on its merged sdv namespace
+// (the generated espn_* wrappers are added ALONGSIDE these, never clobbering
+// them). Data-driven from the service modules, so new legacy methods are
+// covered automatically.
+
+const SERVICES = ['cfb', 'mbb', 'mlb', 'nba', 'ncaa', 'nfl', 'nhl', 'tennis', 'wbb', 'wnba'];
+
+describe('legacy service methods are preserved on every namespace', () => {
+  for (const svc of SERVICES) {
+    it(`${svc}: every exported legacy method is a function on sdv.${svc}`, async () => {
+      const mod = (await import(`../dist/services/${svc}.service.js`)).default;
+      const methods = Object.keys(mod).filter((k) => typeof mod[k] === 'function');
+      methods.length.should.be.above(0, `${svc} service exposes no methods`);
+      should(sdv[svc]).be.an.Object();
+      for (const m of methods) {
+        (typeof sdv[svc][m]).should.equal('function', `sdv.${svc}.${m} is missing`);
+      }
+    });
+  }
+
+  it('legacy methods coexist with the generated wrappers (no clobbering)', () => {
+    (typeof sdv.nba.getPlayByPlay).should.equal('function');
+    (typeof sdv.nba.espnNbaScoreboard).should.equal('function');
+    (typeof sdv.nba.espn_nba_scoreboard).should.equal('function');
+  });
+});

--- a/test/mbb.test.js
+++ b/test/mbb.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('MBB Games', () => {
+live('MBB Games', () => {
     var gameId = 401260281;
 
     it('should populate play by play data for the given game id', async () => {
@@ -55,7 +56,7 @@ describe('MBB Games', () => {
     });
 });
 
-describe('MBB Scoreboard', () => {
+live('MBB Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.mbb.getScoreboard({})
@@ -98,7 +99,7 @@ describe('MBB Scoreboard', () => {
     });
 });
 
-describe('MBB Standings', () => {
+live('MBB Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.mbb.getStandings({
@@ -120,7 +121,7 @@ describe('MBB Standings', () => {
 
     });
 });
-describe('MBB Teams', () => {
+live('MBB Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.mbb.getTeamList({})
@@ -146,7 +147,7 @@ describe('MBB Teams', () => {
 
     });
 });
-describe('MBB Recruiting', () => {
+live('MBB Recruiting', () => {
 
     it('should return a promise for a list of individual rankings for the given year', async () => {
         const data = await app.mbb.getPlayerRankings({

--- a/test/mlb.test.js
+++ b/test/mlb.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('MLB Games', () => {
+live('MLB Games', () => {
 
     var gameId = 401472105;
 
@@ -61,7 +62,7 @@ describe('MLB Games', () => {
 });
 
 
-describe('MLB Scoreboard', () => {
+live('MLB Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.mlb.getScoreboard({})
@@ -105,7 +106,7 @@ describe('MLB Scoreboard', () => {
     });
 });
 
-describe('MLB Standings', () => {
+live('MLB Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.mlb.getStandings({
@@ -128,7 +129,7 @@ describe('MLB Standings', () => {
     });
 });
 
-describe('MLB Teams', () => {
+live('MLB Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.mlb.getTeamList({})

--- a/test/nba.test.js
+++ b/test/nba.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('NBA Games', () => {
+live('NBA Games', () => {
 
     var gameId = 401283399;
 
@@ -56,7 +57,7 @@ describe('NBA Games', () => {
     });
 });
 
-describe('NBA Scoreboard', () => {
+live('NBA Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.nba.getScoreboard({})
@@ -99,7 +100,7 @@ describe('NBA Scoreboard', () => {
     });
 });
 
-describe('NBA Standings', () => {
+live('NBA Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.nba.getStandings({
@@ -122,7 +123,7 @@ describe('NBA Standings', () => {
     });
 });
 
-describe('NBA Teams', () => {
+live('NBA Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.nba.getTeamList({})

--- a/test/ncaa.test.js
+++ b/test/ncaa.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('NCAA Games', () => {
+live('NCAA Games', () => {
 
     var game = 5764053;
     it('should return a promise for ncaa game information for a given game', async () => {
@@ -27,7 +28,7 @@ describe('NCAA Games', () => {
     });
 });
 
-describe('NCAA Scoreboard', () => {
+live('NCAA Scoreboard', () => {
 
     it('should return a promise for ncaa scoreboard data for a given date', async () => {
         const data = await app.ncaa.getScoreboard({

--- a/test/nfl.test.js
+++ b/test/nfl.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('NFL Games', () => {
+live('NFL Games', () => {
 
     var gameId = 401220403;
 
@@ -57,7 +58,7 @@ describe('NFL Games', () => {
 });
 
 
-describe('NFL Scoreboard', () => {
+live('NFL Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.nfl.getScoreboard({})
@@ -100,7 +101,7 @@ describe('NFL Scoreboard', () => {
     });
 });
 
-describe('NFL Weekly Schedule', () => {
+live('NFL Weekly Schedule', () => {
 
     it('should populate schedule data for the first week of regular season for the current year', async () => {
         const data = await app.nfl.getWeeklySchedule({})
@@ -140,7 +141,7 @@ describe('NFL Weekly Schedule', () => {
   
 });
 
-describe('NFL Standings', () => {
+live('NFL Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.nfl.getStandings({
@@ -163,7 +164,7 @@ describe('NFL Standings', () => {
     });
 });
 
-describe('NFL Teams', () => {
+live('NFL Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.nfl.getTeamList({})

--- a/test/nhl.test.js
+++ b/test/nhl.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('NHL Games', () => {
+live('NHL Games', () => {
 
     var gameId = 401272446;
 
@@ -57,7 +58,7 @@ describe('NHL Games', () => {
 });
 
 
-describe('NHL Scoreboard', () => {
+live('NHL Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.nhl.getScoreboard({})
@@ -100,7 +101,7 @@ describe('NHL Scoreboard', () => {
     });
 });
 
-describe('NHL Standings', () => {
+live('NHL Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.nhl.getStandings({
@@ -123,7 +124,7 @@ describe('NHL Standings', () => {
     });
 });
 
-describe('NHL Teams', () => {
+live('NHL Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.nhl.getTeamList({})

--- a/test/playground.test.js
+++ b/test/playground.test.js
@@ -1,0 +1,88 @@
+import should from 'should';
+import { LEAGUES, WRAPPERS } from '../dist/index.js';
+import { resolveRequest } from '../dist/core/espn.js';
+import { HOSTS } from '../dist/core/client.js';
+// the docs playground's standalone runtime (separate port of the resolver + the
+// serverless proxy) — tested here so it can't drift from the package.
+import { resolveUrl } from '../docs/src/playground/resolve.mjs';
+import handler from '../docs/api/run.mjs';
+
+const L = Object.fromEntries(LEAGUES.map((l) => [l.prefix, l]));
+const E = Object.fromEntries(WRAPPERS.map((w) => [w.short, w]));
+
+describe('playground resolve.mjs matches the package resolver', () => {
+  const cases = [
+    ['nba', 'scoreboard', {}],
+    ['nba', 'summary', { event_id: 401584793 }],
+    ['nfl', 'team_roster', { team_id: 12 }],
+    ['nfl', 'team_schedule', { teamId: 12, season: 2024 }],
+    ['soccer', 'scoreboard', { league: 'eng.1' }],
+    ['cfb', 'rankings', {}],
+  ];
+  for (const [prefix, short, params] of cases) {
+    it(`${prefix}.${short} resolves to an identical URL`, () => {
+      const league = L[prefix];
+      const def = E[short];
+      const pkg = resolveRequest(def, league, params);
+      const pkgUrl = new URL(pkg.url);
+      // package resolveRequest returns query=undefined when there are no params
+      for (const [k, v] of Object.entries(pkg.query || {})) pkgUrl.searchParams.set(k, String(v));
+      resolveUrl(def, league, params, HOSTS).should.equal(pkgUrl.toString());
+    });
+  }
+});
+
+function mockRes() {
+  const res = { statusCode: null, body: null, headers: {} };
+  res.status = (c) => ((res.statusCode = c), res);
+  res.json = (o) => ((res.body = o), res);
+  res.send = (s) => ((res.body = s), res);
+  res.setHeader = (k, v) => ((res.headers[k] = v), res);
+  return res;
+}
+
+describe('playground proxy (run.mjs) validation + allowlist', () => {
+  it('rejects non-POST with 405', async () => {
+    const res = mockRes();
+    await handler({ method: 'GET', query: {} }, res);
+    res.statusCode.should.equal(405);
+  });
+
+  it('rejects an invalid JSON body with 400', async () => {
+    const res = mockRes();
+    await handler({ method: 'POST', body: '{not json' }, res);
+    res.statusCode.should.equal(400);
+  });
+
+  it('rejects an unknown league/endpoint with 400', async () => {
+    const res = mockRes();
+    await handler({ method: 'POST', body: { league: 'zzz', endpoint: 'nope', params: {} } }, res);
+    res.statusCode.should.equal(400);
+  });
+
+  it('rejects an out-of-scope endpoint with 400 (nba + rankings)', async () => {
+    const res = mockRes();
+    await handler({ method: 'POST', body: { league: 'nba', endpoint: 'rankings', params: {} } }, res);
+    res.statusCode.should.equal(400);
+  });
+
+  it('proxies an allowed ESPN request to the resolved URL (mocked fetch)', async () => {
+    const original = global.fetch;
+    let fetched = null;
+    global.fetch = async (url) => {
+      fetched = url;
+      return { ok: true, status: 200, text: async () => JSON.stringify({ leagues: [] }) };
+    };
+    try {
+      const res = mockRes();
+      await handler({ method: 'POST', body: { league: 'nba', endpoint: 'scoreboard', params: {} } }, res);
+      res.statusCode.should.equal(200);
+      should(fetched).be.a.String();
+      fetched.should.startWith('https://site.api.espn.com');
+      fetched.should.containEql('/basketball/nba/scoreboard');
+      JSON.parse(res.body).should.have.property('leagues');
+    } finally {
+      global.fetch = original;
+    }
+  });
+});

--- a/test/tennis.test.js
+++ b/test/tennis.test.js
@@ -1,8 +1,9 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
 
-describe('TNNS Scoreboard', () => {
+live('TNNS Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.tennis.getScoreboard({});

--- a/test/wbb.test.js
+++ b/test/wbb.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('WBB Games', () => {
+live('WBB Games', () => {
     var gameId = 401264909;
 
     it('should populate play by play data for the given game id', async () => {
@@ -47,7 +48,7 @@ describe('WBB Games', () => {
     });
 });
 
-describe('WBB Scoreboard', () => {
+live('WBB Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.wbb.getScoreboard({})
@@ -90,7 +91,7 @@ describe('WBB Scoreboard', () => {
     });
 });
 
-describe('WBB Standings', () => {
+live('WBB Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.wbb.getStandings({
@@ -112,7 +113,7 @@ describe('WBB Standings', () => {
 
     });
 });
-describe('WBB Teams', () => {
+live('WBB Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.wbb.getTeamList({})

--- a/test/wnba.test.js
+++ b/test/wnba.test.js
@@ -1,7 +1,8 @@
+import { live } from "./helpers/live.mjs";
 import should from 'should';
 import app from '../dist/index.js';
 
-describe('WNBA Games', () => {
+live('WNBA Games', () => {
 
     var gameId = 401244185;
 
@@ -49,7 +50,7 @@ describe('WNBA Games', () => {
 });
 
 
-describe('WNBA Scoreboard', () => {
+live('WNBA Scoreboard', () => {
 
     it('should populate scoreboard data for the current week and year', async () => {
         const data = await app.wnba.getScoreboard({})
@@ -92,7 +93,7 @@ describe('WNBA Scoreboard', () => {
     });
 });
 
-describe('WNBA Standings', () => {
+live('WNBA Standings', () => {
 
     it('should populate standings for the given year', async () => {
         const data = await app.wnba.getStandings({
@@ -115,7 +116,7 @@ describe('WNBA Standings', () => {
     });
 });
 
-describe('WNBA Teams', () => {
+live('WNBA Teams', () => {
 
     it('should populate a teams list', async () => {
         const data = await app.wnba.getTeamList({})


### PR DESCRIPTION
Adds no-network tests that cover **every function**, gates the flaky live suites, and finally **runs the test suite in CI** (it previously only built + typechecked, so nothing executed the tests — which is why the stale-game-id NCAA failures never blocked anything).

## New deterministic suites (no live API)
- **`espn-contract.test.js`** — the full generated surface:
  - metadata invariants: every wrapper has a valid family/scope, a sport-templated absolute path, unique `short` names, and a HOSTS entry.
  - for **every league × every applicable wrapper (~819)**: both names (`espnNbaScoreboard` + `espn_nba_scoreboard`) exist and are the **same function**, and `resolveRequest` builds a well-formed ESPN URL (correct host, sport + league slugs, **no unresolved `{tokens}`**).
  - required-path-param throws; camelCase param aliases resolve identically.
- **`legacy-surface.test.js`** — data-driven from each service module: every exported legacy method (`getPlayByPlay`, …) is still a function on its `sdv` namespace (no clobbering by the generated wrappers).
- **`playground.test.js`** — the docs playground's standalone runtime:
  - `resolve.mjs` produces URLs **identical** to the package resolver (parity guard so the port can't drift).
  - `run.mjs` enforces POST-only (405) / bad-JSON (400) / unknown + out-of-scope (400) / ESPN-host allowlist, and proxies to the resolved URL (mocked `fetch`, no network).

## Gating
The 10 legacy service suites (`cfb`…`wnba`) hit real ESPN with stale game ids. Gated behind `SDV_LIVE` via `test/helpers/live.mjs` (mirrors `espn-live`). Default `npm test` is now fully deterministic:

```
92 passing · 173 pending (gated) · 0 failing
```

`SDV_LIVE=1 npm test` still runs the live suites.

## CI
Adds a `Test` step to the build job → runs the no-network suite on **Node 20.x + 22.x** on every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Made the default test run deterministic by gating live-network ESPN suites (now using a live wrapper across multiple sport test files).
  * Added a comprehensive ESPN contract test suite validating wrapper metadata and request resolution (including parameter aliasing and host/URL correctness).
  * Added coverage to ensure legacy service modules remain callable on the merged API namespace.
  * Added runtime validation tests for the documentation playground and request proxying behavior.
* **CI**
  * CI now runs the deterministic test suite (`npm test`) as part of the build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->