### PR TITLE
docs(providers): enrich CBS + Fox returns schemas from captures

### DIFF
--- a/docs/docs/reference/cbs.md
+++ b/docs/docs/reference/cbs.md
@@ -110,3 +110,1849 @@ Flat (non-ESPN) wrappers for CBS Sports napi. Host: `https://api.cbssports.com`.
 | `cbs_napi_venue` / `cbsNapiVenue` | `https://api.cbssports.com/resource/venue/{venue_id}` | `venue_id`\* | `resources` | `parse_cbs_napi_list` | — |
 | `cbs_napi_venue_metadata` / `cbsNapiVenueMetadata` | `https://api.cbssports.com/resource/venue/metadata/{venue_id}` | `venue_id`\* | — | `parse_cbs_napi_list` | — |
 | `cbs_napi_weather` / `cbsNapiWeather` | `https://api.cbssports.com/resource/game/weather/{game_id}` | `game_id`\* | — | `parse_cbs_napi_list` | — |
+
+### Returns — `cbs_napi_endpoint_registry` / `cbsNapiEndpointRegistry`
+
+| col_name | type | description |
+|---|---|---|
+| `boxscore_resource_location` | character | Boxscore resource location. |
+| `boxscore_resource_route` | character | Boxscore resource route. |
+| `boxscore_resource_path` | character | Boxscore resource path. |
+| `boxscore_resource_summary` | character | Boxscore resource summary. |
+| `boxscore_resource_notes` | character | Boxscore resource notes. |
+| `boxscore_resource_versions_allowed` | character | Boxscore resource versions allowed. |
+| `boxscore_resource_versions_current` | character | Boxscore resource versions current. |
+| `boxscore_resource_methods` | character | Boxscore resource methods. |
+| `boxscore_resource_formats` | character | Boxscore resource formats. |
+| `boxscore_resource_parameters` | character | Boxscore resource parameters. |
+| `boxscore_resource_auth_settings_require_auth` | logical | Boxscore resource auth settings require auth. |
+| `boxscore_resource_auth_settings_allow_only` | character | Boxscore resource auth settings allow only. |
+| `boxscore_resource_resource_cache_ns` | character | Boxscore resource resource cache ns. |
+| `boxscore_resource_resource_cache_cache_keys` | character | Boxscore resource resource cache cache keys. |
+| `boxscore_resource_resource_cache_cache_buster` | integer | Boxscore resource resource cache cache buster. |
+| `boxscore_resource_expiration_message_object_key_name` | character | Boxscore resource expiration message object key name. |
+| `player_resource_location` | character | Player resource location. |
+| `player_resource_route` | character | Player resource route. |
+| `player_resource_path` | character | Player resource path. |
+| `player_resource_summary` | character | Player resource summary. |
+| `player_resource_notes` | character | Player resource notes. |
+| `player_resource_versions_allowed` | character | Player resource versions allowed. |
+| `player_resource_versions_current` | character | Player resource versions current. |
+| `player_resource_methods` | character | Player resource methods. |
+| `player_resource_formats` | character | Player resource formats. |
+| `player_resource_parameters` | character | Player resource parameters. |
+| `player_resource_auth_settings_require_auth` | logical | Player resource auth settings require auth. |
+| `player_resource_auth_settings_allow_only` | character | Player resource auth settings allow only. |
+| `player_resource_resource_cache_ns` | character | Player resource resource cache ns. |
+| `player_resource_resource_cache_cache_keys` | character | Player resource resource cache cache keys. |
+| `player_resource_resource_cache_cache_buster` | integer | Player resource resource cache cache buster. |
+| `player_resource_expiration_message_object_key_name` | character | Player resource expiration message object key name. |
+| `player_team_associations_resource_location` | character | Player team associations resource location. |
+| `player_team_associations_resource_route` | character | Player team associations resource route. |
+| `player_team_associations_resource_path` | character | Player team associations resource path. |
+| `player_team_associations_resource_summary` | character | Player team associations resource summary. |
+| `player_team_associations_resource_notes` | character | Player team associations resource notes. |
+| `player_team_associations_resource_versions_allowed` | character | Player team associations resource versions allowed. |
+| `player_team_associations_resource_versions_current` | character | Player team associations resource versions current. |
+| `player_team_associations_resource_methods` | character | Player team associations resource methods. |
+| `player_team_associations_resource_formats` | character | Player team associations resource formats. |
+| `player_team_associations_resource_parameters` | character | Player team associations resource parameters. |
+| `player_team_associations_resource_auth_settings_require_auth` | logical | Player team associations resource auth settings require auth. |
+| `player_team_associations_resource_auth_settings_allow_only` | character | Player team associations resource auth settings allow only. |
+| `player_team_associations_resource_resource_cache_ns` | character | Player team associations resource resource cache ns. |
+| `player_team_associations_resource_resource_cache_cache_keys` | character | Player team associations resource resource cache cache keys. |
+| `player_team_associations_resource_resource_cache_cache_buster` | integer | Player team associations resource resource cache cache buster. |
+| `player_team_associations_resource_expiration_message_object_key_name` | character | Player team associations resource expiration message object key name. |
+| `recruit_team_associations_resource_location` | character | Recruit team associations resource location. |
+| `recruit_team_associations_resource_route` | character | Recruit team associations resource route. |
+| `recruit_team_associations_resource_path` | character | Recruit team associations resource path. |
+| `recruit_team_associations_resource_summary` | character | Recruit team associations resource summary. |
+| `recruit_team_associations_resource_notes` | character | Recruit team associations resource notes. |
+| `recruit_team_associations_resource_versions_allowed` | character | Recruit team associations resource versions allowed. |
+| `recruit_team_associations_resource_versions_current` | character | Recruit team associations resource versions current. |
+| `recruit_team_associations_resource_methods` | character | Recruit team associations resource methods. |
+| `recruit_team_associations_resource_formats` | character | Recruit team associations resource formats. |
+| `recruit_team_associations_resource_parameters` | character | Recruit team associations resource parameters. |
+| `recruit_team_associations_resource_auth_settings_require_auth` | logical | Recruit team associations resource auth settings require auth. |
+| `recruit_team_associations_resource_auth_settings_allow_only` | character | Recruit team associations resource auth settings allow only. |
+| `recruit_team_associations_resource_resource_cache_ns` | character | Recruit team associations resource resource cache ns. |
+| `recruit_team_associations_resource_resource_cache_cache_keys` | character | Recruit team associations resource resource cache cache keys. |
+| `recruit_team_associations_resource_resource_cache_cache_buster` | integer | Recruit team associations resource resource cache cache buster. |
+| `recruit_team_associations_resource_expiration_message_object_key_name` | character | Recruit team associations resource expiration message object key name. |
+| `coach_team_associations_resource_location` | character | Coach team associations resource location. |
+| `coach_team_associations_resource_route` | character | Coach team associations resource route. |
+| `coach_team_associations_resource_path` | character | Coach team associations resource path. |
+| `coach_team_associations_resource_summary` | character | Coach team associations resource summary. |
+| `coach_team_associations_resource_notes` | character | Coach team associations resource notes. |
+| `coach_team_associations_resource_versions_allowed` | character | Coach team associations resource versions allowed. |
+| `coach_team_associations_resource_versions_current` | character | Coach team associations resource versions current. |
+| `coach_team_associations_resource_methods` | character | Coach team associations resource methods. |
+| `coach_team_associations_resource_formats` | character | Coach team associations resource formats. |
+| `coach_team_associations_resource_parameters` | character | Coach team associations resource parameters. |
+| `coach_team_associations_resource_auth_settings_require_auth` | logical | Coach team associations resource auth settings require auth. |
+| `coach_team_associations_resource_auth_settings_allow_only` | character | Coach team associations resource auth settings allow only. |
+| `coach_team_associations_resource_resource_cache_ns` | character | Coach team associations resource resource cache ns. |
+| `coach_team_associations_resource_resource_cache_cache_keys` | character | Coach team associations resource resource cache cache keys. |
+| `coach_team_associations_resource_resource_cache_cache_buster` | integer | Coach team associations resource resource cache cache buster. |
+| `coach_team_associations_resource_expiration_message_object_key_name` | character | Coach team associations resource expiration message object key name. |
+| `player_draft_info_resource_location` | character | Player draft info resource location. |
+| `player_draft_info_resource_route` | character | Player draft info resource route. |
+| `player_draft_info_resource_path` | character | Player draft info resource path. |
+| `player_draft_info_resource_summary` | character | Player draft info resource summary. |
+| `player_draft_info_resource_notes` | character | Player draft info resource notes. |
+| `player_draft_info_resource_versions_allowed` | character | Player draft info resource versions allowed. |
+| `player_draft_info_resource_versions_current` | character | Player draft info resource versions current. |
+| `player_draft_info_resource_methods` | character | Player draft info resource methods. |
+| `player_draft_info_resource_formats` | character | Player draft info resource formats. |
+| `player_draft_info_resource_parameters` | character | Player draft info resource parameters. |
+| `player_draft_info_resource_auth_settings_require_auth` | logical | Player draft info resource auth settings require auth. |
+| `player_draft_info_resource_auth_settings_allow_only` | character | Player draft info resource auth settings allow only. |
+| `player_draft_info_resource_resource_cache_ns` | character | Player draft info resource resource cache ns. |
+| `player_draft_info_resource_resource_cache_cache_keys` | character | Player draft info resource resource cache cache keys. |
+| `player_draft_info_resource_resource_cache_cache_buster` | integer | Player draft info resource resource cache cache buster. |
+| `player_draft_info_resource_expiration_message_object_key_name` | character | Player draft info resource expiration message object key name. |
+| `player_combine_data_resource_location` | character | Player combine data resource location. |
+| `player_combine_data_resource_route` | character | Player combine data resource route. |
+| `player_combine_data_resource_path` | character | Player combine data resource path. |
+| `player_combine_data_resource_summary` | character | Player combine data resource summary. |
+| `player_combine_data_resource_notes` | character | Player combine data resource notes. |
+| `player_combine_data_resource_versions_allowed` | character | Player combine data resource versions allowed. |
+| `player_combine_data_resource_versions_current` | character | Player combine data resource versions current. |
+| `player_combine_data_resource_methods` | character | Player combine data resource methods. |
+| `player_combine_data_resource_formats` | character | Player combine data resource formats. |
+| `player_combine_data_resource_parameters` | character | Player combine data resource parameters. |
+| `player_combine_data_resource_auth_settings_require_auth` | logical | Player combine data resource auth settings require auth. |
+| `player_combine_data_resource_auth_settings_allow_only` | character | Player combine data resource auth settings allow only. |
+| `player_combine_data_resource_resource_cache_ns` | character | Player combine data resource resource cache ns. |
+| `player_combine_data_resource_resource_cache_cache_keys` | character | Player combine data resource resource cache cache keys. |
+| `player_combine_data_resource_resource_cache_cache_buster` | integer | Player combine data resource resource cache cache buster. |
+| `player_combine_data_resource_expiration_message_object_key_name` | character | Player combine data resource expiration message object key name. |
+| `player_injuries_resource_location` | character | Player injuries resource location. |
+| `player_injuries_resource_route` | character | Player injuries resource route. |
+| `player_injuries_resource_path` | character | Player injuries resource path. |
+| `player_injuries_resource_summary` | character | Player injuries resource summary. |
+| `player_injuries_resource_notes` | character | Player injuries resource notes. |
+| `player_injuries_resource_versions_allowed` | character | Player injuries resource versions allowed. |
+| `player_injuries_resource_versions_current` | character | Player injuries resource versions current. |
+| `player_injuries_resource_methods` | character | Player injuries resource methods. |
+| `player_injuries_resource_formats` | character | Player injuries resource formats. |
+| `player_injuries_resource_parameters` | character | Player injuries resource parameters. |
+| `player_injuries_resource_auth_settings_require_auth` | logical | Player injuries resource auth settings require auth. |
+| `player_injuries_resource_auth_settings_allow_only` | character | Player injuries resource auth settings allow only. |
+| `player_injuries_resource_resource_cache_ns` | character | Player injuries resource resource cache ns. |
+| `player_injuries_resource_resource_cache_cache_keys` | character | Player injuries resource resource cache cache keys. |
+| `player_injuries_resource_resource_cache_cache_buster` | integer | Player injuries resource resource cache cache buster. |
+| `player_injuries_resource_expiration_message_object_key_name` | character | Player injuries resource expiration message object key name. |
+| `player_transactions_resource_location` | character | Player transactions resource location. |
+| `player_transactions_resource_route` | character | Player transactions resource route. |
+| `player_transactions_resource_path` | character | Player transactions resource path. |
+| `player_transactions_resource_summary` | character | Player transactions resource summary. |
+| `player_transactions_resource_notes` | character | Player transactions resource notes. |
+| `player_transactions_resource_versions_allowed` | character | Player transactions resource versions allowed. |
+| `player_transactions_resource_versions_current` | character | Player transactions resource versions current. |
+| `player_transactions_resource_methods` | character | Player transactions resource methods. |
+| `player_transactions_resource_formats` | character | Player transactions resource formats. |
+| `player_transactions_resource_parameters` | character | Player transactions resource parameters. |
+| `player_transactions_resource_auth_settings_require_auth` | logical | Player transactions resource auth settings require auth. |
+| `player_transactions_resource_auth_settings_allow_only` | character | Player transactions resource auth settings allow only. |
+| `player_transactions_resource_resource_cache_ns` | character | Player transactions resource resource cache ns. |
+| `player_transactions_resource_resource_cache_cache_keys` | character | Player transactions resource resource cache cache keys. |
+| `player_transactions_resource_resource_cache_cache_buster` | integer | Player transactions resource resource cache cache buster. |
+| `player_transactions_resource_expiration_message_object_key_name` | character | Player transactions resource expiration message object key name. |
+| `player_encyclopedia_resource_location` | character | Player encyclopedia resource location. |
+| `player_encyclopedia_resource_route` | character | Player encyclopedia resource route. |
+| `player_encyclopedia_resource_path` | character | Player encyclopedia resource path. |
+| `player_encyclopedia_resource_summary` | character | Player encyclopedia resource summary. |
+| `player_encyclopedia_resource_notes` | character | Player encyclopedia resource notes. |
+| `player_encyclopedia_resource_versions_allowed` | character | Player encyclopedia resource versions allowed. |
+| `player_encyclopedia_resource_versions_current` | character | Player encyclopedia resource versions current. |
+| `player_encyclopedia_resource_methods` | character | Player encyclopedia resource methods. |
+| `player_encyclopedia_resource_formats` | character | Player encyclopedia resource formats. |
+| `player_encyclopedia_resource_parameters` | character | Player encyclopedia resource parameters. |
+| `player_encyclopedia_resource_auth_settings_require_auth` | logical | Player encyclopedia resource auth settings require auth. |
+| `player_encyclopedia_resource_auth_settings_allow_only` | character | Player encyclopedia resource auth settings allow only. |
+| `player_encyclopedia_resource_resource_cache_ns` | character | Player encyclopedia resource resource cache ns. |
+| `player_encyclopedia_resource_resource_cache_cache_keys` | character | Player encyclopedia resource resource cache cache keys. |
+| `player_encyclopedia_resource_resource_cache_cache_buster` | integer | Player encyclopedia resource resource cache cache buster. |
+| `player_encyclopedia_resource_expiration_message_object_key_name` | character | Player encyclopedia resource expiration message object key name. |
+| `golfer_results_resource_location` | character | Golfer results resource location. |
+| `golfer_results_resource_route` | character | Golfer results resource route. |
+| `golfer_results_resource_path` | character | Golfer results resource path. |
+| `golfer_results_resource_summary` | character | Golfer results resource summary. |
+| `golfer_results_resource_notes` | character | Golfer results resource notes. |
+| `golfer_results_resource_versions_allowed` | character | Golfer results resource versions allowed. |
+| `golfer_results_resource_versions_current` | character | Golfer results resource versions current. |
+| `golfer_results_resource_methods` | character | Golfer results resource methods. |
+| `golfer_results_resource_formats` | character | Golfer results resource formats. |
+| `golfer_results_resource_parameters` | character | Golfer results resource parameters. |
+| `golfer_results_resource_auth_settings_require_auth` | logical | Golfer results resource auth settings require auth. |
+| `golfer_results_resource_auth_settings_allow_only` | character | Golfer results resource auth settings allow only. |
+| `golfer_results_resource_resource_cache_ns` | character | Golfer results resource resource cache ns. |
+| `golfer_results_resource_resource_cache_cache_keys` | character | Golfer results resource resource cache cache keys. |
+| `golfer_results_resource_resource_cache_cache_buster` | integer | Golfer results resource resource cache cache buster. |
+| `golfer_results_resource_expiration_message_object_key_name` | character | Golfer results resource expiration message object key name. |
+| `depth_charts_resource_location` | character | Depth charts resource location. |
+| `depth_charts_resource_route` | character | Depth charts resource route. |
+| `depth_charts_resource_path` | character | Depth charts resource path. |
+| `depth_charts_resource_summary` | character | Depth charts resource summary. |
+| `depth_charts_resource_notes` | character | Depth charts resource notes. |
+| `depth_charts_resource_versions_allowed` | character | Depth charts resource versions allowed. |
+| `depth_charts_resource_versions_current` | character | Depth charts resource versions current. |
+| `depth_charts_resource_methods` | character | Depth charts resource methods. |
+| `depth_charts_resource_formats` | character | Depth charts resource formats. |
+| `depth_charts_resource_parameters` | character | Depth charts resource parameters. |
+| `depth_charts_resource_auth_settings_require_auth` | logical | Depth charts resource auth settings require auth. |
+| `depth_charts_resource_auth_settings_allow_only` | character | Depth charts resource auth settings allow only. |
+| `depth_charts_resource_resource_cache_ns` | character | Depth charts resource resource cache ns. |
+| `depth_charts_resource_resource_cache_cache_keys` | character | Depth charts resource resource cache cache keys. |
+| `depth_charts_resource_resource_cache_cache_buster` | integer | Depth charts resource resource cache cache buster. |
+| `depth_charts_resource_expiration_message_object_key_name` | character | Depth charts resource expiration message object key name. |
+| `team_players_resource_location` | character | Team players resource location. |
+| `team_players_resource_route` | character | Team players resource route. |
+| `team_players_resource_path` | character | Team players resource path. |
+| `team_players_resource_summary` | character | Team players resource summary. |
+| `team_players_resource_notes` | character | Team players resource notes. |
+| `team_players_resource_versions_allowed` | character | Team players resource versions allowed. |
+| `team_players_resource_versions_current` | character | Team players resource versions current. |
+| `team_players_resource_methods` | character | Team players resource methods. |
+| `team_players_resource_formats` | character | Team players resource formats. |
+| `team_players_resource_parameters` | character | Team players resource parameters. |
+| `team_players_resource_auth_settings_require_auth` | logical | Team players resource auth settings require auth. |
+| `team_players_resource_auth_settings_allow_only` | character | Team players resource auth settings allow only. |
+| `team_players_resource_resource_cache_ns` | character | Team players resource resource cache ns. |
+| `team_players_resource_resource_cache_cache_keys` | character | Team players resource resource cache cache keys. |
+| `team_players_resource_resource_cache_cache_buster` | integer | Team players resource resource cache cache buster. |
+| `team_players_resource_expiration_message_object_key_name` | character | Team players resource expiration message object key name. |
+| `team_standings_resource_location` | character | Team standings resource location. |
+| `team_standings_resource_route` | character | Team standings resource route. |
+| `team_standings_resource_path` | character | Team standings resource path. |
+| `team_standings_resource_summary` | character | Team standings resource summary. |
+| `team_standings_resource_notes` | character | Team standings resource notes. |
+| `team_standings_resource_versions_allowed` | character | Team standings resource versions allowed. |
+| `team_standings_resource_versions_current` | character | Team standings resource versions current. |
+| `team_standings_resource_methods` | character | Team standings resource methods. |
+| `team_standings_resource_formats` | character | Team standings resource formats. |
+| `team_standings_resource_parameters` | character | Team standings resource parameters. |
+| `team_standings_resource_auth_settings_require_auth` | logical | Team standings resource auth settings require auth. |
+| `team_standings_resource_auth_settings_allow_only` | character | Team standings resource auth settings allow only. |
+| `team_standings_resource_resource_cache_ns` | character | Team standings resource resource cache ns. |
+| `team_standings_resource_resource_cache_cache_keys` | character | Team standings resource resource cache cache keys. |
+| `team_standings_resource_resource_cache_cache_buster` | integer | Team standings resource resource cache cache buster. |
+| `team_standings_resource_expiration_message_object_key_name` | character | Team standings resource expiration message object key name. |
+| `sports_line_team_standings_resource_location` | character | Sports line team standings resource location. |
+| `sports_line_team_standings_resource_route` | character | Sports line team standings resource route. |
+| `sports_line_team_standings_resource_path` | character | Sports line team standings resource path. |
+| `sports_line_team_standings_resource_summary` | character | Sports line team standings resource summary. |
+| `sports_line_team_standings_resource_notes` | character | Sports line team standings resource notes. |
+| `sports_line_team_standings_resource_versions_allowed` | character | Sports line team standings resource versions allowed. |
+| `sports_line_team_standings_resource_versions_current` | character | Sports line team standings resource versions current. |
+| `sports_line_team_standings_resource_methods` | character | Sports line team standings resource methods. |
+| `sports_line_team_standings_resource_formats` | character | Sports line team standings resource formats. |
+| `sports_line_team_standings_resource_parameters` | character | Sports line team standings resource parameters. |
+| `sports_line_team_standings_resource_auth_settings_require_auth` | logical | Sports line team standings resource auth settings require auth. |
+| `sports_line_team_standings_resource_auth_settings_allow_only` | character | Sports line team standings resource auth settings allow only. |
+| `sports_line_team_standings_resource_resource_cache_ns` | character | Sports line team standings resource resource cache ns. |
+| `sports_line_team_standings_resource_resource_cache_cache_keys` | character | Sports line team standings resource resource cache cache keys. |
+| `sports_line_team_standings_resource_resource_cache_cache_buster` | integer | Sports line team standings resource resource cache cache buster. |
+| `sports_line_team_standings_resource_expiration_message_object_key_name` | character | Sports line team standings resource expiration message object key name. |
+| `league_resource_location` | character | League resource location. |
+| `league_resource_route` | character | League resource route. |
+| `league_resource_path` | character | League resource path. |
+| `league_resource_summary` | character | League resource summary. |
+| `league_resource_notes` | character | League resource notes. |
+| `league_resource_versions_allowed` | character | League resource versions allowed. |
+| `league_resource_versions_current` | character | League resource versions current. |
+| `league_resource_methods` | character | League resource methods. |
+| `league_resource_formats` | character | League resource formats. |
+| `league_resource_parameters` | character | League resource parameters. |
+| `league_resource_auth_settings_require_auth` | logical | League resource auth settings require auth. |
+| `league_resource_auth_settings_allow_only` | character | League resource auth settings allow only. |
+| `league_resource_resource_cache_ns` | character | League resource resource cache ns. |
+| `league_resource_resource_cache_cache_keys` | character | League resource resource cache cache keys. |
+| `league_resource_resource_cache_cache_buster` | integer | League resource resource cache cache buster. |
+| `league_resource_expiration_message_object_key_name` | character | League resource expiration message object key name. |
+| `league_teams_resource_location` | character | League teams resource location. |
+| `league_teams_resource_route` | character | League teams resource route. |
+| `league_teams_resource_path` | character | League teams resource path. |
+| `league_teams_resource_summary` | character | League teams resource summary. |
+| `league_teams_resource_notes` | character | League teams resource notes. |
+| `league_teams_resource_versions_allowed` | character | League teams resource versions allowed. |
+| `league_teams_resource_versions_current` | character | League teams resource versions current. |
+| `league_teams_resource_methods` | character | League teams resource methods. |
+| `league_teams_resource_formats` | character | League teams resource formats. |
+| `league_teams_resource_parameters` | character | League teams resource parameters. |
+| `league_teams_resource_auth_settings_require_auth` | logical | League teams resource auth settings require auth. |
+| `league_teams_resource_auth_settings_allow_only` | character | League teams resource auth settings allow only. |
+| `league_teams_resource_resource_cache_ns` | character | League teams resource resource cache ns. |
+| `league_teams_resource_resource_cache_cache_keys` | character | League teams resource resource cache cache keys. |
+| `league_teams_resource_resource_cache_cache_buster` | integer | League teams resource resource cache cache buster. |
+| `league_teams_resource_expiration_message_object_key_name` | character | League teams resource expiration message object key name. |
+| `season_teams_resource_location` | character | Season teams resource location. |
+| `season_teams_resource_route` | character | Season teams resource route. |
+| `season_teams_resource_path` | character | Season teams resource path. |
+| `season_teams_resource_summary` | character | Season teams resource summary. |
+| `season_teams_resource_notes` | character | Season teams resource notes. |
+| `season_teams_resource_versions_allowed` | character | Season teams resource versions allowed. |
+| `season_teams_resource_versions_current` | character | Season teams resource versions current. |
+| `season_teams_resource_methods` | character | Season teams resource methods. |
+| `season_teams_resource_formats` | character | Season teams resource formats. |
+| `season_teams_resource_parameters` | character | Season teams resource parameters. |
+| `season_teams_resource_auth_settings_require_auth` | logical | Season teams resource auth settings require auth. |
+| `season_teams_resource_auth_settings_allow_only` | character | Season teams resource auth settings allow only. |
+| `season_teams_resource_resource_cache_ns` | character | Season teams resource resource cache ns. |
+| `season_teams_resource_resource_cache_cache_keys` | character | Season teams resource resource cache cache keys. |
+| `season_teams_resource_resource_cache_cache_buster` | integer | Season teams resource resource cache cache buster. |
+| `season_teams_resource_expiration_message_object_key_name` | character | Season teams resource expiration message object key name. |
+| `game_resource_location` | character | Game resource location. |
+| `game_resource_route` | character | Game resource route. |
+| `game_resource_path` | character | Game resource path. |
+| `game_resource_summary` | character | Game resource summary. |
+| `game_resource_notes` | character | Game resource notes. |
+| `game_resource_versions_allowed` | character | Game resource versions allowed. |
+| `game_resource_versions_current` | character | Game resource versions current. |
+| `game_resource_methods` | character | Game resource methods. |
+| `game_resource_formats` | character | Game resource formats. |
+| `game_resource_parameters` | character | Game resource parameters. |
+| `game_resource_auth_settings_require_auth` | logical | Game resource auth settings require auth. |
+| `game_resource_auth_settings_allow_only` | character | Game resource auth settings allow only. |
+| `game_resource_resource_cache_ns` | character | Game resource resource cache ns. |
+| `game_resource_resource_cache_cache_keys` | character | Game resource resource cache cache keys. |
+| `game_resource_resource_cache_cache_buster` | integer | Game resource resource cache cache buster. |
+| `game_resource_expiration_message_object_key_name` | character | Game resource expiration message object key name. |
+| `game_lineup_resource_location` | character | Game lineup resource location. |
+| `game_lineup_resource_route` | character | Game lineup resource route. |
+| `game_lineup_resource_path` | character | Game lineup resource path. |
+| `game_lineup_resource_summary` | character | Game lineup resource summary. |
+| `game_lineup_resource_notes` | character | Game lineup resource notes. |
+| `game_lineup_resource_versions_allowed` | character | Game lineup resource versions allowed. |
+| `game_lineup_resource_versions_current` | character | Game lineup resource versions current. |
+| `game_lineup_resource_methods` | character | Game lineup resource methods. |
+| `game_lineup_resource_formats` | character | Game lineup resource formats. |
+| `game_lineup_resource_parameters` | character | Game lineup resource parameters. |
+| `game_lineup_resource_auth_settings_require_auth` | logical | Game lineup resource auth settings require auth. |
+| `game_lineup_resource_auth_settings_allow_only` | character | Game lineup resource auth settings allow only. |
+| `game_lineup_resource_resource_cache_ns` | character | Game lineup resource resource cache ns. |
+| `game_lineup_resource_resource_cache_cache_keys` | character | Game lineup resource resource cache cache keys. |
+| `game_lineup_resource_resource_cache_cache_buster` | integer | Game lineup resource resource cache cache buster. |
+| `game_lineup_resource_expiration_message_object_key_name` | character | Game lineup resource expiration message object key name. |
+| `odds_resource_location` | character | Odds resource location. |
+| `odds_resource_route` | character | Odds resource route. |
+| `odds_resource_path` | character | Odds resource path. |
+| `odds_resource_summary` | character | Odds resource summary. |
+| `odds_resource_notes` | character | Odds resource notes. |
+| `odds_resource_versions_allowed` | character | Odds resource versions allowed. |
+| `odds_resource_versions_current` | character | Odds resource versions current. |
+| `odds_resource_methods` | character | Odds resource methods. |
+| `odds_resource_formats` | character | Odds resource formats. |
+| `odds_resource_parameters` | character | Odds resource parameters. |
+| `odds_resource_auth_settings_require_auth` | logical | Odds resource auth settings require auth. |
+| `odds_resource_auth_settings_allow_only` | character | Odds resource auth settings allow only. |
+| `odds_resource_resource_cache_ns` | character | Odds resource resource cache ns. |
+| `odds_resource_resource_cache_cache_keys` | character | Odds resource resource cache cache keys. |
+| `odds_resource_resource_cache_cache_buster` | integer | Odds resource resource cache cache buster. |
+| `odds_resource_expiration_message_object_key_name` | character | Odds resource expiration message object key name. |
+| `game_outcomes_resource_location` | character | Game outcomes resource location. |
+| `game_outcomes_resource_route` | character | Game outcomes resource route. |
+| `game_outcomes_resource_path` | character | Game outcomes resource path. |
+| `game_outcomes_resource_summary` | character | Game outcomes resource summary. |
+| `game_outcomes_resource_notes` | character | Game outcomes resource notes. |
+| `game_outcomes_resource_versions_allowed` | character | Game outcomes resource versions allowed. |
+| `game_outcomes_resource_versions_current` | character | Game outcomes resource versions current. |
+| `game_outcomes_resource_methods` | character | Game outcomes resource methods. |
+| `game_outcomes_resource_formats` | character | Game outcomes resource formats. |
+| `game_outcomes_resource_parameters` | character | Game outcomes resource parameters. |
+| `game_outcomes_resource_auth_settings_require_auth` | logical | Game outcomes resource auth settings require auth. |
+| `game_outcomes_resource_auth_settings_allow_only` | character | Game outcomes resource auth settings allow only. |
+| `game_outcomes_resource_resource_cache_ns` | character | Game outcomes resource resource cache ns. |
+| `game_outcomes_resource_resource_cache_cache_keys` | character | Game outcomes resource resource cache cache keys. |
+| `game_outcomes_resource_resource_cache_cache_buster` | integer | Game outcomes resource resource cache cache buster. |
+| `game_outcomes_resource_expiration_message_object_key_name` | character | Game outcomes resource expiration message object key name. |
+| `game_odds_resource_location` | character | Game odds resource location. |
+| `game_odds_resource_route` | character | Game odds resource route. |
+| `game_odds_resource_path` | character | Game odds resource path. |
+| `game_odds_resource_summary` | character | Game odds resource summary. |
+| `game_odds_resource_notes` | character | Game odds resource notes. |
+| `game_odds_resource_versions_allowed` | character | Game odds resource versions allowed. |
+| `game_odds_resource_versions_current` | character | Game odds resource versions current. |
+| `game_odds_resource_methods` | character | Game odds resource methods. |
+| `game_odds_resource_formats` | character | Game odds resource formats. |
+| `game_odds_resource_parameters` | character | Game odds resource parameters. |
+| `game_odds_resource_auth_settings_require_auth` | logical | Game odds resource auth settings require auth. |
+| `game_odds_resource_auth_settings_allow_only` | character | Game odds resource auth settings allow only. |
+| `game_odds_resource_resource_cache_ns` | character | Game odds resource resource cache ns. |
+| `game_odds_resource_resource_cache_cache_keys` | character | Game odds resource resource cache cache keys. |
+| `game_odds_resource_resource_cache_cache_buster` | integer | Game odds resource resource cache cache buster. |
+| `game_odds_resource_expiration_message_object_key_name` | character | Game odds resource expiration message object key name. |
+| `game_hq_odds_resource_location` | character | Game hq odds resource location. |
+| `game_hq_odds_resource_route` | character | Game hq odds resource route. |
+| `game_hq_odds_resource_path` | character | Game hq odds resource path. |
+| `game_hq_odds_resource_summary` | character | Game hq odds resource summary. |
+| `game_hq_odds_resource_notes` | character | Game hq odds resource notes. |
+| `game_hq_odds_resource_versions_allowed` | character | Game hq odds resource versions allowed. |
+| `game_hq_odds_resource_versions_current` | character | Game hq odds resource versions current. |
+| `game_hq_odds_resource_methods` | character | Game hq odds resource methods. |
+| `game_hq_odds_resource_formats` | character | Game hq odds resource formats. |
+| `game_hq_odds_resource_parameters` | character | Game hq odds resource parameters. |
+| `game_hq_odds_resource_auth_settings_require_auth` | logical | Game hq odds resource auth settings require auth. |
+| `game_hq_odds_resource_auth_settings_allow_only` | character | Game hq odds resource auth settings allow only. |
+| `game_hq_odds_resource_resource_cache_ns` | character | Game hq odds resource resource cache ns. |
+| `game_hq_odds_resource_resource_cache_cache_keys` | character | Game hq odds resource resource cache cache keys. |
+| `game_hq_odds_resource_resource_cache_cache_buster` | integer | Game hq odds resource resource cache cache buster. |
+| `game_hq_odds_resource_expiration_message_object_key_name` | character | Game hq odds resource expiration message object key name. |
+| `weather_resource_location` | character | Weather resource location. |
+| `weather_resource_route` | character | Weather resource route. |
+| `weather_resource_path` | character | Weather resource path. |
+| `weather_resource_summary` | character | Weather resource summary. |
+| `weather_resource_notes` | character | Weather resource notes. |
+| `weather_resource_versions_allowed` | character | Weather resource versions allowed. |
+| `weather_resource_versions_current` | character | Weather resource versions current. |
+| `weather_resource_methods` | character | Weather resource methods. |
+| `weather_resource_formats` | character | Weather resource formats. |
+| `weather_resource_parameters` | character | Weather resource parameters. |
+| `weather_resource_auth_settings_require_auth` | logical | Weather resource auth settings require auth. |
+| `weather_resource_auth_settings_allow_only` | character | Weather resource auth settings allow only. |
+| `weather_resource_resource_cache_ns` | character | Weather resource resource cache ns. |
+| `weather_resource_resource_cache_cache_keys` | character | Weather resource resource cache cache keys. |
+| `weather_resource_resource_cache_cache_buster` | integer | Weather resource resource cache cache buster. |
+| `weather_resource_expiration_message_object_key_name` | character | Weather resource expiration message object key name. |
+| `game_betting_splits_resource_location` | character | Game betting splits resource location. |
+| `game_betting_splits_resource_route` | character | Game betting splits resource route. |
+| `game_betting_splits_resource_path` | character | Game betting splits resource path. |
+| `game_betting_splits_resource_summary` | character | Game betting splits resource summary. |
+| `game_betting_splits_resource_notes` | character | Game betting splits resource notes. |
+| `game_betting_splits_resource_versions_allowed` | character | Game betting splits resource versions allowed. |
+| `game_betting_splits_resource_versions_current` | character | Game betting splits resource versions current. |
+| `game_betting_splits_resource_methods` | character | Game betting splits resource methods. |
+| `game_betting_splits_resource_formats` | character | Game betting splits resource formats. |
+| `game_betting_splits_resource_parameters` | character | Game betting splits resource parameters. |
+| `game_betting_splits_resource_auth_settings_require_auth` | logical | Game betting splits resource auth settings require auth. |
+| `game_betting_splits_resource_auth_settings_allow_only` | character | Game betting splits resource auth settings allow only. |
+| `game_betting_splits_resource_resource_cache_ns` | character | Game betting splits resource resource cache ns. |
+| `game_betting_splits_resource_resource_cache_cache_keys` | character | Game betting splits resource resource cache cache keys. |
+| `game_betting_splits_resource_resource_cache_cache_buster` | integer | Game betting splits resource resource cache cache buster. |
+| `game_betting_splits_resource_expiration_message_object_key_name` | character | Game betting splits resource expiration message object key name. |
+| `featured_game_resource_location` | character | Featured game resource location. |
+| `featured_game_resource_route` | character | Featured game resource route. |
+| `featured_game_resource_path` | character | Featured game resource path. |
+| `featured_game_resource_summary` | character | Featured game resource summary. |
+| `featured_game_resource_notes` | character | Featured game resource notes. |
+| `featured_game_resource_versions_allowed` | character | Featured game resource versions allowed. |
+| `featured_game_resource_versions_current` | character | Featured game resource versions current. |
+| `featured_game_resource_methods` | character | Featured game resource methods. |
+| `featured_game_resource_formats` | character | Featured game resource formats. |
+| `featured_game_resource_parameters` | character | Featured game resource parameters. |
+| `featured_game_resource_auth_settings_require_auth` | logical | Featured game resource auth settings require auth. |
+| `featured_game_resource_auth_settings_allow_only` | character | Featured game resource auth settings allow only. |
+| `featured_game_resource_resource_cache_ns` | character | Featured game resource resource cache ns. |
+| `featured_game_resource_resource_cache_cache_keys` | character | Featured game resource resource cache cache keys. |
+| `featured_game_resource_resource_cache_cache_buster` | integer | Featured game resource resource cache cache buster. |
+| `featured_game_resource_expiration_message_object_key_name` | character | Featured game resource expiration message object key name. |
+| `game_scoring_leaders_resource_location` | character | Game scoring leaders resource location. |
+| `game_scoring_leaders_resource_route` | character | Game scoring leaders resource route. |
+| `game_scoring_leaders_resource_path` | character | Game scoring leaders resource path. |
+| `game_scoring_leaders_resource_summary` | character | Game scoring leaders resource summary. |
+| `game_scoring_leaders_resource_notes` | character | Game scoring leaders resource notes. |
+| `game_scoring_leaders_resource_versions_allowed` | character | Game scoring leaders resource versions allowed. |
+| `game_scoring_leaders_resource_versions_current` | character | Game scoring leaders resource versions current. |
+| `game_scoring_leaders_resource_methods` | character | Game scoring leaders resource methods. |
+| `game_scoring_leaders_resource_formats` | character | Game scoring leaders resource formats. |
+| `game_scoring_leaders_resource_parameters` | character | Game scoring leaders resource parameters. |
+| `game_scoring_leaders_resource_auth_settings_require_auth` | logical | Game scoring leaders resource auth settings require auth. |
+| `game_scoring_leaders_resource_auth_settings_allow_only` | character | Game scoring leaders resource auth settings allow only. |
+| `game_scoring_leaders_resource_resource_cache_ns` | character | Game scoring leaders resource resource cache ns. |
+| `game_scoring_leaders_resource_resource_cache_cache_keys` | character | Game scoring leaders resource resource cache cache keys. |
+| `game_scoring_leaders_resource_resource_cache_cache_buster` | integer | Game scoring leaders resource resource cache cache buster. |
+| `game_scoring_leaders_resource_expiration_message_object_key_name` | character | Game scoring leaders resource expiration message object key name. |
+| `game_scoring_player_stats_resource_location` | character | Game scoring player stats resource location. |
+| `game_scoring_player_stats_resource_route` | character | Game scoring player stats resource route. |
+| `game_scoring_player_stats_resource_path` | character | Game scoring player stats resource path. |
+| `game_scoring_player_stats_resource_summary` | character | Game scoring player stats resource summary. |
+| `game_scoring_player_stats_resource_notes` | character | Game scoring player stats resource notes. |
+| `game_scoring_player_stats_resource_versions_allowed` | character | Game scoring player stats resource versions allowed. |
+| `game_scoring_player_stats_resource_versions_current` | character | Game scoring player stats resource versions current. |
+| `game_scoring_player_stats_resource_methods` | character | Game scoring player stats resource methods. |
+| `game_scoring_player_stats_resource_formats` | character | Game scoring player stats resource formats. |
+| `game_scoring_player_stats_resource_parameters` | character | Game scoring player stats resource parameters. |
+| `game_scoring_player_stats_resource_auth_settings_require_auth` | logical | Game scoring player stats resource auth settings require auth. |
+| `game_scoring_player_stats_resource_auth_settings_allow_only` | character | Game scoring player stats resource auth settings allow only. |
+| `game_scoring_player_stats_resource_resource_cache_ns` | character | Game scoring player stats resource resource cache ns. |
+| `game_scoring_player_stats_resource_resource_cache_cache_keys` | character | Game scoring player stats resource resource cache cache keys. |
+| `game_scoring_player_stats_resource_resource_cache_cache_buster` | integer | Game scoring player stats resource resource cache cache buster. |
+| `game_scoring_player_stats_resource_expiration_message_object_key_name` | character | Game scoring player stats resource expiration message object key name. |
+| `game_scoring_scoreboard_resource_location` | character | Game scoring scoreboard resource location. |
+| `game_scoring_scoreboard_resource_route` | character | Game scoring scoreboard resource route. |
+| `game_scoring_scoreboard_resource_path` | character | Game scoring scoreboard resource path. |
+| `game_scoring_scoreboard_resource_summary` | character | Game scoring scoreboard resource summary. |
+| `game_scoring_scoreboard_resource_notes` | character | Game scoring scoreboard resource notes. |
+| `game_scoring_scoreboard_resource_versions_allowed` | character | Game scoring scoreboard resource versions allowed. |
+| `game_scoring_scoreboard_resource_versions_current` | character | Game scoring scoreboard resource versions current. |
+| `game_scoring_scoreboard_resource_methods` | character | Game scoring scoreboard resource methods. |
+| `game_scoring_scoreboard_resource_formats` | character | Game scoring scoreboard resource formats. |
+| `game_scoring_scoreboard_resource_parameters` | character | Game scoring scoreboard resource parameters. |
+| `game_scoring_scoreboard_resource_auth_settings_require_auth` | logical | Game scoring scoreboard resource auth settings require auth. |
+| `game_scoring_scoreboard_resource_auth_settings_allow_only` | character | Game scoring scoreboard resource auth settings allow only. |
+| `game_scoring_scoreboard_resource_resource_cache_ns` | character | Game scoring scoreboard resource resource cache ns. |
+| `game_scoring_scoreboard_resource_resource_cache_cache_keys` | character | Game scoring scoreboard resource resource cache cache keys. |
+| `game_scoring_scoreboard_resource_resource_cache_cache_buster` | integer | Game scoring scoreboard resource resource cache cache buster. |
+| `game_scoring_scoreboard_resource_expiration_message_object_key_name` | character | Game scoring scoreboard resource expiration message object key name. |
+| `game_scoring_scores_resource_location` | character | Game scoring scores resource location. |
+| `game_scoring_scores_resource_route` | character | Game scoring scores resource route. |
+| `game_scoring_scores_resource_path` | character | Game scoring scores resource path. |
+| `game_scoring_scores_resource_summary` | character | Game scoring scores resource summary. |
+| `game_scoring_scores_resource_notes` | character | Game scoring scores resource notes. |
+| `game_scoring_scores_resource_versions_allowed` | character | Game scoring scores resource versions allowed. |
+| `game_scoring_scores_resource_versions_current` | character | Game scoring scores resource versions current. |
+| `game_scoring_scores_resource_methods` | character | Game scoring scores resource methods. |
+| `game_scoring_scores_resource_formats` | character | Game scoring scores resource formats. |
+| `game_scoring_scores_resource_parameters` | character | Game scoring scores resource parameters. |
+| `game_scoring_scores_resource_auth_settings_require_auth` | logical | Game scoring scores resource auth settings require auth. |
+| `game_scoring_scores_resource_auth_settings_allow_only` | character | Game scoring scores resource auth settings allow only. |
+| `game_scoring_scores_resource_resource_cache_ns` | character | Game scoring scores resource resource cache ns. |
+| `game_scoring_scores_resource_resource_cache_cache_keys` | character | Game scoring scores resource resource cache cache keys. |
+| `game_scoring_scores_resource_resource_cache_cache_buster` | integer | Game scoring scores resource resource cache cache buster. |
+| `game_scoring_scores_resource_expiration_message_object_key_name` | character | Game scoring scores resource expiration message object key name. |
+| `game_scoring_ytd_player_stats_resource_location` | character | Game scoring year-to-date player stats resource location. |
+| `game_scoring_ytd_player_stats_resource_route` | character | Game scoring year-to-date player stats resource route. |
+| `game_scoring_ytd_player_stats_resource_path` | character | Game scoring year-to-date player stats resource path. |
+| `game_scoring_ytd_player_stats_resource_summary` | character | Game scoring year-to-date player stats resource summary. |
+| `game_scoring_ytd_player_stats_resource_notes` | character | Game scoring year-to-date player stats resource notes. |
+| `game_scoring_ytd_player_stats_resource_versions_allowed` | character | Game scoring year-to-date player stats resource versions allowed. |
+| `game_scoring_ytd_player_stats_resource_versions_current` | character | Game scoring year-to-date player stats resource versions current. |
+| `game_scoring_ytd_player_stats_resource_methods` | character | Game scoring year-to-date player stats resource methods. |
+| `game_scoring_ytd_player_stats_resource_formats` | character | Game scoring year-to-date player stats resource formats. |
+| `game_scoring_ytd_player_stats_resource_parameters` | character | Game scoring year-to-date player stats resource parameters. |
+| `game_scoring_ytd_player_stats_resource_auth_settings_require_auth` | logical | Game scoring year-to-date player stats resource auth settings require auth. |
+| `game_scoring_ytd_player_stats_resource_auth_settings_allow_only` | character | Game scoring year-to-date player stats resource auth settings allow only. |
+| `game_scoring_ytd_player_stats_resource_resource_cache_ns` | character | Game scoring year-to-date player stats resource resource cache ns. |
+| `game_scoring_ytd_player_stats_resource_resource_cache_cache_keys` | character | Game scoring year-to-date player stats resource resource cache cache keys. |
+| `game_scoring_ytd_player_stats_resource_resource_cache_cache_buster` | integer | Game scoring year-to-date player stats resource resource cache cache buster. |
+| `game_scoring_ytd_player_stats_resource_expiration_message_object_key_name` | character | Game scoring year-to-date player stats resource expiration message object key name. |
+| `game_scoring_plays_resource_location` | character | Game scoring plays resource location. |
+| `game_scoring_plays_resource_route` | character | Game scoring plays resource route. |
+| `game_scoring_plays_resource_path` | character | Game scoring plays resource path. |
+| `game_scoring_plays_resource_summary` | character | Game scoring plays resource summary. |
+| `game_scoring_plays_resource_notes` | character | Game scoring plays resource notes. |
+| `game_scoring_plays_resource_versions_allowed` | character | Game scoring plays resource versions allowed. |
+| `game_scoring_plays_resource_versions_current` | character | Game scoring plays resource versions current. |
+| `game_scoring_plays_resource_methods` | character | Game scoring plays resource methods. |
+| `game_scoring_plays_resource_formats` | character | Game scoring plays resource formats. |
+| `game_scoring_plays_resource_parameters` | character | Game scoring plays resource parameters. |
+| `game_scoring_plays_resource_auth_settings_require_auth` | logical | Game scoring plays resource auth settings require auth. |
+| `game_scoring_plays_resource_auth_settings_allow_only` | character | Game scoring plays resource auth settings allow only. |
+| `game_scoring_plays_resource_resource_cache_ns` | character | Game scoring plays resource resource cache ns. |
+| `game_scoring_plays_resource_resource_cache_cache_keys` | character | Game scoring plays resource resource cache cache keys. |
+| `game_scoring_plays_resource_resource_cache_cache_buster` | integer | Game scoring plays resource resource cache cache buster. |
+| `game_scoring_plays_resource_expiration_message_object_key_name` | character | Game scoring plays resource expiration message object key name. |
+| `game_scoring_drives_resource_location` | character | Game scoring drives resource location. |
+| `game_scoring_drives_resource_route` | character | Game scoring drives resource route. |
+| `game_scoring_drives_resource_path` | character | Game scoring drives resource path. |
+| `game_scoring_drives_resource_summary` | character | Game scoring drives resource summary. |
+| `game_scoring_drives_resource_notes` | character | Game scoring drives resource notes. |
+| `game_scoring_drives_resource_versions_allowed` | character | Game scoring drives resource versions allowed. |
+| `game_scoring_drives_resource_versions_current` | character | Game scoring drives resource versions current. |
+| `game_scoring_drives_resource_methods` | character | Game scoring drives resource methods. |
+| `game_scoring_drives_resource_formats` | character | Game scoring drives resource formats. |
+| `game_scoring_drives_resource_parameters` | character | Game scoring drives resource parameters. |
+| `game_scoring_drives_resource_auth_settings_require_auth` | logical | Game scoring drives resource auth settings require auth. |
+| `game_scoring_drives_resource_auth_settings_allow_only` | character | Game scoring drives resource auth settings allow only. |
+| `game_scoring_drives_resource_resource_cache_ns` | character | Game scoring drives resource resource cache ns. |
+| `game_scoring_drives_resource_resource_cache_cache_keys` | character | Game scoring drives resource resource cache cache keys. |
+| `game_scoring_drives_resource_resource_cache_cache_buster` | integer | Game scoring drives resource resource cache cache buster. |
+| `game_scoring_drives_resource_expiration_message_object_key_name` | character | Game scoring drives resource expiration message object key name. |
+| `game_scoring_rosters_resource_location` | character | Game scoring rosters resource location. |
+| `game_scoring_rosters_resource_route` | character | Game scoring rosters resource route. |
+| `game_scoring_rosters_resource_path` | character | Game scoring rosters resource path. |
+| `game_scoring_rosters_resource_summary` | character | Game scoring rosters resource summary. |
+| `game_scoring_rosters_resource_notes` | character | Game scoring rosters resource notes. |
+| `game_scoring_rosters_resource_versions_allowed` | character | Game scoring rosters resource versions allowed. |
+| `game_scoring_rosters_resource_versions_current` | character | Game scoring rosters resource versions current. |
+| `game_scoring_rosters_resource_methods` | character | Game scoring rosters resource methods. |
+| `game_scoring_rosters_resource_formats` | character | Game scoring rosters resource formats. |
+| `game_scoring_rosters_resource_parameters` | character | Game scoring rosters resource parameters. |
+| `game_scoring_rosters_resource_auth_settings_require_auth` | logical | Game scoring rosters resource auth settings require auth. |
+| `game_scoring_rosters_resource_auth_settings_allow_only` | character | Game scoring rosters resource auth settings allow only. |
+| `game_scoring_rosters_resource_resource_cache_ns` | character | Game scoring rosters resource resource cache ns. |
+| `game_scoring_rosters_resource_resource_cache_cache_keys` | character | Game scoring rosters resource resource cache cache keys. |
+| `game_scoring_rosters_resource_resource_cache_cache_buster` | integer | Game scoring rosters resource resource cache cache buster. |
+| `game_scoring_rosters_resource_expiration_message_object_key_name` | character | Game scoring rosters resource expiration message object key name. |
+| `recruit_rankings_resource_location` | character | Recruit rankings resource location. |
+| `recruit_rankings_resource_route` | character | Recruit rankings resource route. |
+| `recruit_rankings_resource_path` | character | Recruit rankings resource path. |
+| `recruit_rankings_resource_summary` | character | Recruit rankings resource summary. |
+| `recruit_rankings_resource_notes` | character | Recruit rankings resource notes. |
+| `recruit_rankings_resource_versions_allowed` | character | Recruit rankings resource versions allowed. |
+| `recruit_rankings_resource_versions_current` | character | Recruit rankings resource versions current. |
+| `recruit_rankings_resource_methods` | character | Recruit rankings resource methods. |
+| `recruit_rankings_resource_formats` | character | Recruit rankings resource formats. |
+| `recruit_rankings_resource_parameters` | character | Recruit rankings resource parameters. |
+| `recruit_rankings_resource_auth_settings_require_auth` | logical | Recruit rankings resource auth settings require auth. |
+| `recruit_rankings_resource_auth_settings_allow_only` | character | Recruit rankings resource auth settings allow only. |
+| `recruit_rankings_resource_resource_cache_ns` | character | Recruit rankings resource resource cache ns. |
+| `recruit_rankings_resource_resource_cache_cache_keys` | character | Recruit rankings resource resource cache cache keys. |
+| `recruit_rankings_resource_resource_cache_cache_buster` | integer | Recruit rankings resource resource cache cache buster. |
+| `recruit_rankings_resource_expiration_message_object_key_name` | character | Recruit rankings resource expiration message object key name. |
+| `coach_rankings_resource_location` | character | Coach rankings resource location. |
+| `coach_rankings_resource_route` | character | Coach rankings resource route. |
+| `coach_rankings_resource_path` | character | Coach rankings resource path. |
+| `coach_rankings_resource_summary` | character | Coach rankings resource summary. |
+| `coach_rankings_resource_notes` | character | Coach rankings resource notes. |
+| `coach_rankings_resource_versions_allowed` | character | Coach rankings resource versions allowed. |
+| `coach_rankings_resource_versions_current` | character | Coach rankings resource versions current. |
+| `coach_rankings_resource_methods` | character | Coach rankings resource methods. |
+| `coach_rankings_resource_formats` | character | Coach rankings resource formats. |
+| `coach_rankings_resource_parameters` | character | Coach rankings resource parameters. |
+| `coach_rankings_resource_auth_settings_require_auth` | logical | Coach rankings resource auth settings require auth. |
+| `coach_rankings_resource_auth_settings_allow_only` | character | Coach rankings resource auth settings allow only. |
+| `coach_rankings_resource_resource_cache_ns` | character | Coach rankings resource resource cache ns. |
+| `coach_rankings_resource_resource_cache_cache_keys` | character | Coach rankings resource resource cache cache keys. |
+| `coach_rankings_resource_resource_cache_cache_buster` | integer | Coach rankings resource resource cache cache buster. |
+| `coach_rankings_resource_expiration_message_object_key_name` | character | Coach rankings resource expiration message object key name. |
+| `player_golf_metadata_resource_location` | character | Player golf metadata resource location. |
+| `player_golf_metadata_resource_route` | character | Player golf metadata resource route. |
+| `player_golf_metadata_resource_path` | character | Player golf metadata resource path. |
+| `player_golf_metadata_resource_summary` | character | Player golf metadata resource summary. |
+| `player_golf_metadata_resource_notes` | character | Player golf metadata resource notes. |
+| `player_golf_metadata_resource_versions_allowed` | character | Player golf metadata resource versions allowed. |
+| `player_golf_metadata_resource_versions_current` | character | Player golf metadata resource versions current. |
+| `player_golf_metadata_resource_methods` | character | Player golf metadata resource methods. |
+| `player_golf_metadata_resource_formats` | character | Player golf metadata resource formats. |
+| `player_golf_metadata_resource_parameters` | character | Player golf metadata resource parameters. |
+| `player_golf_metadata_resource_auth_settings_require_auth` | logical | Player golf metadata resource auth settings require auth. |
+| `player_golf_metadata_resource_auth_settings_allow_only` | character | Player golf metadata resource auth settings allow only. |
+| `player_golf_metadata_resource_resource_cache_ns` | character | Player golf metadata resource resource cache ns. |
+| `player_golf_metadata_resource_resource_cache_cache_keys` | character | Player golf metadata resource resource cache cache keys. |
+| `player_golf_metadata_resource_resource_cache_cache_buster` | integer | Player golf metadata resource resource cache cache buster. |
+| `player_golf_metadata_resource_expiration_message_object_key_name` | character | Player golf metadata resource expiration message object key name. |
+| `game_scoring_ytd_team_stats_resource_location` | character | Game scoring year-to-date team stats resource location. |
+| `game_scoring_ytd_team_stats_resource_route` | character | Game scoring year-to-date team stats resource route. |
+| `game_scoring_ytd_team_stats_resource_path` | character | Game scoring year-to-date team stats resource path. |
+| `game_scoring_ytd_team_stats_resource_summary` | character | Game scoring year-to-date team stats resource summary. |
+| `game_scoring_ytd_team_stats_resource_notes` | character | Game scoring year-to-date team stats resource notes. |
+| `game_scoring_ytd_team_stats_resource_versions_allowed` | character | Game scoring year-to-date team stats resource versions allowed. |
+| `game_scoring_ytd_team_stats_resource_versions_current` | character | Game scoring year-to-date team stats resource versions current. |
+| `game_scoring_ytd_team_stats_resource_methods` | character | Game scoring year-to-date team stats resource methods. |
+| `game_scoring_ytd_team_stats_resource_formats` | character | Game scoring year-to-date team stats resource formats. |
+| `game_scoring_ytd_team_stats_resource_parameters` | character | Game scoring year-to-date team stats resource parameters. |
+| `game_scoring_ytd_team_stats_resource_auth_settings_require_auth` | logical | Game scoring year-to-date team stats resource auth settings require auth. |
+| `game_scoring_ytd_team_stats_resource_auth_settings_allow_only` | character | Game scoring year-to-date team stats resource auth settings allow only. |
+| `game_scoring_ytd_team_stats_resource_resource_cache_ns` | character | Game scoring year-to-date team stats resource resource cache ns. |
+| `game_scoring_ytd_team_stats_resource_resource_cache_cache_keys` | character | Game scoring year-to-date team stats resource resource cache cache keys. |
+| `game_scoring_ytd_team_stats_resource_resource_cache_cache_buster` | integer | Game scoring year-to-date team stats resource resource cache cache buster. |
+| `game_scoring_ytd_team_stats_resource_expiration_message_object_key_name` | character | Game scoring year-to-date team stats resource expiration message object key name. |
+| `game_scoring_team_stats_resource_location` | character | Game scoring team stats resource location. |
+| `game_scoring_team_stats_resource_route` | character | Game scoring team stats resource route. |
+| `game_scoring_team_stats_resource_path` | character | Game scoring team stats resource path. |
+| `game_scoring_team_stats_resource_summary` | character | Game scoring team stats resource summary. |
+| `game_scoring_team_stats_resource_notes` | character | Game scoring team stats resource notes. |
+| `game_scoring_team_stats_resource_versions_allowed` | character | Game scoring team stats resource versions allowed. |
+| `game_scoring_team_stats_resource_versions_current` | character | Game scoring team stats resource versions current. |
+| `game_scoring_team_stats_resource_methods` | character | Game scoring team stats resource methods. |
+| `game_scoring_team_stats_resource_formats` | character | Game scoring team stats resource formats. |
+| `game_scoring_team_stats_resource_parameters` | character | Game scoring team stats resource parameters. |
+| `game_scoring_team_stats_resource_auth_settings_require_auth` | logical | Game scoring team stats resource auth settings require auth. |
+| `game_scoring_team_stats_resource_auth_settings_allow_only` | character | Game scoring team stats resource auth settings allow only. |
+| `game_scoring_team_stats_resource_resource_cache_ns` | character | Game scoring team stats resource resource cache ns. |
+| `game_scoring_team_stats_resource_resource_cache_cache_keys` | character | Game scoring team stats resource resource cache cache keys. |
+| `game_scoring_team_stats_resource_resource_cache_cache_buster` | integer | Game scoring team stats resource resource cache cache buster. |
+| `game_scoring_team_stats_resource_expiration_message_object_key_name` | character | Game scoring team stats resource expiration message object key name. |
+| `game_scoring_winprob_resource_location` | character | Game scoring winprob resource location. |
+| `game_scoring_winprob_resource_route` | character | Game scoring winprob resource route. |
+| `game_scoring_winprob_resource_path` | character | Game scoring winprob resource path. |
+| `game_scoring_winprob_resource_summary` | character | Game scoring winprob resource summary. |
+| `game_scoring_winprob_resource_notes` | character | Game scoring winprob resource notes. |
+| `game_scoring_winprob_resource_versions_allowed` | character | Game scoring winprob resource versions allowed. |
+| `game_scoring_winprob_resource_versions_current` | character | Game scoring winprob resource versions current. |
+| `game_scoring_winprob_resource_methods` | character | Game scoring winprob resource methods. |
+| `game_scoring_winprob_resource_formats` | character | Game scoring winprob resource formats. |
+| `game_scoring_winprob_resource_parameters` | character | Game scoring winprob resource parameters. |
+| `game_scoring_winprob_resource_auth_settings_require_auth` | logical | Game scoring winprob resource auth settings require auth. |
+| `game_scoring_winprob_resource_auth_settings_allow_only` | character | Game scoring winprob resource auth settings allow only. |
+| `game_scoring_winprob_resource_resource_cache_ns` | character | Game scoring winprob resource resource cache ns. |
+| `game_scoring_winprob_resource_resource_cache_cache_keys` | character | Game scoring winprob resource resource cache cache keys. |
+| `game_scoring_winprob_resource_resource_cache_cache_buster` | integer | Game scoring winprob resource resource cache cache buster. |
+| `game_scoring_winprob_resource_expiration_message_object_key_name` | character | Game scoring winprob resource expiration message object key name. |
+| `game_rtwp_resource_location` | character | Game real-time win probability resource location. |
+| `game_rtwp_resource_route` | character | Game real-time win probability resource route. |
+| `game_rtwp_resource_path` | character | Game real-time win probability resource path. |
+| `game_rtwp_resource_summary` | character | Game real-time win probability resource summary. |
+| `game_rtwp_resource_notes` | character | Game real-time win probability resource notes. |
+| `game_rtwp_resource_versions_allowed` | character | Game real-time win probability resource versions allowed. |
+| `game_rtwp_resource_versions_current` | character | Game real-time win probability resource versions current. |
+| `game_rtwp_resource_methods` | character | Game real-time win probability resource methods. |
+| `game_rtwp_resource_formats` | character | Game real-time win probability resource formats. |
+| `game_rtwp_resource_parameters` | character | Game real-time win probability resource parameters. |
+| `game_rtwp_resource_auth_settings_require_auth` | logical | Game real-time win probability resource auth settings require auth. |
+| `game_rtwp_resource_auth_settings_allow_only` | character | Game real-time win probability resource auth settings allow only. |
+| `game_rtwp_resource_resource_cache_ns` | character | Game real-time win probability resource resource cache ns. |
+| `game_rtwp_resource_resource_cache_cache_keys` | character | Game real-time win probability resource resource cache cache keys. |
+| `game_rtwp_resource_resource_cache_cache_buster` | integer | Game real-time win probability resource resource cache cache buster. |
+| `game_rtwp_resource_expiration_message_object_key_name` | character | Game real-time win probability resource expiration message object key name. |
+| `game_ticket_resource_location` | character | Game ticket resource location. |
+| `game_ticket_resource_route` | character | Game ticket resource route. |
+| `game_ticket_resource_path` | character | Game ticket resource path. |
+| `game_ticket_resource_summary` | character | Game ticket resource summary. |
+| `game_ticket_resource_notes` | character | Game ticket resource notes. |
+| `game_ticket_resource_versions_allowed` | character | Game ticket resource versions allowed. |
+| `game_ticket_resource_versions_current` | character | Game ticket resource versions current. |
+| `game_ticket_resource_methods` | character | Game ticket resource methods. |
+| `game_ticket_resource_formats` | character | Game ticket resource formats. |
+| `game_ticket_resource_parameters` | character | Game ticket resource parameters. |
+| `game_ticket_resource_auth_settings_require_auth` | logical | Game ticket resource auth settings require auth. |
+| `game_ticket_resource_auth_settings_allow_only` | character | Game ticket resource auth settings allow only. |
+| `game_ticket_resource_resource_cache_ns` | character | Game ticket resource resource cache ns. |
+| `game_ticket_resource_resource_cache_cache_keys` | character | Game ticket resource resource cache cache keys. |
+| `game_ticket_resource_resource_cache_cache_buster` | integer | Game ticket resource resource cache cache buster. |
+| `game_ticket_resource_expiration_message_object_key_name` | character | Game ticket resource expiration message object key name. |
+| `game_content_preview_resource_location` | character | Game content preview resource location. |
+| `game_content_preview_resource_route` | character | Game content preview resource route. |
+| `game_content_preview_resource_path` | character | Game content preview resource path. |
+| `game_content_preview_resource_summary` | character | Game content preview resource summary. |
+| `game_content_preview_resource_notes` | character | Game content preview resource notes. |
+| `game_content_preview_resource_versions_allowed` | character | Game content preview resource versions allowed. |
+| `game_content_preview_resource_versions_current` | character | Game content preview resource versions current. |
+| `game_content_preview_resource_methods` | character | Game content preview resource methods. |
+| `game_content_preview_resource_formats` | character | Game content preview resource formats. |
+| `game_content_preview_resource_parameters` | character | Game content preview resource parameters. |
+| `game_content_preview_resource_auth_settings_require_auth` | logical | Game content preview resource auth settings require auth. |
+| `game_content_preview_resource_auth_settings_allow_only` | character | Game content preview resource auth settings allow only. |
+| `game_content_preview_resource_resource_cache_ns` | character | Game content preview resource resource cache ns. |
+| `game_content_preview_resource_resource_cache_cache_keys` | character | Game content preview resource resource cache cache keys. |
+| `game_content_preview_resource_resource_cache_cache_buster` | integer | Game content preview resource resource cache cache buster. |
+| `game_content_preview_resource_expiration_message_object_key_name` | character | Game content preview resource expiration message object key name. |
+| `game_content_recap_resource_location` | character | Game content recap resource location. |
+| `game_content_recap_resource_route` | character | Game content recap resource route. |
+| `game_content_recap_resource_path` | character | Game content recap resource path. |
+| `game_content_recap_resource_summary` | character | Game content recap resource summary. |
+| `game_content_recap_resource_notes` | character | Game content recap resource notes. |
+| `game_content_recap_resource_versions_allowed` | character | Game content recap resource versions allowed. |
+| `game_content_recap_resource_versions_current` | character | Game content recap resource versions current. |
+| `game_content_recap_resource_methods` | character | Game content recap resource methods. |
+| `game_content_recap_resource_formats` | character | Game content recap resource formats. |
+| `game_content_recap_resource_parameters` | character | Game content recap resource parameters. |
+| `game_content_recap_resource_auth_settings_require_auth` | logical | Game content recap resource auth settings require auth. |
+| `game_content_recap_resource_auth_settings_allow_only` | character | Game content recap resource auth settings allow only. |
+| `game_content_recap_resource_resource_cache_ns` | character | Game content recap resource resource cache ns. |
+| `game_content_recap_resource_resource_cache_cache_keys` | character | Game content recap resource resource cache cache keys. |
+| `game_content_recap_resource_resource_cache_cache_buster` | integer | Game content recap resource resource cache cache buster. |
+| `game_content_recap_resource_expiration_message_object_key_name` | character | Game content recap resource expiration message object key name. |
+| `game_content_story_resource_location` | character | Game content story resource location. |
+| `game_content_story_resource_route` | character | Game content story resource route. |
+| `game_content_story_resource_path` | character | Game content story resource path. |
+| `game_content_story_resource_summary` | character | Game content story resource summary. |
+| `game_content_story_resource_notes` | character | Game content story resource notes. |
+| `game_content_story_resource_versions_allowed` | character | Game content story resource versions allowed. |
+| `game_content_story_resource_versions_current` | character | Game content story resource versions current. |
+| `game_content_story_resource_methods` | character | Game content story resource methods. |
+| `game_content_story_resource_formats` | character | Game content story resource formats. |
+| `game_content_story_resource_parameters` | character | Game content story resource parameters. |
+| `game_content_story_resource_auth_settings_require_auth` | logical | Game content story resource auth settings require auth. |
+| `game_content_story_resource_auth_settings_allow_only` | character | Game content story resource auth settings allow only. |
+| `game_content_story_resource_resource_cache_ns` | character | Game content story resource resource cache ns. |
+| `game_content_story_resource_resource_cache_cache_keys` | character | Game content story resource resource cache cache keys. |
+| `game_content_story_resource_resource_cache_cache_buster` | integer | Game content story resource resource cache cache buster. |
+| `game_content_story_resource_expiration_message_object_key_name` | character | Game content story resource expiration message object key name. |
+| `game_scoring_boxscores_resource_location` | character | Game scoring boxscores resource location. |
+| `game_scoring_boxscores_resource_route` | character | Game scoring boxscores resource route. |
+| `game_scoring_boxscores_resource_path` | character | Game scoring boxscores resource path. |
+| `game_scoring_boxscores_resource_summary` | character | Game scoring boxscores resource summary. |
+| `game_scoring_boxscores_resource_notes` | character | Game scoring boxscores resource notes. |
+| `game_scoring_boxscores_resource_versions_allowed` | character | Game scoring boxscores resource versions allowed. |
+| `game_scoring_boxscores_resource_versions_current` | character | Game scoring boxscores resource versions current. |
+| `game_scoring_boxscores_resource_methods` | character | Game scoring boxscores resource methods. |
+| `game_scoring_boxscores_resource_formats` | character | Game scoring boxscores resource formats. |
+| `game_scoring_boxscores_resource_parameters` | character | Game scoring boxscores resource parameters. |
+| `game_scoring_boxscores_resource_auth_settings_require_auth` | logical | Game scoring boxscores resource auth settings require auth. |
+| `game_scoring_boxscores_resource_auth_settings_allow_only` | character | Game scoring boxscores resource auth settings allow only. |
+| `game_scoring_boxscores_resource_resource_cache_ns` | character | Game scoring boxscores resource resource cache ns. |
+| `game_scoring_boxscores_resource_resource_cache_cache_keys` | character | Game scoring boxscores resource resource cache cache keys. |
+| `game_scoring_boxscores_resource_resource_cache_cache_buster` | integer | Game scoring boxscores resource resource cache cache buster. |
+| `game_scoring_boxscores_resource_expiration_message_object_key_name` | character | Game scoring boxscores resource expiration message object key name. |
+| `event_leaderboard_resource_location` | character | Event leaderboard resource location. |
+| `event_leaderboard_resource_route` | character | Event leaderboard resource route. |
+| `event_leaderboard_resource_path` | character | Event leaderboard resource path. |
+| `event_leaderboard_resource_summary` | character | Event leaderboard resource summary. |
+| `event_leaderboard_resource_notes` | character | Event leaderboard resource notes. |
+| `event_leaderboard_resource_versions_allowed` | character | Event leaderboard resource versions allowed. |
+| `event_leaderboard_resource_versions_current` | character | Event leaderboard resource versions current. |
+| `event_leaderboard_resource_methods` | character | Event leaderboard resource methods. |
+| `event_leaderboard_resource_formats` | character | Event leaderboard resource formats. |
+| `event_leaderboard_resource_parameters` | character | Event leaderboard resource parameters. |
+| `event_leaderboard_resource_auth_settings_require_auth` | logical | Event leaderboard resource auth settings require auth. |
+| `event_leaderboard_resource_auth_settings_allow_only` | character | Event leaderboard resource auth settings allow only. |
+| `event_leaderboard_resource_resource_cache_ns` | character | Event leaderboard resource resource cache ns. |
+| `event_leaderboard_resource_resource_cache_cache_keys` | character | Event leaderboard resource resource cache cache keys. |
+| `event_leaderboard_resource_resource_cache_cache_buster` | integer | Event leaderboard resource resource cache cache buster. |
+| `event_leaderboard_resource_expiration_message_object_key_name` | character | Event leaderboard resource expiration message object key name. |
+| `probable_players_resource_location` | character | Probable players resource location. |
+| `probable_players_resource_route` | character | Probable players resource route. |
+| `probable_players_resource_path` | character | Probable players resource path. |
+| `probable_players_resource_summary` | character | Probable players resource summary. |
+| `probable_players_resource_notes` | character | Probable players resource notes. |
+| `probable_players_resource_versions_allowed` | character | Probable players resource versions allowed. |
+| `probable_players_resource_versions_current` | character | Probable players resource versions current. |
+| `probable_players_resource_methods` | character | Probable players resource methods. |
+| `probable_players_resource_formats` | character | Probable players resource formats. |
+| `probable_players_resource_parameters` | character | Probable players resource parameters. |
+| `probable_players_resource_auth_settings_require_auth` | logical | Probable players resource auth settings require auth. |
+| `probable_players_resource_auth_settings_allow_only` | character | Probable players resource auth settings allow only. |
+| `probable_players_resource_resource_cache_ns` | character | Probable players resource resource cache ns. |
+| `probable_players_resource_resource_cache_cache_keys` | character | Probable players resource resource cache cache keys. |
+| `probable_players_resource_resource_cache_cache_buster` | integer | Probable players resource resource cache cache buster. |
+| `probable_players_resource_expiration_message_object_key_name` | character | Probable players resource expiration message object key name. |
+| `conference_resource_location` | character | Conference resource location. |
+| `conference_resource_routes` | character | Conference resource routes. |
+| `conference_resource_paths` | character | Conference resource paths. |
+| `conference_resource_summary` | character | Conference resource summary. |
+| `conference_resource_notes` | character | Conference resource notes. |
+| `conference_resource_versions_allowed` | character | Conference resource versions allowed. |
+| `conference_resource_versions_current` | character | Conference resource versions current. |
+| `conference_resource_methods` | character | Conference resource methods. |
+| `conference_resource_formats` | character | Conference resource formats. |
+| `conference_resource_parameters` | character | Conference resource parameters. |
+| `conference_resource_auth_settings_require_auth` | logical | Conference resource auth settings require auth. |
+| `conference_resource_auth_settings_allow_only` | character | Conference resource auth settings allow only. |
+| `conference_resource_resource_cache_ns` | character | Conference resource resource cache ns. |
+| `conference_resource_resource_cache_cache_keys` | character | Conference resource resource cache cache keys. |
+| `conference_resource_resource_cache_cache_buster` | integer | Conference resource resource cache cache buster. |
+| `conference_resource_expiration_message_object_key_name` | character | Conference resource expiration message object key name. |
+| `division_resource_location` | character | Division resource location. |
+| `division_resource_routes` | character | Division resource routes. |
+| `division_resource_paths` | character | Division resource paths. |
+| `division_resource_summary` | character | Division resource summary. |
+| `division_resource_notes` | character | Division resource notes. |
+| `division_resource_versions_allowed` | character | Division resource versions allowed. |
+| `division_resource_versions_current` | character | Division resource versions current. |
+| `division_resource_methods` | character | Division resource methods. |
+| `division_resource_formats` | character | Division resource formats. |
+| `division_resource_parameters` | character | Division resource parameters. |
+| `division_resource_auth_settings_require_auth` | logical | Division resource auth settings require auth. |
+| `division_resource_auth_settings_allow_only` | character | Division resource auth settings allow only. |
+| `division_resource_resource_cache_ns` | character | Division resource resource cache ns. |
+| `division_resource_resource_cache_cache_keys` | character | Division resource resource cache cache keys. |
+| `division_resource_resource_cache_cache_buster` | integer | Division resource resource cache cache buster. |
+| `division_resource_expiration_message_object_key_name` | character | Division resource expiration message object key name. |
+| `sub_divisions_resource_location` | character | Sub divisions resource location. |
+| `sub_divisions_resource_route` | character | Sub divisions resource route. |
+| `sub_divisions_resource_path` | character | Sub divisions resource path. |
+| `sub_divisions_resource_summary` | character | Sub divisions resource summary. |
+| `sub_divisions_resource_notes` | character | Sub divisions resource notes. |
+| `sub_divisions_resource_versions_allowed` | character | Sub divisions resource versions allowed. |
+| `sub_divisions_resource_versions_current` | character | Sub divisions resource versions current. |
+| `sub_divisions_resource_methods` | character | Sub divisions resource methods. |
+| `sub_divisions_resource_formats` | character | Sub divisions resource formats. |
+| `sub_divisions_resource_parameters` | character | Sub divisions resource parameters. |
+| `sub_divisions_resource_auth_settings_require_auth` | logical | Sub divisions resource auth settings require auth. |
+| `sub_divisions_resource_auth_settings_allow_only` | character | Sub divisions resource auth settings allow only. |
+| `sub_divisions_resource_resource_cache_ns` | character | Sub divisions resource resource cache ns. |
+| `sub_divisions_resource_resource_cache_cache_keys` | character | Sub divisions resource resource cache cache keys. |
+| `sub_divisions_resource_resource_cache_cache_buster` | integer | Sub divisions resource resource cache cache buster. |
+| `sub_divisions_resource_expiration_message_object_key_name` | character | Sub divisions resource expiration message object key name. |
+| `sport_resource_location` | character | Sport resource location. |
+| `sport_resource_route` | character | Sport resource route. |
+| `sport_resource_path` | character | Sport resource path. |
+| `sport_resource_summary` | character | Sport resource summary. |
+| `sport_resource_notes` | character | Sport resource notes. |
+| `sport_resource_versions_allowed` | character | Sport resource versions allowed. |
+| `sport_resource_versions_current` | character | Sport resource versions current. |
+| `sport_resource_methods` | character | Sport resource methods. |
+| `sport_resource_formats` | character | Sport resource formats. |
+| `sport_resource_parameters` | character | Sport resource parameters. |
+| `sport_resource_auth_settings_require_auth` | logical | Sport resource auth settings require auth. |
+| `sport_resource_auth_settings_allow_only` | character | Sport resource auth settings allow only. |
+| `sport_resource_resource_cache_ns` | character | Sport resource resource cache ns. |
+| `sport_resource_resource_cache_cache_keys` | character | Sport resource resource cache cache keys. |
+| `sport_resource_resource_cache_cache_buster` | integer | Sport resource resource cache cache buster. |
+| `sport_resource_expiration_message` | character | Sport resource expiration message. |
+| `sport_leagues_resource_location` | character | Sport leagues resource location. |
+| `sport_leagues_resource_route` | character | Sport leagues resource route. |
+| `sport_leagues_resource_path` | character | Sport leagues resource path. |
+| `sport_leagues_resource_summary` | character | Sport leagues resource summary. |
+| `sport_leagues_resource_notes` | character | Sport leagues resource notes. |
+| `sport_leagues_resource_versions_allowed` | character | Sport leagues resource versions allowed. |
+| `sport_leagues_resource_versions_current` | character | Sport leagues resource versions current. |
+| `sport_leagues_resource_methods` | character | Sport leagues resource methods. |
+| `sport_leagues_resource_formats` | character | Sport leagues resource formats. |
+| `sport_leagues_resource_parameters` | character | Sport leagues resource parameters. |
+| `sport_leagues_resource_auth_settings_require_auth` | logical | Sport leagues resource auth settings require auth. |
+| `sport_leagues_resource_auth_settings_allow_only` | character | Sport leagues resource auth settings allow only. |
+| `sport_leagues_resource_resource_cache_ns` | character | Sport leagues resource resource cache ns. |
+| `sport_leagues_resource_resource_cache_cache_keys` | character | Sport leagues resource resource cache cache keys. |
+| `sport_leagues_resource_resource_cache_cache_buster` | integer | Sport leagues resource resource cache cache buster. |
+| `sport_leagues_resource_expiration_message` | character | Sport leagues resource expiration message. |
+| `baseball_player_meta_resource_location` | character | Baseball player meta resource location. |
+| `baseball_player_meta_resource_route` | character | Baseball player meta resource route. |
+| `baseball_player_meta_resource_path` | character | Baseball player meta resource path. |
+| `baseball_player_meta_resource_summary` | character | Baseball player meta resource summary. |
+| `baseball_player_meta_resource_notes` | character | Baseball player meta resource notes. |
+| `baseball_player_meta_resource_versions_allowed` | character | Baseball player meta resource versions allowed. |
+| `baseball_player_meta_resource_versions_current` | character | Baseball player meta resource versions current. |
+| `baseball_player_meta_resource_methods` | character | Baseball player meta resource methods. |
+| `baseball_player_meta_resource_formats` | character | Baseball player meta resource formats. |
+| `baseball_player_meta_resource_parameters` | character | Baseball player meta resource parameters. |
+| `baseball_player_meta_resource_auth_settings_require_auth` | logical | Baseball player meta resource auth settings require auth. |
+| `baseball_player_meta_resource_auth_settings_allow_only` | character | Baseball player meta resource auth settings allow only. |
+| `baseball_player_meta_resource_resource_cache_ns` | character | Baseball player meta resource resource cache ns. |
+| `baseball_player_meta_resource_resource_cache_cache_keys` | character | Baseball player meta resource resource cache cache keys. |
+| `baseball_player_meta_resource_resource_cache_cache_buster` | integer | Baseball player meta resource resource cache cache buster. |
+| `baseball_player_meta_resource_expiration_message_object_key_name` | character | Baseball player meta resource expiration message object key name. |
+| `season_resource_location` | character | Season resource location. |
+| `season_resource_route` | character | Season resource route. |
+| `season_resource_path` | character | Season resource path. |
+| `season_resource_summary` | character | Season resource summary. |
+| `season_resource_notes` | character | Season resource notes. |
+| `season_resource_versions_allowed` | character | Season resource versions allowed. |
+| `season_resource_versions_current` | character | Season resource versions current. |
+| `season_resource_methods` | character | Season resource methods. |
+| `season_resource_formats` | character | Season resource formats. |
+| `season_resource_parameters` | character | Season resource parameters. |
+| `season_resource_auth_settings_require_auth` | logical | Season resource auth settings require auth. |
+| `season_resource_auth_settings_allow_only` | character | Season resource auth settings allow only. |
+| `season_resource_resource_cache_ns` | character | Season resource resource cache ns. |
+| `season_resource_resource_cache_cache_keys` | character | Season resource resource cache cache keys. |
+| `season_resource_resource_cache_cache_buster` | integer | Season resource resource cache cache buster. |
+| `season_resource_expiration_message_object_key_name` | character | Season resource expiration message object key name. |
+| `team_seasons_resource_location` | character | Team seasons resource location. |
+| `team_seasons_resource_route` | character | Team seasons resource route. |
+| `team_seasons_resource_path` | character | Team seasons resource path. |
+| `team_seasons_resource_summary` | character | Team seasons resource summary. |
+| `team_seasons_resource_notes` | character | Team seasons resource notes. |
+| `team_seasons_resource_versions_allowed` | character | Team seasons resource versions allowed. |
+| `team_seasons_resource_versions_current` | character | Team seasons resource versions current. |
+| `team_seasons_resource_methods` | character | Team seasons resource methods. |
+| `team_seasons_resource_formats` | character | Team seasons resource formats. |
+| `team_seasons_resource_parameters` | character | Team seasons resource parameters. |
+| `team_seasons_resource_auth_settings_require_auth` | logical | Team seasons resource auth settings require auth. |
+| `team_seasons_resource_auth_settings_allow_only` | character | Team seasons resource auth settings allow only. |
+| `team_seasons_resource_resource_cache_ns` | character | Team seasons resource resource cache ns. |
+| `team_seasons_resource_resource_cache_cache_keys` | character | Team seasons resource resource cache cache keys. |
+| `team_seasons_resource_resource_cache_cache_buster` | integer | Team seasons resource resource cache cache buster. |
+| `team_seasons_resource_expiration_message_object_key_name` | character | Team seasons resource expiration message object key name. |
+| `team_polls_resource_location` | character | Team polls resource location. |
+| `team_polls_resource_route` | character | Team polls resource route. |
+| `team_polls_resource_path` | character | Team polls resource path. |
+| `team_polls_resource_summary` | character | Team polls resource summary. |
+| `team_polls_resource_notes` | character | Team polls resource notes. |
+| `team_polls_resource_versions_allowed` | character | Team polls resource versions allowed. |
+| `team_polls_resource_versions_current` | character | Team polls resource versions current. |
+| `team_polls_resource_methods` | character | Team polls resource methods. |
+| `team_polls_resource_formats` | character | Team polls resource formats. |
+| `team_polls_resource_parameters` | character | Team polls resource parameters. |
+| `team_polls_resource_auth_settings_require_auth` | logical | Team polls resource auth settings require auth. |
+| `team_polls_resource_auth_settings_allow_only` | character | Team polls resource auth settings allow only. |
+| `team_polls_resource_resource_cache_ns` | character | Team polls resource resource cache ns. |
+| `team_polls_resource_resource_cache_cache_keys` | character | Team polls resource resource cache cache keys. |
+| `team_polls_resource_resource_cache_cache_buster` | integer | Team polls resource resource cache cache buster. |
+| `team_polls_resource_expiration_message_object_key_name` | character | Team polls resource expiration message object key name. |
+| `client_configuration_resource_location` | character | Client configuration resource location. |
+| `client_configuration_resource_route` | character | Client configuration resource route. |
+| `client_configuration_resource_path` | character | Client configuration resource path. |
+| `client_configuration_resource_summary` | character | Client configuration resource summary. |
+| `client_configuration_resource_notes` | character | Client configuration resource notes. |
+| `client_configuration_resource_versions_allowed` | character | Client configuration resource versions allowed. |
+| `client_configuration_resource_versions_current` | character | Client configuration resource versions current. |
+| `client_configuration_resource_methods` | character | Client configuration resource methods. |
+| `client_configuration_resource_formats` | character | Client configuration resource formats. |
+| `client_configuration_resource_parameters` | character | Client configuration resource parameters. |
+| `client_configuration_resource_auth_settings_require_auth` | logical | Client configuration resource auth settings require auth. |
+| `client_configuration_resource_resource_cache_ns` | character | Client configuration resource resource cache ns. |
+| `client_configuration_resource_resource_cache_cache_keys` | character | Client configuration resource resource cache cache keys. |
+| `client_configuration_resource_resource_cache_cache_buster` | integer | Client configuration resource resource cache cache buster. |
+| `client_configuration_resource_expiration_message_object_key_name` | character | Client configuration resource expiration message object key name. |
+| `player_stats_resource_location` | character | Player stats resource location. |
+| `player_stats_resource_route` | character | Player stats resource route. |
+| `player_stats_resource_path` | character | Player stats resource path. |
+| `player_stats_resource_summary` | character | Player stats resource summary. |
+| `player_stats_resource_notes` | character | Player stats resource notes. |
+| `player_stats_resource_versions_allowed` | character | Player stats resource versions allowed. |
+| `player_stats_resource_versions_current` | character | Player stats resource versions current. |
+| `player_stats_resource_methods` | character | Player stats resource methods. |
+| `player_stats_resource_formats` | character | Player stats resource formats. |
+| `player_stats_resource_parameters` | character | Player stats resource parameters. |
+| `player_stats_resource_auth_settings_require_auth` | logical | Player stats resource auth settings require auth. |
+| `player_stats_resource_auth_settings_allow_only` | character | Player stats resource auth settings allow only. |
+| `player_stats_resource_resource_cache_ns` | character | Player stats resource resource cache ns. |
+| `player_stats_resource_resource_cache_cache_keys` | character | Player stats resource resource cache cache keys. |
+| `player_stats_resource_resource_cache_cache_buster` | integer | Player stats resource resource cache cache buster. |
+| `player_stats_resource_expiration_message_object_key_name` | character | Player stats resource expiration message object key name. |
+| `team_stats_resource_location` | character | Team stats resource location. |
+| `team_stats_resource_route` | character | Team stats resource route. |
+| `team_stats_resource_path` | character | Team stats resource path. |
+| `team_stats_resource_summary` | character | Team stats resource summary. |
+| `team_stats_resource_notes` | character | Team stats resource notes. |
+| `team_stats_resource_versions_allowed` | character | Team stats resource versions allowed. |
+| `team_stats_resource_versions_current` | character | Team stats resource versions current. |
+| `team_stats_resource_methods` | character | Team stats resource methods. |
+| `team_stats_resource_formats` | character | Team stats resource formats. |
+| `team_stats_resource_parameters` | character | Team stats resource parameters. |
+| `team_stats_resource_auth_settings_require_auth` | logical | Team stats resource auth settings require auth. |
+| `team_stats_resource_auth_settings_allow_only` | character | Team stats resource auth settings allow only. |
+| `team_stats_resource_resource_cache_ns` | character | Team stats resource resource cache ns. |
+| `team_stats_resource_resource_cache_cache_keys` | character | Team stats resource resource cache cache keys. |
+| `team_stats_resource_resource_cache_cache_buster` | integer | Team stats resource resource cache cache buster. |
+| `team_stats_resource_expiration_message_object_key_name` | character | Team stats resource expiration message object key name. |
+| `team_futures_resource_location` | character | Team futures resource location. |
+| `team_futures_resource_route` | character | Team futures resource route. |
+| `team_futures_resource_path` | character | Team futures resource path. |
+| `team_futures_resource_summary` | character | Team futures resource summary. |
+| `team_futures_resource_notes` | character | Team futures resource notes. |
+| `team_futures_resource_versions_allowed` | character | Team futures resource versions allowed. |
+| `team_futures_resource_versions_current` | character | Team futures resource versions current. |
+| `team_futures_resource_methods` | character | Team futures resource methods. |
+| `team_futures_resource_formats` | character | Team futures resource formats. |
+| `team_futures_resource_parameters` | character | Team futures resource parameters. |
+| `team_futures_resource_auth_settings_require_auth` | logical | Team futures resource auth settings require auth. |
+| `team_futures_resource_auth_settings_allow_only` | character | Team futures resource auth settings allow only. |
+| `team_futures_resource_resource_cache_ns` | character | Team futures resource resource cache ns. |
+| `team_futures_resource_resource_cache_cache_keys` | character | Team futures resource resource cache cache keys. |
+| `team_futures_resource_resource_cache_cache_buster` | integer | Team futures resource resource cache cache buster. |
+| `team_futures_resource_expiration_message_object_key_name` | character | Team futures resource expiration message object key name. |
+| `player_futures_resource_location` | character | Player futures resource location. |
+| `player_futures_resource_route` | character | Player futures resource route. |
+| `player_futures_resource_path` | character | Player futures resource path. |
+| `player_futures_resource_summary` | character | Player futures resource summary. |
+| `player_futures_resource_notes` | character | Player futures resource notes. |
+| `player_futures_resource_versions_allowed` | character | Player futures resource versions allowed. |
+| `player_futures_resource_versions_current` | character | Player futures resource versions current. |
+| `player_futures_resource_methods` | character | Player futures resource methods. |
+| `player_futures_resource_formats` | character | Player futures resource formats. |
+| `player_futures_resource_parameters` | character | Player futures resource parameters. |
+| `player_futures_resource_auth_settings_require_auth` | logical | Player futures resource auth settings require auth. |
+| `player_futures_resource_auth_settings_allow_only` | character | Player futures resource auth settings allow only. |
+| `player_futures_resource_resource_cache_ns` | character | Player futures resource resource cache ns. |
+| `player_futures_resource_resource_cache_cache_keys` | character | Player futures resource resource cache cache keys. |
+| `player_futures_resource_resource_cache_cache_buster` | integer | Player futures resource resource cache cache buster. |
+| `player_futures_resource_expiration_message_object_key_name` | character | Player futures resource expiration message object key name. |
+| `game_props_resource_location` | character | Game props resource location. |
+| `game_props_resource_route` | character | Game props resource route. |
+| `game_props_resource_path` | character | Game props resource path. |
+| `game_props_resource_summary` | character | Game props resource summary. |
+| `game_props_resource_notes` | character | Game props resource notes. |
+| `game_props_resource_versions_allowed` | character | Game props resource versions allowed. |
+| `game_props_resource_versions_current` | character | Game props resource versions current. |
+| `game_props_resource_methods` | character | Game props resource methods. |
+| `game_props_resource_formats` | character | Game props resource formats. |
+| `game_props_resource_parameters` | character | Game props resource parameters. |
+| `game_props_resource_auth_settings_require_auth` | logical | Game props resource auth settings require auth. |
+| `game_props_resource_auth_settings_allow_only` | character | Game props resource auth settings allow only. |
+| `game_props_resource_resource_cache_ns` | character | Game props resource resource cache ns. |
+| `game_props_resource_resource_cache_cache_keys` | character | Game props resource resource cache cache keys. |
+| `game_props_resource_resource_cache_cache_buster` | integer | Game props resource resource cache cache buster. |
+| `game_props_resource_expiration_message_object_key_name` | character | Game props resource expiration message object key name. |
+| `player_standings_resource_location` | character | Player standings resource location. |
+| `player_standings_resource_route` | character | Player standings resource route. |
+| `player_standings_resource_path` | character | Player standings resource path. |
+| `player_standings_resource_summary` | character | Player standings resource summary. |
+| `player_standings_resource_notes` | character | Player standings resource notes. |
+| `player_standings_resource_versions_allowed` | character | Player standings resource versions allowed. |
+| `player_standings_resource_versions_current` | character | Player standings resource versions current. |
+| `player_standings_resource_methods` | character | Player standings resource methods. |
+| `player_standings_resource_formats` | character | Player standings resource formats. |
+| `player_standings_resource_parameters` | character | Player standings resource parameters. |
+| `player_standings_resource_auth_settings_require_auth` | logical | Player standings resource auth settings require auth. |
+| `player_standings_resource_auth_settings_allow_only` | character | Player standings resource auth settings allow only. |
+| `player_standings_resource_resource_cache_ns` | character | Player standings resource resource cache ns. |
+| `player_standings_resource_resource_cache_cache_keys` | character | Player standings resource resource cache cache keys. |
+| `player_standings_resource_resource_cache_cache_buster` | integer | Player standings resource resource cache cache buster. |
+| `player_standings_resource_expiration_message_object_key_name` | character | Player standings resource expiration message object key name. |
+| `golf_event_markets_resource_location` | character | Golf event markets resource location. |
+| `golf_event_markets_resource_route` | character | Golf event markets resource route. |
+| `golf_event_markets_resource_path` | character | Golf event markets resource path. |
+| `golf_event_markets_resource_summary` | character | Golf event markets resource summary. |
+| `golf_event_markets_resource_notes` | character | Golf event markets resource notes. |
+| `golf_event_markets_resource_versions_allowed` | character | Golf event markets resource versions allowed. |
+| `golf_event_markets_resource_versions_current` | character | Golf event markets resource versions current. |
+| `golf_event_markets_resource_methods` | character | Golf event markets resource methods. |
+| `golf_event_markets_resource_formats` | character | Golf event markets resource formats. |
+| `golf_event_markets_resource_parameters` | character | Golf event markets resource parameters. |
+| `golf_event_markets_resource_auth_settings_require_auth` | logical | Golf event markets resource auth settings require auth. |
+| `golf_event_markets_resource_auth_settings_allow_only` | character | Golf event markets resource auth settings allow only. |
+| `golf_event_markets_resource_resource_cache_ns` | character | Golf event markets resource resource cache ns. |
+| `golf_event_markets_resource_resource_cache_cache_keys` | character | Golf event markets resource resource cache cache keys. |
+| `golf_event_markets_resource_resource_cache_cache_buster` | integer | Golf event markets resource resource cache cache buster. |
+| `golf_event_markets_resource_expiration_message_object_key_name` | character | Golf event markets resource expiration message object key name. |
+| `golf_player_markets_resource_location` | character | Golf player markets resource location. |
+| `golf_player_markets_resource_route` | character | Golf player markets resource route. |
+| `golf_player_markets_resource_path` | character | Golf player markets resource path. |
+| `golf_player_markets_resource_summary` | character | Golf player markets resource summary. |
+| `golf_player_markets_resource_notes` | character | Golf player markets resource notes. |
+| `golf_player_markets_resource_versions_allowed` | character | Golf player markets resource versions allowed. |
+| `golf_player_markets_resource_versions_current` | character | Golf player markets resource versions current. |
+| `golf_player_markets_resource_methods` | character | Golf player markets resource methods. |
+| `golf_player_markets_resource_formats` | character | Golf player markets resource formats. |
+| `golf_player_markets_resource_parameters` | character | Golf player markets resource parameters. |
+| `golf_player_markets_resource_auth_settings_require_auth` | logical | Golf player markets resource auth settings require auth. |
+| `golf_player_markets_resource_auth_settings_allow_only` | character | Golf player markets resource auth settings allow only. |
+| `golf_player_markets_resource_resource_cache_ns` | character | Golf player markets resource resource cache ns. |
+| `golf_player_markets_resource_resource_cache_cache_keys` | character | Golf player markets resource resource cache cache keys. |
+| `golf_player_markets_resource_resource_cache_cache_buster` | integer | Golf player markets resource resource cache cache buster. |
+| `golf_player_markets_resource_expiration_message_object_key_name` | character | Golf player markets resource expiration message object key name. |
+| `bulk_resource_controller_is_active` | logical | Bulk resource controller is active. |
+| `bulk_resource_controller_location` | character | Bulk resource controller location. |
+| `bulk_resource_controller_route` | character | Bulk resource controller route. |
+| `bulk_resource_controller_path` | character | Bulk resource controller path. |
+| `bulk_resource_controller_summary` | character | Bulk resource controller summary. |
+| `bulk_resource_controller_notes` | character | Bulk resource controller notes. |
+| `bulk_resource_controller_versions_allowed` | character | Bulk resource controller versions allowed. |
+| `bulk_resource_controller_versions_current` | character | Bulk resource controller versions current. |
+| `bulk_resource_controller_methods` | character | Bulk resource controller methods. |
+| `bulk_resource_controller_formats` | character | Bulk resource controller formats. |
+| `bulk_resource_controller_parameters` | character | Bulk resource controller parameters. |
+| `bulk_resource_controller_auth_settings_require_auth` | logical | Bulk resource controller auth settings require auth. |
+| `bulk_resource_controller_auth_settings_allow_only` | character | Bulk resource controller auth settings allow only. |
+| `bulk_resource_controller_resource_cache_no_cache` | logical | Bulk resource controller resource cache no cache. |
+| `bulk_resource_controller_expiration_message` | character | Bulk resource controller expiration message. |
+| `endpoint_registry_resource_location` | character | Endpoint registry resource location. |
+| `endpoint_registry_resource_route` | character | Endpoint registry resource route. |
+| `endpoint_registry_resource_path` | character | Endpoint registry resource path. |
+| `endpoint_registry_resource_summary` | character | Endpoint registry resource summary. |
+| `endpoint_registry_resource_notes` | character | Endpoint registry resource notes. |
+| `endpoint_registry_resource_versions_allowed` | character | Endpoint registry resource versions allowed. |
+| `endpoint_registry_resource_versions_current` | character | Endpoint registry resource versions current. |
+| `endpoint_registry_resource_methods` | character | Endpoint registry resource methods. |
+| `endpoint_registry_resource_formats` | character | Endpoint registry resource formats. |
+| `endpoint_registry_resource_parameters` | character | Endpoint registry resource parameters. |
+| `endpoint_registry_resource_auth_settings_require_auth` | logical | Endpoint registry resource auth settings require auth. |
+| `endpoint_registry_resource_auth_settings_allow_only` | character | Endpoint registry resource auth settings allow only. |
+| `endpoint_registry_resource_resource_cache_no_cache` | logical | Endpoint registry resource resource cache no cache. |
+| `endpoint_registry_resource_expiration_message` | character | Endpoint registry resource expiration message. |
+| `event_resource_location` | character | Event resource location. |
+| `event_resource_route` | character | Event resource route. |
+| `event_resource_path` | character | Event resource path. |
+| `event_resource_summary` | character | Event resource summary. |
+| `event_resource_notes` | character | Event resource notes. |
+| `event_resource_versions_allowed` | character | Event resource versions allowed. |
+| `event_resource_versions_current` | character | Event resource versions current. |
+| `event_resource_methods` | character | Event resource methods. |
+| `event_resource_formats` | character | Event resource formats. |
+| `event_resource_parameters` | character | Event resource parameters. |
+| `event_resource_auth_settings_require_auth` | logical | Event resource auth settings require auth. |
+| `event_resource_auth_settings_allow_only` | character | Event resource auth settings allow only. |
+| `event_resource_resource_cache_ns` | character | Event resource resource cache ns. |
+| `event_resource_resource_cache_cache_keys` | character | Event resource resource cache cache keys. |
+| `event_resource_resource_cache_cache_buster` | integer | Event resource resource cache cache buster. |
+| `event_resource_expiration_message_object_key_name` | character | Event resource expiration message object key name. |
+| `venue_resource_location` | character | Venue resource location. |
+| `venue_resource_route` | character | Venue resource route. |
+| `venue_resource_path` | character | Venue resource path. |
+| `venue_resource_summary` | character | Venue resource summary. |
+| `venue_resource_notes` | character | Venue resource notes. |
+| `venue_resource_versions_allowed` | character | Venue resource versions allowed. |
+| `venue_resource_versions_current` | character | Venue resource versions current. |
+| `venue_resource_methods` | character | Venue resource methods. |
+| `venue_resource_formats` | character | Venue resource formats. |
+| `venue_resource_parameters` | character | Venue resource parameters. |
+| `venue_resource_auth_settings_require_auth` | logical | Venue resource auth settings require auth. |
+| `venue_resource_auth_settings_allow_only` | character | Venue resource auth settings allow only. |
+| `venue_resource_resource_cache_ns` | character | Venue resource resource cache ns. |
+| `venue_resource_resource_cache_cache_keys` | character | Venue resource resource cache cache keys. |
+| `venue_resource_resource_cache_cache_buster` | integer | Venue resource resource cache cache buster. |
+| `venue_resource_expiration_message_object_key_name` | character | Venue resource expiration message object key name. |
+| `venue_metadata_resource_location` | character | Venue metadata resource location. |
+| `venue_metadata_resource_route` | character | Venue metadata resource route. |
+| `venue_metadata_resource_path` | character | Venue metadata resource path. |
+| `venue_metadata_resource_summary` | character | Venue metadata resource summary. |
+| `venue_metadata_resource_notes` | character | Venue metadata resource notes. |
+| `venue_metadata_resource_versions_allowed` | character | Venue metadata resource versions allowed. |
+| `venue_metadata_resource_versions_current` | character | Venue metadata resource versions current. |
+| `venue_metadata_resource_methods` | character | Venue metadata resource methods. |
+| `venue_metadata_resource_formats` | character | Venue metadata resource formats. |
+| `venue_metadata_resource_parameters` | character | Venue metadata resource parameters. |
+| `venue_metadata_resource_auth_settings_require_auth` | logical | Venue metadata resource auth settings require auth. |
+| `venue_metadata_resource_auth_settings_allow_only` | character | Venue metadata resource auth settings allow only. |
+| `venue_metadata_resource_resource_cache_ns` | character | Venue metadata resource resource cache ns. |
+| `venue_metadata_resource_resource_cache_cache_keys` | character | Venue metadata resource resource cache cache keys. |
+| `venue_metadata_resource_resource_cache_cache_buster` | integer | Venue metadata resource resource cache cache buster. |
+| `venue_metadata_resource_expiration_message_object_key_name` | character | Venue metadata resource expiration message object key name. |
+| `event_entrants_resource_location` | character | Event entrants resource location. |
+| `event_entrants_resource_route` | character | Event entrants resource route. |
+| `event_entrants_resource_path` | character | Event entrants resource path. |
+| `event_entrants_resource_summary` | character | Event entrants resource summary. |
+| `event_entrants_resource_notes` | character | Event entrants resource notes. |
+| `event_entrants_resource_versions_allowed` | character | Event entrants resource versions allowed. |
+| `event_entrants_resource_versions_current` | character | Event entrants resource versions current. |
+| `event_entrants_resource_methods` | character | Event entrants resource methods. |
+| `event_entrants_resource_formats` | character | Event entrants resource formats. |
+| `event_entrants_resource_parameters` | character | Event entrants resource parameters. |
+| `event_entrants_resource_auth_settings_require_auth` | logical | Event entrants resource auth settings require auth. |
+| `event_entrants_resource_auth_settings_allow_only` | character | Event entrants resource auth settings allow only. |
+| `event_entrants_resource_resource_cache_ns` | character | Event entrants resource resource cache ns. |
+| `event_entrants_resource_resource_cache_cache_keys` | character | Event entrants resource resource cache cache keys. |
+| `event_entrants_resource_resource_cache_cache_buster` | integer | Event entrants resource resource cache cache buster. |
+| `event_seasons_resource_location` | character | Event seasons resource location. |
+| `event_seasons_resource_route` | character | Event seasons resource route. |
+| `event_seasons_resource_path` | character | Event seasons resource path. |
+| `event_seasons_resource_summary` | character | Event seasons resource summary. |
+| `event_seasons_resource_notes` | character | Event seasons resource notes. |
+| `event_seasons_resource_versions_allowed` | character | Event seasons resource versions allowed. |
+| `event_seasons_resource_versions_current` | character | Event seasons resource versions current. |
+| `event_seasons_resource_methods` | character | Event seasons resource methods. |
+| `event_seasons_resource_formats` | character | Event seasons resource formats. |
+| `event_seasons_resource_parameters` | character | Event seasons resource parameters. |
+| `event_seasons_resource_auth_settings_require_auth` | logical | Event seasons resource auth settings require auth. |
+| `event_seasons_resource_auth_settings_allow_only` | character | Event seasons resource auth settings allow only. |
+| `event_seasons_resource_resource_cache_ns` | character | Event seasons resource resource cache ns. |
+| `event_seasons_resource_resource_cache_cache_keys` | character | Event seasons resource resource cache cache keys. |
+| `event_seasons_resource_resource_cache_cache_buster` | integer | Event seasons resource resource cache cache buster. |
+| `event_venues_resource_location` | character | Event venues resource location. |
+| `event_venues_resource_route` | character | Event venues resource route. |
+| `event_venues_resource_path` | character | Event venues resource path. |
+| `event_venues_resource_summary` | character | Event venues resource summary. |
+| `event_venues_resource_notes` | character | Event venues resource notes. |
+| `event_venues_resource_versions_allowed` | character | Event venues resource versions allowed. |
+| `event_venues_resource_versions_current` | character | Event venues resource versions current. |
+| `event_venues_resource_methods` | character | Event venues resource methods. |
+| `event_venues_resource_formats` | character | Event venues resource formats. |
+| `event_venues_resource_parameters` | character | Event venues resource parameters. |
+| `event_venues_resource_auth_settings_require_auth` | logical | Event venues resource auth settings require auth. |
+| `event_venues_resource_auth_settings_allow_only` | character | Event venues resource auth settings allow only. |
+| `event_venues_resource_resource_cache_ns` | character | Event venues resource resource cache ns. |
+| `event_venues_resource_resource_cache_cache_keys` | character | Event venues resource resource cache cache keys. |
+| `event_venues_resource_resource_cache_cache_buster` | integer | Event venues resource resource cache cache buster. |
+| `event_venues_resource_expiration_message_object_key_name` | character | Event venues resource expiration message object key name. |
+| `player_rankings_resource_location` | character | Player rankings resource location. |
+| `player_rankings_resource_route` | character | Player rankings resource route. |
+| `player_rankings_resource_path` | character | Player rankings resource path. |
+| `player_rankings_resource_summary` | character | Player rankings resource summary. |
+| `player_rankings_resource_notes` | character | Player rankings resource notes. |
+| `player_rankings_resource_versions_allowed` | character | Player rankings resource versions allowed. |
+| `player_rankings_resource_versions_current` | character | Player rankings resource versions current. |
+| `player_rankings_resource_methods` | character | Player rankings resource methods. |
+| `player_rankings_resource_formats` | character | Player rankings resource formats. |
+| `player_rankings_resource_parameters` | character | Player rankings resource parameters. |
+| `player_rankings_resource_auth_settings_require_auth` | logical | Player rankings resource auth settings require auth. |
+| `player_rankings_resource_auth_settings_allow_only` | character | Player rankings resource auth settings allow only. |
+| `player_rankings_resource_resource_cache_ns` | character | Player rankings resource resource cache ns. |
+| `player_rankings_resource_resource_cache_cache_keys` | character | Player rankings resource resource cache cache keys. |
+| `player_rankings_resource_resource_cache_cache_buster` | integer | Player rankings resource resource cache cache buster. |
+| `player_rankings_resource_expiration_message_object_key_name` | character | Player rankings resource expiration message object key name. |
+| `player_outlook_resource_location` | character | Player outlook resource location. |
+| `player_outlook_resource_route` | character | Player outlook resource route. |
+| `player_outlook_resource_path` | character | Player outlook resource path. |
+| `player_outlook_resource_summary` | character | Player outlook resource summary. |
+| `player_outlook_resource_notes` | character | Player outlook resource notes. |
+| `player_outlook_resource_versions_allowed` | character | Player outlook resource versions allowed. |
+| `player_outlook_resource_versions_current` | character | Player outlook resource versions current. |
+| `player_outlook_resource_methods` | character | Player outlook resource methods. |
+| `player_outlook_resource_formats` | character | Player outlook resource formats. |
+| `player_outlook_resource_parameters` | character | Player outlook resource parameters. |
+| `player_outlook_resource_auth_settings_require_auth` | logical | Player outlook resource auth settings require auth. |
+| `player_outlook_resource_auth_settings_allow_only` | character | Player outlook resource auth settings allow only. |
+| `player_outlook_resource_resource_cache_ns` | character | Player outlook resource resource cache ns. |
+| `player_outlook_resource_resource_cache_cache_keys` | character | Player outlook resource resource cache cache keys. |
+| `player_outlook_resource_resource_cache_cache_buster` | integer | Player outlook resource resource cache cache buster. |
+| `player_outlook_resource_expiration_message_object_key_name` | character | Player outlook resource expiration message object key name. |
+| `team_rankings_resource_location` | character | Team rankings resource location. |
+| `team_rankings_resource_route` | character | Team rankings resource route. |
+| `team_rankings_resource_path` | character | Team rankings resource path. |
+| `team_rankings_resource_summary` | character | Team rankings resource summary. |
+| `team_rankings_resource_notes` | character | Team rankings resource notes. |
+| `team_rankings_resource_versions_allowed` | character | Team rankings resource versions allowed. |
+| `team_rankings_resource_versions_current` | character | Team rankings resource versions current. |
+| `team_rankings_resource_methods` | character | Team rankings resource methods. |
+| `team_rankings_resource_formats` | character | Team rankings resource formats. |
+| `team_rankings_resource_parameters` | character | Team rankings resource parameters. |
+| `team_rankings_resource_auth_settings_require_auth` | logical | Team rankings resource auth settings require auth. |
+| `team_rankings_resource_auth_settings_allow_only` | character | Team rankings resource auth settings allow only. |
+| `team_rankings_resource_resource_cache_ns` | character | Team rankings resource resource cache ns. |
+| `team_rankings_resource_resource_cache_cache_keys` | character | Team rankings resource resource cache cache keys. |
+| `team_rankings_resource_resource_cache_cache_buster` | integer | Team rankings resource resource cache cache buster. |
+| `team_rankings_resource_expiration_message_object_key_name` | character | Team rankings resource expiration message object key name. |
+| `sports_line_team_rankings_resource_location` | character | Sports line team rankings resource location. |
+| `sports_line_team_rankings_resource_route` | character | Sports line team rankings resource route. |
+| `sports_line_team_rankings_resource_path` | character | Sports line team rankings resource path. |
+| `sports_line_team_rankings_resource_summary` | character | Sports line team rankings resource summary. |
+| `sports_line_team_rankings_resource_notes` | character | Sports line team rankings resource notes. |
+| `sports_line_team_rankings_resource_versions_allowed` | character | Sports line team rankings resource versions allowed. |
+| `sports_line_team_rankings_resource_versions_current` | character | Sports line team rankings resource versions current. |
+| `sports_line_team_rankings_resource_methods` | character | Sports line team rankings resource methods. |
+| `sports_line_team_rankings_resource_formats` | character | Sports line team rankings resource formats. |
+| `sports_line_team_rankings_resource_parameters` | character | Sports line team rankings resource parameters. |
+| `sports_line_team_rankings_resource_auth_settings_require_auth` | logical | Sports line team rankings resource auth settings require auth. |
+| `sports_line_team_rankings_resource_auth_settings_allow_only` | character | Sports line team rankings resource auth settings allow only. |
+| `sports_line_team_rankings_resource_resource_cache_ns` | character | Sports line team rankings resource resource cache ns. |
+| `sports_line_team_rankings_resource_resource_cache_cache_keys` | character | Sports line team rankings resource resource cache cache keys. |
+| `sports_line_team_rankings_resource_resource_cache_cache_buster` | integer | Sports line team rankings resource resource cache cache buster. |
+| `sports_line_team_rankings_resource_expiration_message_object_key_name` | character | Sports line team rankings resource expiration message object key name. |
+| `team_metadata_resource_location` | character | Team metadata resource location. |
+| `team_metadata_resource_route` | character | Team metadata resource route. |
+| `team_metadata_resource_path` | character | Team metadata resource path. |
+| `team_metadata_resource_summary` | character | Team metadata resource summary. |
+| `team_metadata_resource_notes` | character | Team metadata resource notes. |
+| `team_metadata_resource_versions_allowed` | character | Team metadata resource versions allowed. |
+| `team_metadata_resource_versions_current` | character | Team metadata resource versions current. |
+| `team_metadata_resource_methods` | character | Team metadata resource methods. |
+| `team_metadata_resource_formats` | character | Team metadata resource formats. |
+| `team_metadata_resource_parameters` | character | Team metadata resource parameters. |
+| `team_metadata_resource_auth_settings_require_auth` | logical | Team metadata resource auth settings require auth. |
+| `team_metadata_resource_auth_settings_allow_only` | character | Team metadata resource auth settings allow only. |
+| `team_metadata_resource_resource_cache_ns` | character | Team metadata resource resource cache ns. |
+| `team_metadata_resource_resource_cache_cache_keys` | character | Team metadata resource resource cache cache keys. |
+| `team_metadata_resource_resource_cache_cache_buster` | integer | Team metadata resource resource cache cache buster. |
+| `team_resource_location` | character | Team resource location. |
+| `team_resource_routes` | character | Team resource routes. |
+| `team_resource_paths` | character | Team resource paths. |
+| `team_resource_summary` | character | Team resource summary. |
+| `team_resource_notes` | character | Team resource notes. |
+| `team_resource_versions_allowed` | character | Team resource versions allowed. |
+| `team_resource_versions_current` | character | Team resource versions current. |
+| `team_resource_methods` | character | Team resource methods. |
+| `team_resource_formats` | character | Team resource formats. |
+| `team_resource_parameters` | character | Team resource parameters. |
+| `team_resource_auth_settings_require_auth` | logical | Team resource auth settings require auth. |
+| `team_resource_auth_settings_allow_only` | character | Team resource auth settings allow only. |
+| `team_resource_resource_cache_ns` | character | Team resource resource cache ns. |
+| `team_resource_resource_cache_cache_keys` | character | Team resource resource cache cache keys. |
+| `team_resource_resource_cache_cache_buster` | integer | Team resource resource cache cache buster. |
+| `team_resource_expiration_message_object_key_name` | character | Team resource expiration message object key name. |
+| `position_rankings_resource_location` | character | Position rankings resource location. |
+| `position_rankings_resource_route` | character | Position rankings resource route. |
+| `position_rankings_resource_path` | character | Position rankings resource path. |
+| `position_rankings_resource_summary` | character | Position rankings resource summary. |
+| `position_rankings_resource_notes` | character | Position rankings resource notes. |
+| `position_rankings_resource_versions_allowed` | character | Position rankings resource versions allowed. |
+| `position_rankings_resource_versions_current` | character | Position rankings resource versions current. |
+| `position_rankings_resource_methods` | character | Position rankings resource methods. |
+| `position_rankings_resource_formats` | character | Position rankings resource formats. |
+| `position_rankings_resource_parameters` | character | Position rankings resource parameters. |
+| `position_rankings_resource_auth_settings_require_auth` | logical | Position rankings resource auth settings require auth. |
+| `position_rankings_resource_auth_settings_allow_only` | character | Position rankings resource auth settings allow only. |
+| `position_rankings_resource_resource_cache_ns` | character | Position rankings resource resource cache ns. |
+| `position_rankings_resource_resource_cache_cache_keys` | character | Position rankings resource resource cache cache keys. |
+| `position_rankings_resource_resource_cache_cache_buster` | integer | Position rankings resource resource cache cache buster. |
+| `position_rankings_resource_expiration_message_object_key_name` | character | Position rankings resource expiration message object key name. |
+| `player_game_stats_resource_location` | character | Player game stats resource location. |
+| `player_game_stats_resource_route` | character | Player game stats resource route. |
+| `player_game_stats_resource_path` | character | Player game stats resource path. |
+| `player_game_stats_resource_summary` | character | Player game stats resource summary. |
+| `player_game_stats_resource_notes` | character | Player game stats resource notes. |
+| `player_game_stats_resource_versions_allowed` | character | Player game stats resource versions allowed. |
+| `player_game_stats_resource_versions_current` | character | Player game stats resource versions current. |
+| `player_game_stats_resource_methods` | character | Player game stats resource methods. |
+| `player_game_stats_resource_formats` | character | Player game stats resource formats. |
+| `player_game_stats_resource_parameters` | character | Player game stats resource parameters. |
+| `player_game_stats_resource_auth_settings_require_auth` | logical | Player game stats resource auth settings require auth. |
+| `player_game_stats_resource_auth_settings_allow_only` | character | Player game stats resource auth settings allow only. |
+| `player_game_stats_resource_resource_cache_ns` | character | Player game stats resource resource cache ns. |
+| `player_game_stats_resource_resource_cache_cache_keys` | character | Player game stats resource resource cache cache keys. |
+| `player_game_stats_resource_resource_cache_cache_buster` | integer | Player game stats resource resource cache cache buster. |
+| `player_game_stats_resource_expiration_message_object_key_name` | character | Player game stats resource expiration message object key name. |
+| `ruwt_highlights_resource_location` | character | Ruwt highlights resource location. |
+| `ruwt_highlights_resource_route` | character | Ruwt highlights resource route. |
+| `ruwt_highlights_resource_path` | character | Ruwt highlights resource path. |
+| `ruwt_highlights_resource_summary` | character | Ruwt highlights resource summary. |
+| `ruwt_highlights_resource_notes` | character | Ruwt highlights resource notes. |
+| `ruwt_highlights_resource_versions_allowed` | character | Ruwt highlights resource versions allowed. |
+| `ruwt_highlights_resource_versions_current` | character | Ruwt highlights resource versions current. |
+| `ruwt_highlights_resource_methods` | character | Ruwt highlights resource methods. |
+| `ruwt_highlights_resource_formats` | character | Ruwt highlights resource formats. |
+| `ruwt_highlights_resource_parameters` | character | Ruwt highlights resource parameters. |
+| `ruwt_highlights_resource_auth_settings_require_auth` | logical | Ruwt highlights resource auth settings require auth. |
+| `ruwt_highlights_resource_auth_settings_allow_only` | character | Ruwt highlights resource auth settings allow only. |
+| `ruwt_highlights_resource_resource_cache_ns` | character | Ruwt highlights resource resource cache ns. |
+| `ruwt_highlights_resource_resource_cache_cache_keys` | character | Ruwt highlights resource resource cache cache keys. |
+| `ruwt_highlights_resource_resource_cache_cache_buster` | integer | Ruwt highlights resource resource cache cache buster. |
+| `ruwt_highlights_resource_expiration_message_object_key_name` | character | Ruwt highlights resource expiration message object key name. |
+| `hockey_player_meta_resource_location` | character | Hockey player meta resource location. |
+| `hockey_player_meta_resource_route` | character | Hockey player meta resource route. |
+| `hockey_player_meta_resource_path` | character | Hockey player meta resource path. |
+| `hockey_player_meta_resource_summary` | character | Hockey player meta resource summary. |
+| `hockey_player_meta_resource_notes` | character | Hockey player meta resource notes. |
+| `hockey_player_meta_resource_versions_allowed` | character | Hockey player meta resource versions allowed. |
+| `hockey_player_meta_resource_versions_current` | character | Hockey player meta resource versions current. |
+| `hockey_player_meta_resource_methods` | character | Hockey player meta resource methods. |
+| `hockey_player_meta_resource_formats` | character | Hockey player meta resource formats. |
+| `hockey_player_meta_resource_parameters` | character | Hockey player meta resource parameters. |
+| `hockey_player_meta_resource_auth_settings_require_auth` | logical | Hockey player meta resource auth settings require auth. |
+| `hockey_player_meta_resource_auth_settings_allow_only` | character | Hockey player meta resource auth settings allow only. |
+| `hockey_player_meta_resource_resource_cache_ns` | character | Hockey player meta resource resource cache ns. |
+| `hockey_player_meta_resource_resource_cache_cache_keys` | character | Hockey player meta resource resource cache cache keys. |
+| `hockey_player_meta_resource_resource_cache_cache_buster` | integer | Hockey player meta resource resource cache cache buster. |
+| `hockey_player_meta_resource_expiration_message_object_key_name` | character | Hockey player meta resource expiration message object key name. |
+
+### Returns — `cbs_napi_league` / `cbsNapiLeague`
+
+| col_name | type | description |
+|---|---|---|
+| `league_id` | integer | League ID. |
+| `league_abbr` | character | League abbreviation. |
+| `league_name` | character | League name. |
+| `sport_id` | integer | Sport ID. |
+| `league_type` | character | League type. |
+| `teams` | character | Teams. |
+| `color_primary` | character | Color primary. |
+| `color_secondary` | character | Color secondary. |
+
+### Returns — `cbs_napi_season_teams` / `cbsNapiSeasonTeams`
+
+| col_name | type | description |
+|---|---|---|
+| `team_id` | integer | Team ID. |
+| `stub_hub_team_id` | character | Stub hub team ID. |
+| `location` | character | Location. |
+| `nick_name` | character | Nick name. |
+| `medium_name` | character | Medium name. |
+| `short_name` | character | Short name. |
+| `abbrev` | character | Abbrev. |
+| `status` | character | Status. |
+| `home_venue_id` | integer | Home venue ID. |
+| `conference_id` | integer | Conference ID. |
+| `league_id` | integer | League ID. |
+| `division_id` | character | Division ID. |
+| `ticket_url` | character | Ticket URL. |
+| `color_hex_dex` | character | Color hex dex. |
+| `color_primary_hex` | character | Color primary hex. |
+| `color_secondary_hex` | character | Color secondary hex. |
+| `players` | character | Players. |
+| `league` | character | League. |
+| `standings` | character | Standings. |
+| `conference` | character | Conference. |
+| `division` | character | Division. |
+| `team_seasons` | character | Team seasons. |
+| `polls` | character | Polls. |
+| `home_venue` | character | Home venue. |
+| `sports_line_standings` | character | Sports line standings. |
+| `team_stats` | character | Team stats. |
+| `team_rankings` | character | Team rankings. |
+| `sports_line_rankings` | character | Sports line rankings. |
+| `meta_tsa_overlay` | logical | Meta tsa overlay. |
+| `meta_season_id` | integer | Meta season ID. |
+
+### Returns — `cbs_napi_team_players` / `cbsNapiTeamPlayers`
+
+| col_name | type | description |
+|---|---|---|
+| `player_id` | integer | Player ID. |
+| `first_name` | character | First name. |
+| `full_first_name` | character | Full first name. |
+| `last_name` | character | Last name. |
+| `full_last_name` | character | Full last name. |
+| `nick_name` | character | Nick name. |
+| `height` | character | Height. |
+| `weight` | integer | Weight. |
+| `experience` | integer | Experience. |
+| `school` | character | School. |
+| `home_town` | character | Home town. |
+| `debut` | character | Debut. |
+| `birth_date` | character | Birth date. |
+| `birth_country` | character | Birth country. |
+| `birth_country_code` | character | Birth country code. |
+| `nationality_country` | character | Nationality country. |
+| `nationality_country_code` | character | Nationality country code. |
+| `locked` | integer | Locked. |
+| `player_team_associations` | character | Player team associations. |
+| `injuries` | character | Injuries. |
+| `transactions` | character | Transactions. |
+| `depth_charts` | character | Depth charts. |
+| `position_rankings` | character | Position rankings. |
+| `player_stats` | character | Player stats. |
+| `standings` | character | Standings. |
+| `rankings` | character | Rankings. |
+| `player_outlook` | character | Player outlook. |
+| `meta_data` | character | Meta data. |
+| `draft_info` | character | Draft info. |
+| `game_stats` | character | Game stats. |
+| `combine_data` | character | Combine data. |
+
+### Returns — `cbs_napi_team_standings` / `cbsNapiTeamStandings`
+
+| col_name | type | description |
+|---|---|---|
+| `2016_regular_wins_number` | integer | 2016 regular wins number. |
+| `2016_regular_goals_for_goals` | integer | 2016 regular goals for goals. |
+| `2016_regular_last_results_r2` | character | 2016 regular last results r2. |
+| `2016_regular_last_results_r3` | character | 2016 regular last results r3. |
+| `2016_regular_last_results_r4` | character | 2016 regular last results r4. |
+| `2016_regular_last_results_r5` | character | 2016 regular last results r5. |
+| `2016_regular_last_results_r1` | character | 2016 regular last results r1. |
+| `2016_regular_winning_percentage_percentage` | character | 2016 regular winning percentage percentage. |
+| `2016_regular_goals_against_goals` | integer | 2016 regular goals against goals. |
+| `2016_regular_streak` | character | 2016 regular streak. |
+| `2016_regular_losses_number` | integer | 2016 regular losses number. |
+| `2016_regular_points_penalty_points` | integer | 2016 regular points penalty points. |
+| `2016_regular_points_points_per_game` | number | 2016 regular points points per game. |
+| `2016_regular_points_points` | integer | 2016 regular points points. |
+| `2016_regular_ties_number` | integer | 2016 regular ties number. |
+| `2016_regular_games_played_games` | integer | 2016 regular games played games. |
+| `2016_regular_place_previous` | integer | 2016 regular place previous. |
+| `2016_regular_place_season_end_id` | character | 2016 regular place season end ID. |
+| `2016_regular_place_season_end` | character | 2016 regular place season end. |
+| `2016_regular_place_place` | integer | 2016 regular place place. |
+| `2016_regular_clinch_status_id` | integer | 2016 regular clinch status ID. |
+| `2016_regular_clinch_status_status` | character | 2016 regular clinch status status. |
+| `2016_regular_win_loss_record` | character | 2016 regular win loss record. |
+| `2016_regular_team_info_display_name` | character | 2016 regular team info display name. |
+| `2016_regular_team_info_name` | character | 2016 regular team info name. |
+| `2016_regular_team_info_alias` | character | 2016 regular team info alias. |
+| `2016_regular_team_info_location` | character | 2016 regular team info location. |
+| `2016_regular_team_info_id` | integer | 2016 regular team info ID. |
+| `2016_regular_team_info_global_id` | integer | 2016 regular team info global ID. |
+| `2016_regular_season_id` | integer | 2016 regular season ID. |
+| `2016_regular_season_season_id` | integer | 2016 regular season season ID. |
+| `2016_regular_season_sport_id` | integer | 2016 regular season sport ID. |
+| `2016_regular_season_league_id` | integer | 2016 regular season league ID. |
+| `2016_regular_season_league` | character | 2016 regular season league. |
+| `2016_regular_season_teams` | character | 2016 regular season teams. |
+| `2016_regular_season_season_year` | integer | 2016 regular season season year. |
+| `2016_regular_season_is_current` | integer | 2016 regular season is current. |
+| `2016_regular_season_season_type` | character | 2016 regular season season type. |
+| `2016_regular_season_season_type_desc` | character | 2016 regular season season type desc. |
+| `2016_regular_season_season_start_date` | character | 2016 regular season season start date. |
+| `2016_regular_season_season_end_date` | character | 2016 regular season season end date. |
+| `2017_regular_wins_number` | integer | 2017 regular wins number. |
+| `2017_regular_goals_for_goals` | integer | 2017 regular goals for goals. |
+| `2017_regular_last_results_r2` | character | 2017 regular last results r2. |
+| `2017_regular_last_results_r3` | character | 2017 regular last results r3. |
+| `2017_regular_last_results_r4` | character | 2017 regular last results r4. |
+| `2017_regular_last_results_r5` | character | 2017 regular last results r5. |
+| `2017_regular_last_results_r1` | character | 2017 regular last results r1. |
+| `2017_regular_winning_percentage_percentage` | character | 2017 regular winning percentage percentage. |
+| `2017_regular_goals_against_goals` | integer | 2017 regular goals against goals. |
+| `2017_regular_streak` | character | 2017 regular streak. |
+| `2017_regular_losses_number` | integer | 2017 regular losses number. |
+| `2017_regular_points_penalty_points` | integer | 2017 regular points penalty points. |
+| `2017_regular_points_points_per_game` | number | 2017 regular points points per game. |
+| `2017_regular_points_points` | integer | 2017 regular points points. |
+| `2017_regular_ties_number` | integer | 2017 regular ties number. |
+| `2017_regular_games_played_games` | integer | 2017 regular games played games. |
+| `2017_regular_place_previous` | integer | 2017 regular place previous. |
+| `2017_regular_place_season_end_id` | character | 2017 regular place season end ID. |
+| `2017_regular_place_place` | integer | 2017 regular place place. |
+| `2017_regular_place_season_end` | character | 2017 regular place season end. |
+| `2017_regular_win_loss_record` | character | 2017 regular win loss record. |
+| `2017_regular_team_info_display_name` | character | 2017 regular team info display name. |
+| `2017_regular_team_info_name` | character | 2017 regular team info name. |
+| `2017_regular_team_info_alias` | character | 2017 regular team info alias. |
+| `2017_regular_team_info_location` | character | 2017 regular team info location. |
+| `2017_regular_team_info_global_id` | integer | 2017 regular team info global ID. |
+| `2017_regular_team_info_id` | integer | 2017 regular team info ID. |
+| `2017_regular_season_id` | integer | 2017 regular season ID. |
+| `2017_regular_season_season_id` | integer | 2017 regular season season ID. |
+| `2017_regular_season_sport_id` | integer | 2017 regular season sport ID. |
+| `2017_regular_season_league_id` | integer | 2017 regular season league ID. |
+| `2017_regular_season_league` | character | 2017 regular season league. |
+| `2017_regular_season_teams` | character | 2017 regular season teams. |
+| `2017_regular_season_season_year` | integer | 2017 regular season season year. |
+| `2017_regular_season_is_current` | integer | 2017 regular season is current. |
+| `2017_regular_season_season_type` | character | 2017 regular season season type. |
+| `2017_regular_season_season_type_desc` | character | 2017 regular season season type desc. |
+| `2017_regular_season_season_start_date` | character | 2017 regular season season start date. |
+| `2017_regular_season_season_end_date` | character | 2017 regular season season end date. |
+| `2018_regular_wins_number` | integer | 2018 regular wins number. |
+| `2018_regular_goals_for_goals` | integer | 2018 regular goals for goals. |
+| `2018_regular_last_results_r2` | character | 2018 regular last results r2. |
+| `2018_regular_last_results_r3` | character | 2018 regular last results r3. |
+| `2018_regular_last_results_r4` | character | 2018 regular last results r4. |
+| `2018_regular_last_results_r5` | character | 2018 regular last results r5. |
+| `2018_regular_last_results_r1` | character | 2018 regular last results r1. |
+| `2018_regular_winning_percentage_percentage` | character | 2018 regular winning percentage percentage. |
+| `2018_regular_goals_against_goals` | integer | 2018 regular goals against goals. |
+| `2018_regular_streak` | character | 2018 regular streak. |
+| `2018_regular_losses_number` | integer | 2018 regular losses number. |
+| `2018_regular_points_penalty_points` | integer | 2018 regular points penalty points. |
+| `2018_regular_points_points_per_game` | number | 2018 regular points points per game. |
+| `2018_regular_points_points` | integer | 2018 regular points points. |
+| `2018_regular_ties_number` | integer | 2018 regular ties number. |
+| `2018_regular_games_played_games` | integer | 2018 regular games played games. |
+| `2018_regular_place_previous` | integer | 2018 regular place previous. |
+| `2018_regular_place_season_end_id` | integer | 2018 regular place season end ID. |
+| `2018_regular_place_place` | integer | 2018 regular place place. |
+| `2018_regular_place_season_end` | character | 2018 regular place season end. |
+| `2018_regular_clinch_status_id` | integer | 2018 regular clinch status ID. |
+| `2018_regular_clinch_status_status` | character | 2018 regular clinch status status. |
+| `2018_regular_win_loss_record` | character | 2018 regular win loss record. |
+| `2018_regular_team_info_display_name` | character | 2018 regular team info display name. |
+| `2018_regular_team_info_name` | character | 2018 regular team info name. |
+| `2018_regular_team_info_alias` | character | 2018 regular team info alias. |
+| `2018_regular_team_info_location` | character | 2018 regular team info location. |
+| `2018_regular_team_info_global_id` | integer | 2018 regular team info global ID. |
+| `2018_regular_team_info_id` | integer | 2018 regular team info ID. |
+| `2018_regular_season_id` | integer | 2018 regular season ID. |
+| `2018_regular_season_season_id` | integer | 2018 regular season season ID. |
+| `2018_regular_season_sport_id` | integer | 2018 regular season sport ID. |
+| `2018_regular_season_league_id` | integer | 2018 regular season league ID. |
+| `2018_regular_season_league` | character | 2018 regular season league. |
+| `2018_regular_season_teams` | character | 2018 regular season teams. |
+| `2018_regular_season_season_year` | integer | 2018 regular season season year. |
+| `2018_regular_season_is_current` | integer | 2018 regular season is current. |
+| `2018_regular_season_season_type` | character | 2018 regular season season type. |
+| `2018_regular_season_season_type_desc` | character | 2018 regular season season type desc. |
+| `2018_regular_season_season_start_date` | character | 2018 regular season season start date. |
+| `2018_regular_season_season_end_date` | character | 2018 regular season season end date. |
+| `2019_regular_wins_number` | integer | 2019 regular wins number. |
+| `2019_regular_goals_for_goals` | integer | 2019 regular goals for goals. |
+| `2019_regular_last_results_r2` | character | 2019 regular last results r2. |
+| `2019_regular_last_results_r3` | character | 2019 regular last results r3. |
+| `2019_regular_last_results_r4` | character | 2019 regular last results r4. |
+| `2019_regular_last_results_r5` | character | 2019 regular last results r5. |
+| `2019_regular_last_results_r1` | character | 2019 regular last results r1. |
+| `2019_regular_winning_percentage_percentage` | character | 2019 regular winning percentage percentage. |
+| `2019_regular_goals_against_goals` | integer | 2019 regular goals against goals. |
+| `2019_regular_streak` | character | 2019 regular streak. |
+| `2019_regular_losses_number` | integer | 2019 regular losses number. |
+| `2019_regular_points_penalty_points` | integer | 2019 regular points penalty points. |
+| `2019_regular_points_points_per_game` | number | 2019 regular points points per game. |
+| `2019_regular_points_points` | integer | 2019 regular points points. |
+| `2019_regular_ties_number` | integer | 2019 regular ties number. |
+| `2019_regular_games_played_games` | integer | 2019 regular games played games. |
+| `2019_regular_place_previous` | integer | 2019 regular place previous. |
+| `2019_regular_place_season_end_id` | character | 2019 regular place season end ID. |
+| `2019_regular_place_place` | integer | 2019 regular place place. |
+| `2019_regular_place_season_end` | character | 2019 regular place season end. |
+| `2019_regular_clinch_status_id` | integer | 2019 regular clinch status ID. |
+| `2019_regular_clinch_status_status` | character | 2019 regular clinch status status. |
+| `2019_regular_win_loss_record` | character | 2019 regular win loss record. |
+| `2019_regular_team_info_display_name` | character | 2019 regular team info display name. |
+| `2019_regular_team_info_name` | character | 2019 regular team info name. |
+| `2019_regular_team_info_alias` | character | 2019 regular team info alias. |
+| `2019_regular_team_info_location` | character | 2019 regular team info location. |
+| `2019_regular_team_info_global_id` | integer | 2019 regular team info global ID. |
+| `2019_regular_team_info_id` | integer | 2019 regular team info ID. |
+| `2019_regular_season_id` | integer | 2019 regular season ID. |
+| `2019_regular_season_season_id` | integer | 2019 regular season season ID. |
+| `2019_regular_season_sport_id` | integer | 2019 regular season sport ID. |
+| `2019_regular_season_league_id` | integer | 2019 regular season league ID. |
+| `2019_regular_season_league` | character | 2019 regular season league. |
+| `2019_regular_season_teams` | character | 2019 regular season teams. |
+| `2019_regular_season_season_year` | integer | 2019 regular season season year. |
+| `2019_regular_season_is_current` | integer | 2019 regular season is current. |
+| `2019_regular_season_season_type` | character | 2019 regular season season type. |
+| `2019_regular_season_season_type_desc` | character | 2019 regular season season type desc. |
+| `2019_regular_season_season_start_date` | character | 2019 regular season season start date. |
+| `2019_regular_season_season_end_date` | character | 2019 regular season season end date. |
+| `2020_regular_wins_number` | integer | 2020 regular wins number. |
+| `2020_regular_goals_for_goals` | integer | 2020 regular goals for goals. |
+| `2020_regular_last_results_r2` | character | 2020 regular last results r2. |
+| `2020_regular_last_results_r3` | character | 2020 regular last results r3. |
+| `2020_regular_last_results_r4` | character | 2020 regular last results r4. |
+| `2020_regular_last_results_r5` | character | 2020 regular last results r5. |
+| `2020_regular_last_results_r1` | character | 2020 regular last results r1. |
+| `2020_regular_winning_percentage_percentage` | character | 2020 regular winning percentage percentage. |
+| `2020_regular_goals_against_goals` | integer | 2020 regular goals against goals. |
+| `2020_regular_streak` | character | 2020 regular streak. |
+| `2020_regular_losses_number` | integer | 2020 regular losses number. |
+| `2020_regular_points_penalty_points` | integer | 2020 regular points penalty points. |
+| `2020_regular_points_points_per_game` | number | 2020 regular points points per game. |
+| `2020_regular_points_points` | integer | 2020 regular points points. |
+| `2020_regular_ties_number` | integer | 2020 regular ties number. |
+| `2020_regular_games_played_games` | integer | 2020 regular games played games. |
+| `2020_regular_place_previous` | integer | 2020 regular place previous. |
+| `2020_regular_place_season_end_id` | character | 2020 regular place season end ID. |
+| `2020_regular_place_place` | integer | 2020 regular place place. |
+| `2020_regular_place_season_end` | character | 2020 regular place season end. |
+| `2020_regular_goal_differential_differential` | integer | 2020 regular goal differential differential. |
+| `2020_regular_win_loss_record` | character | 2020 regular win loss record. |
+| `2020_regular_team_info_display_name` | character | 2020 regular team info display name. |
+| `2020_regular_team_info_name` | character | 2020 regular team info name. |
+| `2020_regular_team_info_alias` | character | 2020 regular team info alias. |
+| `2020_regular_team_info_location` | character | 2020 regular team info location. |
+| `2020_regular_team_info_global_id` | integer | 2020 regular team info global ID. |
+| `2020_regular_team_info_id` | integer | 2020 regular team info ID. |
+| `2020_regular_season_id` | integer | 2020 regular season ID. |
+| `2020_regular_season_season_id` | integer | 2020 regular season season ID. |
+| `2020_regular_season_sport_id` | integer | 2020 regular season sport ID. |
+| `2020_regular_season_league_id` | integer | 2020 regular season league ID. |
+| `2020_regular_season_league` | character | 2020 regular season league. |
+| `2020_regular_season_teams` | character | 2020 regular season teams. |
+| `2020_regular_season_season_year` | integer | 2020 regular season season year. |
+| `2020_regular_season_is_current` | integer | 2020 regular season is current. |
+| `2020_regular_season_season_type` | character | 2020 regular season season type. |
+| `2020_regular_season_season_type_desc` | character | 2020 regular season season type desc. |
+| `2020_regular_season_season_start_date` | character | 2020 regular season season start date. |
+| `2020_regular_season_season_end_date` | character | 2020 regular season season end date. |
+| `2021_regular_wins_number` | integer | 2021 regular wins number. |
+| `2021_regular_goals_for_goals` | integer | 2021 regular goals for goals. |
+| `2021_regular_last_results_r2` | character | 2021 regular last results r2. |
+| `2021_regular_last_results_r3` | character | 2021 regular last results r3. |
+| `2021_regular_last_results_r4` | character | 2021 regular last results r4. |
+| `2021_regular_last_results_r5` | character | 2021 regular last results r5. |
+| `2021_regular_last_results_r1` | character | 2021 regular last results r1. |
+| `2021_regular_winning_percentage_percentage` | character | 2021 regular winning percentage percentage. |
+| `2021_regular_goals_against_goals` | integer | 2021 regular goals against goals. |
+| `2021_regular_streak` | character | 2021 regular streak. |
+| `2021_regular_losses_number` | integer | 2021 regular losses number. |
+| `2021_regular_points_penalty_points` | integer | 2021 regular points penalty points. |
+| `2021_regular_points_points_per_game` | number | 2021 regular points points per game. |
+| `2021_regular_points_points` | integer | 2021 regular points points. |
+| `2021_regular_ties_number` | integer | 2021 regular ties number. |
+| `2021_regular_games_played_games` | integer | 2021 regular games played games. |
+| `2021_regular_place_previous` | integer | 2021 regular place previous. |
+| `2021_regular_place_season_end_id` | integer | 2021 regular place season end ID. |
+| `2021_regular_place_place` | integer | 2021 regular place place. |
+| `2021_regular_place_season_end` | character | 2021 regular place season end. |
+| `2021_regular_clinch_status_id` | integer | 2021 regular clinch status ID. |
+| `2021_regular_clinch_status_status` | character | 2021 regular clinch status status. |
+| `2021_regular_goal_differential_differential` | integer | 2021 regular goal differential differential. |
+| `2021_regular_win_loss_record` | character | 2021 regular win loss record. |
+| `2021_regular_team_info_display_name` | character | 2021 regular team info display name. |
+| `2021_regular_team_info_name` | character | 2021 regular team info name. |
+| `2021_regular_team_info_alias` | character | 2021 regular team info alias. |
+| `2021_regular_team_info_location` | character | 2021 regular team info location. |
+| `2021_regular_team_info_global_id` | integer | 2021 regular team info global ID. |
+| `2021_regular_team_info_id` | integer | 2021 regular team info ID. |
+| `2021_regular_season_id` | integer | 2021 regular season ID. |
+| `2021_regular_season_season_id` | integer | 2021 regular season season ID. |
+| `2021_regular_season_sport_id` | integer | 2021 regular season sport ID. |
+| `2021_regular_season_league_id` | integer | 2021 regular season league ID. |
+| `2021_regular_season_league` | character | 2021 regular season league. |
+| `2021_regular_season_teams` | character | 2021 regular season teams. |
+| `2021_regular_season_season_year` | integer | 2021 regular season season year. |
+| `2021_regular_season_is_current` | integer | 2021 regular season is current. |
+| `2021_regular_season_season_type` | character | 2021 regular season season type. |
+| `2021_regular_season_season_type_desc` | character | 2021 regular season season type desc. |
+| `2021_regular_season_season_start_date` | character | 2021 regular season season start date. |
+| `2021_regular_season_season_end_date` | character | 2021 regular season season end date. |
+| `2022_regular_wins_number` | integer | 2022 regular wins number. |
+| `2022_regular_goals_for_goals` | integer | 2022 regular goals for goals. |
+| `2022_regular_last_results_r2` | character | 2022 regular last results r2. |
+| `2022_regular_last_results_r3` | character | 2022 regular last results r3. |
+| `2022_regular_last_results_r4` | character | 2022 regular last results r4. |
+| `2022_regular_last_results_r5` | character | 2022 regular last results r5. |
+| `2022_regular_last_results_r1` | character | 2022 regular last results r1. |
+| `2022_regular_winning_percentage_percentage` | character | 2022 regular winning percentage percentage. |
+| `2022_regular_goals_against_goals` | integer | 2022 regular goals against goals. |
+| `2022_regular_streak` | character | 2022 regular streak. |
+| `2022_regular_losses_number` | integer | 2022 regular losses number. |
+| `2022_regular_points_penalty_points` | integer | 2022 regular points penalty points. |
+| `2022_regular_points_points_per_game` | number | 2022 regular points points per game. |
+| `2022_regular_points_points` | integer | 2022 regular points points. |
+| `2022_regular_ties_number` | integer | 2022 regular ties number. |
+| `2022_regular_games_played_games` | integer | 2022 regular games played games. |
+| `2022_regular_place_previous` | integer | 2022 regular place previous. |
+| `2022_regular_place_season_end_id` | character | 2022 regular place season end ID. |
+| `2022_regular_place_place` | integer | 2022 regular place place. |
+| `2022_regular_place_season_end` | character | 2022 regular place season end. |
+| `2022_regular_win_loss_record` | character | 2022 regular win loss record. |
+| `2022_regular_team_info_display_name` | character | 2022 regular team info display name. |
+| `2022_regular_team_info_name` | character | 2022 regular team info name. |
+| `2022_regular_team_info_alias` | character | 2022 regular team info alias. |
+| `2022_regular_team_info_location` | character | 2022 regular team info location. |
+| `2022_regular_team_info_global_id` | integer | 2022 regular team info global ID. |
+| `2022_regular_team_info_id` | integer | 2022 regular team info ID. |
+| `2022_regular_season_id` | integer | 2022 regular season ID. |
+| `2022_regular_season_season_id` | integer | 2022 regular season season ID. |
+| `2022_regular_season_sport_id` | integer | 2022 regular season sport ID. |
+| `2022_regular_season_league_id` | integer | 2022 regular season league ID. |
+| `2022_regular_season_league` | character | 2022 regular season league. |
+| `2022_regular_season_teams` | character | 2022 regular season teams. |
+| `2022_regular_season_season_year` | integer | 2022 regular season season year. |
+| `2022_regular_season_is_current` | integer | 2022 regular season is current. |
+| `2022_regular_season_season_type` | character | 2022 regular season season type. |
+| `2022_regular_season_season_type_desc` | character | 2022 regular season season type desc. |
+| `2022_regular_season_season_start_date` | character | 2022 regular season season start date. |
+| `2022_regular_season_season_end_date` | character | 2022 regular season season end date. |
+| `2023_regular_wins_number` | integer | 2023 regular wins number. |
+| `2023_regular_goals_for_goals` | integer | 2023 regular goals for goals. |
+| `2023_regular_last_results_r2` | character | 2023 regular last results r2. |
+| `2023_regular_last_results_r3` | character | 2023 regular last results r3. |
+| `2023_regular_last_results_r4` | character | 2023 regular last results r4. |
+| `2023_regular_last_results_r5` | character | 2023 regular last results r5. |
+| `2023_regular_last_results_r1` | character | 2023 regular last results r1. |
+| `2023_regular_winning_percentage_percentage` | character | 2023 regular winning percentage percentage. |
+| `2023_regular_goals_against_goals` | integer | 2023 regular goals against goals. |
+| `2023_regular_streak` | character | 2023 regular streak. |
+| `2023_regular_losses_number` | integer | 2023 regular losses number. |
+| `2023_regular_points_penalty_points` | integer | 2023 regular points penalty points. |
+| `2023_regular_points_points_per_game` | number | 2023 regular points points per game. |
+| `2023_regular_points_points` | integer | 2023 regular points points. |
+| `2023_regular_ties_number` | integer | 2023 regular ties number. |
+| `2023_regular_games_played_games` | integer | 2023 regular games played games. |
+| `2023_regular_place_previous` | integer | 2023 regular place previous. |
+| `2023_regular_place_season_end_id` | character | 2023 regular place season end ID. |
+| `2023_regular_place_place` | integer | 2023 regular place place. |
+| `2023_regular_place_season_end` | character | 2023 regular place season end. |
+| `2023_regular_goal_differential_differential` | integer | 2023 regular goal differential differential. |
+| `2023_regular_win_loss_record` | character | 2023 regular win loss record. |
+| `2023_regular_team_info_display_name` | character | 2023 regular team info display name. |
+| `2023_regular_team_info_name` | character | 2023 regular team info name. |
+| `2023_regular_team_info_alias` | character | 2023 regular team info alias. |
+| `2023_regular_team_info_location` | character | 2023 regular team info location. |
+| `2023_regular_team_info_global_id` | integer | 2023 regular team info global ID. |
+| `2023_regular_team_info_id` | integer | 2023 regular team info ID. |
+| `2023_regular_season_id` | integer | 2023 regular season ID. |
+| `2023_regular_season_season_id` | integer | 2023 regular season season ID. |
+| `2023_regular_season_sport_id` | integer | 2023 regular season sport ID. |
+| `2023_regular_season_league_id` | integer | 2023 regular season league ID. |
+| `2023_regular_season_league` | character | 2023 regular season league. |
+| `2023_regular_season_teams` | character | 2023 regular season teams. |
+| `2023_regular_season_season_year` | integer | 2023 regular season season year. |
+| `2023_regular_season_is_current` | integer | 2023 regular season is current. |
+| `2023_regular_season_season_type` | character | 2023 regular season season type. |
+| `2023_regular_season_season_type_desc` | character | 2023 regular season season type desc. |
+| `2023_regular_season_season_start_date` | character | 2023 regular season season start date. |
+| `2023_regular_season_season_end_date` | character | 2023 regular season season end date. |
+| `2024_regular_wins_number` | integer | 2024 regular wins number. |
+| `2024_regular_goals_for_goals` | integer | 2024 regular goals for goals. |
+| `2024_regular_last_results_r2` | character | 2024 regular last results r2. |
+| `2024_regular_last_results_r3` | character | 2024 regular last results r3. |
+| `2024_regular_last_results_r4` | character | 2024 regular last results r4. |
+| `2024_regular_last_results_r5` | character | 2024 regular last results r5. |
+| `2024_regular_last_results_r1` | character | 2024 regular last results r1. |
+| `2024_regular_winning_percentage_percentage` | character | 2024 regular winning percentage percentage. |
+| `2024_regular_goals_against_goals` | integer | 2024 regular goals against goals. |
+| `2024_regular_streak` | character | 2024 regular streak. |
+| `2024_regular_losses_number` | integer | 2024 regular losses number. |
+| `2024_regular_points_penalty_points` | integer | 2024 regular points penalty points. |
+| `2024_regular_points_points_per_game` | number | 2024 regular points points per game. |
+| `2024_regular_points_points` | integer | 2024 regular points points. |
+| `2024_regular_ties_number` | integer | 2024 regular ties number. |
+| `2024_regular_games_played_games` | integer | 2024 regular games played games. |
+| `2024_regular_place_previous` | integer | 2024 regular place previous. |
+| `2024_regular_place_season_end_id` | integer | 2024 regular place season end ID. |
+| `2024_regular_place_place` | integer | 2024 regular place place. |
+| `2024_regular_place_season_end` | character | 2024 regular place season end. |
+| `2024_regular_clinch_status_id` | integer | 2024 regular clinch status ID. |
+| `2024_regular_clinch_status_status` | character | 2024 regular clinch status status. |
+| `2024_regular_goal_differential_differential` | integer | 2024 regular goal differential differential. |
+| `2024_regular_win_loss_record` | character | 2024 regular win loss record. |
+| `2024_regular_team_info_display_name` | character | 2024 regular team info display name. |
+| `2024_regular_team_info_name` | character | 2024 regular team info name. |
+| `2024_regular_team_info_alias` | character | 2024 regular team info alias. |
+| `2024_regular_team_info_location` | character | 2024 regular team info location. |
+| `2024_regular_team_info_global_id` | integer | 2024 regular team info global ID. |
+| `2024_regular_team_info_id` | integer | 2024 regular team info ID. |
+| `2024_regular_season_id` | integer | 2024 regular season ID. |
+| `2024_regular_season_season_id` | integer | 2024 regular season season ID. |
+| `2024_regular_season_sport_id` | integer | 2024 regular season sport ID. |
+| `2024_regular_season_league_id` | integer | 2024 regular season league ID. |
+| `2024_regular_season_league` | character | 2024 regular season league. |
+| `2024_regular_season_teams` | character | 2024 regular season teams. |
+| `2024_regular_season_season_year` | integer | 2024 regular season season year. |
+| `2024_regular_season_is_current` | integer | 2024 regular season is current. |
+| `2024_regular_season_season_type` | character | 2024 regular season season type. |
+| `2024_regular_season_season_type_desc` | character | 2024 regular season season type desc. |
+| `2024_regular_season_season_start_date` | character | 2024 regular season season start date. |
+| `2024_regular_season_season_end_date` | character | 2024 regular season season end date. |
+| `2025_regular_wins_number` | integer | 2025 regular wins number. |
+| `2025_regular_goals_for_goals` | integer | 2025 regular goals for goals. |
+| `2025_regular_goals_against_goals` | integer | 2025 regular goals against goals. |
+| `2025_regular_goal_differential_differential` | integer | 2025 regular goal differential differential. |
+| `2025_regular_winning_percentage_percentage` | character | 2025 regular winning percentage percentage. |
+| `2025_regular_streak` | character | 2025 regular streak. |
+| `2025_regular_losses_number` | integer | 2025 regular losses number. |
+| `2025_regular_points_points` | integer | 2025 regular points points. |
+| `2025_regular_points_penalty_points` | integer | 2025 regular points penalty points. |
+| `2025_regular_points_points_per_game` | character | 2025 regular points points per game. |
+| `2025_regular_ties_number` | integer | 2025 regular ties number. |
+| `2025_regular_games_played_games` | integer | 2025 regular games played games. |
+| `2025_regular_place_place` | integer | 2025 regular place place. |
+| `2025_regular_win_loss_record` | character | 2025 regular win loss record. |
+| `2025_regular_team_info_display_name` | character | 2025 regular team info display name. |
+| `2025_regular_team_info_name` | character | 2025 regular team info name. |
+| `2025_regular_team_info_alias` | character | 2025 regular team info alias. |
+| `2025_regular_team_info_location` | character | 2025 regular team info location. |
+| `2025_regular_team_info_global_id` | integer | 2025 regular team info global ID. |
+| `2025_regular_team_info_id` | integer | 2025 regular team info ID. |
+| `2025_regular_clinch_status_id` | integer | 2025 regular clinch status ID. |
+| `2025_regular_clinch_status_status` | character | 2025 regular clinch status status. |
+| `2025_regular_season_id` | integer | 2025 regular season ID. |
+| `2025_regular_season_season_id` | integer | 2025 regular season season ID. |
+| `2025_regular_season_sport_id` | integer | 2025 regular season sport ID. |
+| `2025_regular_season_league_id` | integer | 2025 regular season league ID. |
+| `2025_regular_season_league` | character | 2025 regular season league. |
+| `2025_regular_season_teams` | character | 2025 regular season teams. |
+| `2025_regular_season_season_year` | integer | 2025 regular season season year. |
+| `2025_regular_season_is_current` | integer | 2025 regular season is current. |
+| `2025_regular_season_season_type` | character | 2025 regular season season type. |
+| `2025_regular_season_season_type_desc` | character | 2025 regular season season type desc. |
+| `2025_regular_season_season_start_date` | character | 2025 regular season season start date. |
+| `2025_regular_season_season_end_date` | character | 2025 regular season season end date. |

--- a/docs/docs/reference/fox.md
+++ b/docs/docs/reference/fox.md
@@ -84,6 +84,83 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `left_item_details` | list | Bifrost event_matchup field `leftItemDetails`. |
 | `right_item_details` | list | Bifrost event_matchup field `rightItemDetails`. |
 
+### Returns — `fox_bifrost_event_odds` / `foxBifrostEventOdds`
+
+| col_name | type | description |
+|---|---|---|
+| `modules` | character | Bifrost field `modules`: modules. |
+
+### Returns — `fox_bifrost_event_recap` / `foxBifrostEventRecap`
+
+| col_name | type | description |
+|---|---|---|
+| `id` | character | Bifrost field `id`: ID. |
+| `type` | character | Bifrost field `type`: type. |
+| `order` | integer | Bifrost field `order`: order. |
+| `last_update` | character | Bifrost field `last_update`: last update. |
+
+### Returns — `fox_bifrost_event_standings` / `foxBifrostEventStandings`
+
+| col_name | type | description |
+|---|---|---|
+| `section_id` | character | Bifrost field `section_id`: section ID. |
+| `section_title` | character | Bifrost field `section_title`: section title. |
+| `section_metadata_parameters_standings_type` | character | Bifrost field `section_metadata_parameters_standings_type`: section metadata parameters standings type. |
+| `section_metadata_parameters_league_name` | character | Bifrost field `section_metadata_parameters_league_name`: section metadata parameters league name. |
+| `section_metadata_parameters_group_name` | character | Bifrost field `section_metadata_parameters_group_name`: section metadata parameters group name. |
+| `section_metadata_parameters_season` | character | Bifrost field `section_metadata_parameters_season`: section metadata parameters season. |
+| `template` | character | Bifrost field `template`: template. |
+| `headers` | character | Bifrost field `headers`: headers. |
+| `rows` | character | Bifrost field `rows`: rows. |
+
+### Returns — `fox_bifrost_explore_browse` / `foxBifrostExploreBrowse`
+
+| col_name | type | description |
+|---|---|---|
+| `header_title` | character | Bifrost field `header_title`: header title. |
+| `items` | character | Bifrost field `items`: items. |
+
+### Returns — `fox_bifrost_explore_odds` / `foxBifrostExploreOdds`
+
+| col_name | type | description |
+|---|---|---|
+| `modules` | character | Bifrost field `modules`: modules. |
+
+### Returns — `fox_bifrost_league_conferences` / `foxBifrostLeagueConferences`
+
+| col_name | type | description |
+|---|---|---|
+| `items` | character | Bifrost field `items`: items. |
+
+### Returns — `fox_bifrost_league_header` / `foxBifrostLeagueHeader`
+
+| col_name | type | description |
+|---|---|---|
+| `template` | character | Bifrost field `template`: template. |
+| `title` | character | Bifrost field `title`: title. |
+| `color` | character | Bifrost field `color`: color. |
+| `logo_url` | character | Bifrost field `logo_url`: logo URL. |
+| `image_type` | character | Bifrost field `image_type`: image type. |
+| `image_alt_text` | character | Bifrost field `image_alt_text`: image alt text. |
+| `content_uri` | character | Bifrost field `content_uri`: content URI. |
+| `content_type` | character | Bifrost field `content_type`: content type. |
+| `has_feature` | character | Bifrost field `has_feature`: has feature. |
+| `metadata_parameters_group` | character | Bifrost field `metadata_parameters_group`: metadata parameters group. |
+| `sponsorship_template` | character | Bifrost field `sponsorship_template`: sponsorship template. |
+| `sponsorship_secondary_template` | character | Bifrost field `sponsorship_secondary_template`: sponsorship secondary template. |
+| `sponsorship_sponsor_text` | character | Bifrost field `sponsorship_sponsor_text`: sponsorship sponsor text. |
+| `sponsorship_url` | character | Bifrost field `sponsorship_url`: sponsorship URL. |
+| `sponsorship_image_url` | character | Bifrost field `sponsorship_image_url`: sponsorship image URL. |
+| `sponsorship_image_alt_url` | character | Bifrost field `sponsorship_image_alt_url`: sponsorship image alt URL. |
+| `sponsorship_image_type` | character | Bifrost field `sponsorship_image_type`: sponsorship image type. |
+| `sponsorship_image_alt_text` | character | Bifrost field `sponsorship_image_alt_text`: sponsorship image alt text. |
+| `sponsorship_background_color` | character | Bifrost field `sponsorship_background_color`: sponsorship background color. |
+| `sponsorship_alt_background_color` | character | Bifrost field `sponsorship_alt_background_color`: sponsorship alt background color. |
+| `sponsorship_text_color` | character | Bifrost field `sponsorship_text_color`: sponsorship text color. |
+| `sponsorship_alt_text_color` | character | Bifrost field `sponsorship_alt_text_color`: sponsorship alt text color. |
+| `sponsorship_start_date` | character | Bifrost field `sponsorship_start_date`: sponsorship start date. |
+| `sponsorship_end_date` | character | Bifrost field `sponsorship_end_date`: sponsorship end date. |
+
 ### Returns — `fox_bifrost_league_odds` / `foxBifrostLeagueOdds`
 
 | col_name | type | description |
@@ -94,6 +171,38 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `web_url` | character | Bifrost league_odds field `webUrl`. |
 | `parameters` | list | Bifrost league_odds field `parameters`. |
 | `selected` | logical | Bifrost league_odds field `selected`. |
+
+### Returns — `fox_bifrost_league_playernews` / `foxBifrostLeaguePlayernews`
+
+| col_name | type | description |
+|---|---|---|
+| `image_url` | character | Bifrost field `image_url`: image URL. |
+| `image_type` | character | Bifrost field `image_type`: image type. |
+| `image_alt_text` | character | Bifrost field `image_alt_text`: image alt text. |
+| `title` | character | Bifrost field `title`: title. |
+| `subtitle` | character | Bifrost field `subtitle`: subtitle. |
+| `headline` | character | Bifrost field `headline`: headline. |
+| `description` | character | Bifrost field `description`: description. |
+| `impact_title` | character | Bifrost field `impact_title`: impact title. |
+| `impact` | character | Bifrost field `impact`: impact. |
+| `entity_link_title` | character | Bifrost field `entity_link_title`: entity link title. |
+| `entity_link_web_url` | character | Bifrost field `entity_link_web_url`: entity link web URL. |
+| `entity_link_color` | character | Bifrost field `entity_link_color`: entity link color. |
+| `entity_link_image_url` | character | Bifrost field `entity_link_image_url`: entity link image URL. |
+| `entity_link_image_type` | character | Bifrost field `entity_link_image_type`: entity link image type. |
+| `entity_link_image_alt_text` | character | Bifrost field `entity_link_image_alt_text`: entity link image alt text. |
+| `entity_link_content_uri` | character | Bifrost field `entity_link_content_uri`: entity link content URI. |
+| `entity_link_content_type` | character | Bifrost field `entity_link_content_type`: entity link content type. |
+| `entity_link_layout_path` | character | Bifrost field `entity_link_layout_path`: entity link layout path. |
+| `entity_link_layout_tokens_id` | character | Bifrost field `entity_link_layout_tokens_id`: entity link layout tokens ID. |
+| `entity_link_layout_tokens_content_uri` | character | Bifrost field `entity_link_layout_tokens_content_uri`: entity link layout tokens content URI. |
+| `entity_link_analytics_name` | character | Bifrost field `entity_link_analytics_name`: entity link analytics name. |
+| `entity_link_analytics_sport` | character | Bifrost field `entity_link_analytics_sport`: entity link analytics sport. |
+| `entity_link_type` | character | Bifrost field `entity_link_type`: entity link type. |
+| `entity_link_alternate_image_url` | character | Bifrost field `entity_link_alternate_image_url`: entity link alternate image URL. |
+| `alternate_image_url` | character | Bifrost field `alternate_image_url`: alternate image URL. |
+| `date` | character | Bifrost field `date`: date. |
+| `source` | character | Bifrost field `source`: source. |
 
 ### Returns — `fox_bifrost_league_polls` / `foxBifrostLeaguePolls`
 
@@ -127,6 +236,23 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `section_last_updated` | character | Bifrost league_standings field `lastUpdated`. |
 | `section_metadata` | list | Bifrost league_standings field `metadata`. |
 
+### Returns — `fox_bifrost_league_stats` / `foxBifrostLeagueStats`
+
+| col_name | type | description |
+|---|---|---|
+| `title` | character | Bifrost field `title`: title. |
+| `leaders` | character | Bifrost field `leaders`: leaders. |
+
+### Returns — `fox_bifrost_league_stats_con` / `foxBifrostLeagueStatsCon`
+
+| col_name | type | description |
+|---|---|---|
+| `id` | character | Bifrost field `id`: ID. |
+| `table_template` | character | Bifrost field `table_template`: table template. |
+| `table_headers` | character | Bifrost field `table_headers`: table headers. |
+| `table_rows` | character | Bifrost field `table_rows`: table rows. |
+| `legend_details` | character | Bifrost field `legend_details`: legend details. |
+
 ### Returns — `fox_bifrost_league_teamnav` / `foxBifrostLeagueTeamnav`
 
 | col_name | type | description |
@@ -159,6 +285,12 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `title` | character | Bifrost search_entities field `title`. |
 | `components` | list | Bifrost search_entities field `components`. |
 
+### Returns — `fox_bifrost_search_popular` / `foxBifrostSearchPopular`
+
+| col_name | type | description |
+|---|---|---|
+| `components` | character | Bifrost field `components`: components. |
+
 ### Returns — `fox_bifrost_team_gamelog` / `foxBifrostTeamGamelog`
 
 | col_name | type | description |
@@ -168,12 +300,42 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `legend` | list | Bifrost team_gamelog field `legend`. |
 | `more_link` | list | Bifrost team_gamelog field `moreLink`. |
 
+### Returns — `fox_bifrost_team_header` / `foxBifrostTeamHeader`
+
+| col_name | type | description |
+|---|---|---|
+| `text` | character | Bifrost field `text`: text. |
+
 ### Returns — `fox_bifrost_team_roster` / `foxBifrostTeamRoster`
 
 | col_name | type | description |
 |---|---|---|
 | `group_template` | character | Bifrost team_roster field `template`. |
 | `group_headers` | list | Bifrost team_roster field `headers`. |
+
+### Returns — `fox_bifrost_team_standings` / `foxBifrostTeamStandings`
+
+| col_name | type | description |
+|---|---|---|
+| `section_id` | character | Bifrost field `section_id`: section ID. |
+| `section_title` | character | Bifrost field `section_title`: section title. |
+| `section_page_title` | character | Bifrost field `section_page_title`: section page title. |
+| `section_last_updated` | character | Bifrost field `section_last_updated`: section last updated. |
+| `section_legend_details` | character | Bifrost field `section_legend_details`: section legend details. |
+| `section_metadata_parameters_standings_type` | character | Bifrost field `section_metadata_parameters_standings_type`: section metadata parameters standings type. |
+| `section_metadata_parameters_league_name` | character | Bifrost field `section_metadata_parameters_league_name`: section metadata parameters league name. |
+| `section_metadata_parameters_team_name` | character | Bifrost field `section_metadata_parameters_team_name`: section metadata parameters team name. |
+| `section_metadata_parameters_season` | character | Bifrost field `section_metadata_parameters_season`: section metadata parameters season. |
+| `template` | character | Bifrost field `template`: template. |
+| `headers` | character | Bifrost field `headers`: headers. |
+| `rows` | character | Bifrost field `rows`: rows. |
+
+### Returns — `fox_bifrost_team_stats` / `foxBifrostTeamStats`
+
+| col_name | type | description |
+|---|---|---|
+| `title` | character | Bifrost field `title`: title. |
+| `leaders` | character | Bifrost field `leaders`: leaders. |
 
 ### Returns — `fox_bifrost_topevents_scoreboard_segment` / `foxBifrostTopeventsScoreboardSegment`
 
@@ -189,3 +351,33 @@ Flat (non-ESPN) wrappers for Fox Sports Bifrost API. Host: `https://api.foxsport
 | `title_link` | list | Bifrost topevents_scoreboard_segment field `titleLink`. |
 | `header_text` | character | Bifrost topevents_scoreboard_segment field `headerText`. |
 | `header_link` | list | Bifrost topevents_scoreboard_segment field `headerLink`. |
+
+### Returns — `fox_bifrost_trending_articles` / `foxBifrostTrendingArticles`
+
+| col_name | type | description |
+|---|---|---|
+| `data_existing_total` | integer | Bifrost field `data_existing_total`: data existing total. |
+| `data_results` | character | Bifrost field `data_results`: data results. |
+| `data_request_type` | character | Bifrost field `data_request_type`: data request type. |
+| `data_request_content_type` | character | Bifrost field `data_request_content_type`: data request content type. |
+| `data_request_internal` | logical | Bifrost field `data_request_internal`: data request internal. |
+| `data_request_platform` | character | Bifrost field `data_request_platform`: data request platform. |
+| `data_request_params` | character | Bifrost field `data_request_params`: data request params. |
+| `data_request_path_params_proxy` | character | Bifrost field `data_request_path_params_proxy`: data request path params proxy. |
+| `data_status_success` | logical | Bifrost field `data_status_success`: data status success. |
+| `data_status_code` | integer | Bifrost field `data_status_code`: data status code. |
+
+### Returns — `fox_bifrost_trending_videos` / `foxBifrostTrendingVideos`
+
+| col_name | type | description |
+|---|---|---|
+| `data_existing_total` | integer | Bifrost field `data_existing_total`: data existing total. |
+| `data_results` | character | Bifrost field `data_results`: data results. |
+| `data_request_type` | character | Bifrost field `data_request_type`: data request type. |
+| `data_request_content_type` | character | Bifrost field `data_request_content_type`: data request content type. |
+| `data_request_internal` | logical | Bifrost field `data_request_internal`: data request internal. |
+| `data_request_platform` | character | Bifrost field `data_request_platform`: data request platform. |
+| `data_request_params` | character | Bifrost field `data_request_params`: data request params. |
+| `data_request_path_params_proxy` | character | Bifrost field `data_request_path_params_proxy`: data request path params proxy. |
+| `data_status_success` | logical | Bifrost field `data_status_success`: data status success. |
+| `data_status_code` | integer | Bifrost field `data_status_code`: data status code. |

--- a/tools/codegen/_enrich_cbs_napi_schemas.mjs
+++ b/tools/codegen/_enrich_cbs_napi_schemas.mjs
@@ -26,21 +26,32 @@ import { parse } from "yaml";
 import { CBS_NAPI_PARSERS } from "../../dist/parsers/cbs_napi.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(__dirname, "..", "..");
 const endpointsYaml = join(__dirname, "endpoints", "cbs_napi.yaml");
 const schemasDir = join(__dirname, "schemas");
-const capturesRoot = "c:/Users/saiem/Documents/sdv-internal-refs/cbs/captures";
+// The capture corpus lives outside the repo (the sdv-internal-refs checkout).
+// Override its root with the SDV_REFS_ROOT env var; defaults to the author's
+// local path. When the corpus is absent the script simply types nothing.
+const REFS_ROOT = process.env.SDV_REFS_ROOT || "c:/Users/saiem/Documents/sdv-internal-refs";
+const capturesRoot = join(REFS_ROOT, "cbs", "captures");
 const napiDir = join(capturesRoot, "napi");
 
 // Endpoint `short` -> a representative capture file (absolute path). CBS only
 // captured 5 distinct resource families; everything else has no capture.
 function findNapiCapture(suffixMatcher) {
   // Walk napi/<id>/ subdirs + napi/_discovery for the first file matching.
-  for (const sub of readdirSync(napiDir)) {
+  // The capture corpus is external, so tolerate a missing directory; sort for
+  // deterministic selection across platforms/filesystems.
+  let subs;
+  try {
+    subs = readdirSync(napiDir).sort();
+  } catch {
+    return null; // no capture corpus present
+  }
+  for (const sub of subs) {
     const subPath = join(napiDir, sub);
     let entries;
     try {
-      entries = readdirSync(subPath);
+      entries = readdirSync(subPath).sort();
     } catch {
       continue; // not a directory
     }

--- a/tools/codegen/_enrich_cbs_napi_schemas.mjs
+++ b/tools/codegen/_enrich_cbs_napi_schemas.mjs
@@ -85,7 +85,9 @@ function inferType(v) {
   if (typeof v === "number") return Number.isInteger(v) ? "integer" : "number";
   if (typeof v === "string") return "character";
   if (v === null || v === undefined) return "character";
-  if (typeof v === "object") return "object"; // (parser stringifies arrays, but be safe)
+  // Non-scalar -> "list" to match the rest of the returns-schema corpus (the
+  // parsers stringify arrays/objects, so this is a rare safety branch).
+  if (typeof v === "object") return "list";
   return "character";
 }
 

--- a/tools/codegen/_enrich_cbs_napi_schemas.mjs
+++ b/tools/codegen/_enrich_cbs_napi_schemas.mjs
@@ -29,9 +29,17 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const endpointsYaml = join(__dirname, "endpoints", "cbs_napi.yaml");
 const schemasDir = join(__dirname, "schemas");
 // The capture corpus lives outside the repo (the sdv-internal-refs checkout).
-// Override its root with the SDV_REFS_ROOT env var; defaults to the author's
-// local path. When the corpus is absent the script simply types nothing.
-const REFS_ROOT = process.env.SDV_REFS_ROOT || "c:/Users/saiem/Documents/sdv-internal-refs";
+// Point SDV_REFS_ROOT at it; with no default (a hard-coded path would be
+// non-portable and leak a local username). Absent the env var, there's nothing
+// to enrich — exit cleanly so the already-committed schemas are untouched.
+const REFS_ROOT = process.env.SDV_REFS_ROOT;
+if (!REFS_ROOT) {
+  console.log(
+    "SDV_REFS_ROOT is not set — set it to your sdv-internal-refs checkout to " +
+      "re-derive columns from the capture corpus. Nothing to do; exiting."
+  );
+  process.exit(0);
+}
 const capturesRoot = join(REFS_ROOT, "cbs", "captures");
 const napiDir = join(capturesRoot, "napi");
 
@@ -191,7 +199,8 @@ for (const ep of endpoints) {
     rows = parseFn(payload);
   } catch (err) {
     leftEmpty++;
-    emptyReasons.push(`${short}: capture parse/parser error (${err.message})`);
+    const msg = err instanceof Error ? err.message : String(err);
+    emptyReasons.push(`${short}: capture parse/parser error (${msg})`);
     continue;
   }
   if (!rows || rows.length === 0) {

--- a/tools/codegen/_enrich_cbs_napi_schemas.mjs
+++ b/tools/codegen/_enrich_cbs_napi_schemas.mjs
@@ -1,0 +1,197 @@
+// One-shot enrichment: derive returns-schema columns for the CBS NAPI
+// (`cbs_napi`) family from captured response payloads.
+//
+// The CBS NAPI OpenAPI spec ships no typed 200-response schemas, so every
+// returns schema under tools/codegen/schemas/native/cbs_napi/ starts as
+// `columns: []`. This script fills the empty schemas by:
+//
+//   1. reading the endpoint YAML (short / path / parser / returns_schema);
+//   2. matching each endpoint to a capture under
+//      <refs>/cbs/captures/napi/ — the manifest `templates` column is empty
+//      for CBS, so we match by the capture FILENAME pattern that encodes the
+//      resource (league_<id>_meta / season_<id>_teams / team_<id>_players /
+//      team_<id>_standings) plus the _discovery endpoint_registry capture;
+//   3. running the endpoint's REGISTERED parser over the captured payload and
+//      taking the union of row keys (first 200 rows) as the column set;
+//   4. OVERWRITING only the currently-empty schemas. Endpoints with no
+//      matching capture (or a 0-row parse) are LEFT as `columns: []` and logged.
+//
+// Run:  node tools/codegen/_enrich_cbs_napi_schemas.mjs
+// (requires `npm run build` first — imports the compiled parsers from dist/).
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import { CBS_NAPI_PARSERS } from "../../dist/parsers/cbs_napi.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+const endpointsYaml = join(__dirname, "endpoints", "cbs_napi.yaml");
+const schemasDir = join(__dirname, "schemas");
+const capturesRoot = "c:/Users/saiem/Documents/sdv-internal-refs/cbs/captures";
+const napiDir = join(capturesRoot, "napi");
+
+// Endpoint `short` -> a representative capture file (absolute path). CBS only
+// captured 5 distinct resource families; everything else has no capture.
+function findNapiCapture(suffixMatcher) {
+  // Walk napi/<id>/ subdirs + napi/_discovery for the first file matching.
+  for (const sub of readdirSync(napiDir)) {
+    const subPath = join(napiDir, sub);
+    let entries;
+    try {
+      entries = readdirSync(subPath);
+    } catch {
+      continue; // not a directory
+    }
+    for (const f of entries) {
+      if (suffixMatcher(f)) return join(subPath, f);
+    }
+  }
+  return null;
+}
+
+const CAPTURE_BY_SHORT = {
+  league: findNapiCapture((f) => /^league_\d+_meta\.json$/.test(f)),
+  season_teams: findNapiCapture((f) => /^season_\d+_teams\.json$/.test(f)),
+  team_players: findNapiCapture((f) => /^team_\d+_players\.json$/.test(f)),
+  team_standings: findNapiCapture((f) => /^team_\d+_standings\.json$/.test(f)),
+  endpoint_registry: findNapiCapture((f) => /^resource_endpoint_registry\.json$/.test(f)),
+};
+
+// ---- helpers ---------------------------------------------------------------
+
+function inferType(v) {
+  if (typeof v === "boolean") return "logical";
+  if (typeof v === "number") return Number.isInteger(v) ? "integer" : "number";
+  if (typeof v === "string") return "character";
+  if (v === null || v === undefined) return "character";
+  if (typeof v === "object") return "object"; // (parser stringifies arrays, but be safe)
+  return "character";
+}
+
+function describe(name) {
+  // Best-effort human description from the snake_cased key.
+  const words = name
+    .split("_")
+    .map((w) => {
+      const map = {
+        id: "ID",
+        url: "URL",
+        abbr: "abbreviation",
+        ytd: "year-to-date",
+        rtwp: "real-time win probability",
+        ts: "timestamp",
+        uid: "UID",
+      };
+      return map[w] ?? w;
+    })
+    .join(" ");
+  if (!words) return "";
+  return words.charAt(0).toUpperCase() + words.slice(1) + ".";
+}
+
+/** Union of keys across rows (first `cap`), preserving first-seen order, with
+ *  a representative non-null value per key for type inference. */
+function deriveColumns(rows, cap = 200) {
+  const order = [];
+  const sample = new Map();
+  for (const row of rows.slice(0, cap)) {
+    for (const [k, v] of Object.entries(row)) {
+      if (!sample.has(k)) {
+        order.push(k);
+        sample.set(k, v);
+      } else if (sample.get(k) === null || sample.get(k) === undefined) {
+        if (v !== null && v !== undefined) sample.set(k, v);
+      }
+    }
+  }
+  return order.map((name) => ({
+    name,
+    type: inferType(sample.get(name)),
+    description: describe(name),
+  }));
+}
+
+const HEADER = `# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. \`type\` is
+# inferred from the captured JS value; \`description\` is best-effort from the
+# snake_cased key. Endpoints with no capture remain \`columns: []\`.
+`;
+
+function dumpYaml(short, columns) {
+  let out = HEADER;
+  out += `schema: ${short}\n`;
+  out += `kind: dataframe\n`;
+  out += `columns:\n`;
+  for (const c of columns) {
+    out += `- name: ${c.name}\n`;
+    out += `  type: ${c.type}\n`;
+    // descriptions are plain ASCII words + a period; no YAML escaping needed,
+    // but quote defensively if a colon/# sneaks in.
+    const d = c.description ?? "";
+    const needsQuote = /[:#]/.test(d);
+    out += `  description: ${needsQuote ? JSON.stringify(d) : d}\n`;
+  }
+  return out;
+}
+
+// ---- main ------------------------------------------------------------------
+
+const doc = parse(readFileSync(endpointsYaml, "utf8"));
+const endpoints = doc.endpoints ?? [];
+
+let typed = 0;
+let leftEmpty = 0;
+const emptyReasons = [];
+
+for (const ep of endpoints) {
+  const { short, parser, returns_schema } = ep;
+  const schemaFile = join(schemasDir, `${returns_schema}.yaml`);
+  if (!existsSync(schemaFile)) {
+    emptyReasons.push(`${short}: schema file missing (${returns_schema})`);
+    continue;
+  }
+  // Only touch currently-empty schemas.
+  const existing = parse(readFileSync(schemaFile, "utf8"));
+  const alreadyTyped = Array.isArray(existing?.columns) && existing.columns.length > 0;
+  if (alreadyTyped) continue;
+
+  const capPath = CAPTURE_BY_SHORT[short];
+  if (!capPath || !existsSync(capPath)) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: no capture`);
+    continue;
+  }
+  const parseFn = CBS_NAPI_PARSERS[parser];
+  if (!parseFn) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: parser ${parser} not found`);
+    continue;
+  }
+  const payload = JSON.parse(readFileSync(capPath, "utf8"));
+  const rows = parseFn(payload);
+  if (!rows || rows.length === 0) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: parser yielded 0 rows`);
+    continue;
+  }
+  const columns = deriveColumns(rows);
+  if (columns.length === 0) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: 0 columns derived`);
+    continue;
+  }
+  writeFileSync(schemaFile, dumpYaml(short, columns));
+  typed++;
+  console.log(
+    `  typed ${short.padEnd(30)} <- ${capPath.replace(capturesRoot + "/", "")} (${rows.length} rows, ${columns.length} cols)`
+  );
+}
+
+console.log("");
+console.log(`CBS NAPI enrichment: ${typed} schemas typed, ${leftEmpty} left empty (of 82 total).`);
+console.log("Left empty (no capture / 0 rows):");
+for (const r of emptyReasons) console.log(`  - ${r}`);

--- a/tools/codegen/_enrich_cbs_napi_schemas.mjs
+++ b/tools/codegen/_enrich_cbs_napi_schemas.mjs
@@ -162,6 +162,7 @@ for (const ep of endpoints) {
   const { short, parser, returns_schema } = ep;
   const schemaFile = join(schemasDir, `${returns_schema}.yaml`);
   if (!existsSync(schemaFile)) {
+    leftEmpty++;
     emptyReasons.push(`${short}: schema file missing (${returns_schema})`);
     continue;
   }
@@ -182,8 +183,17 @@ for (const ep of endpoints) {
     emptyReasons.push(`${short}: parser ${parser} not found`);
     continue;
   }
-  const payload = JSON.parse(readFileSync(capPath, "utf8"));
-  const rows = parseFn(payload);
+  // Guard per-capture: a malformed JSON file or a parser throwing must not abort
+  // the whole run (the corpus is external + heterogeneous) — log + skip it.
+  let rows;
+  try {
+    const payload = JSON.parse(readFileSync(capPath, "utf8"));
+    rows = parseFn(payload);
+  } catch (err) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: capture parse/parser error (${err.message})`);
+    continue;
+  }
   if (!rows || rows.length === 0) {
     leftEmpty++;
     emptyReasons.push(`${short}: parser yielded 0 rows`);

--- a/tools/codegen/_enrich_fox_bifrost_schemas.mjs
+++ b/tools/codegen/_enrich_fox_bifrost_schemas.mjs
@@ -1,0 +1,231 @@
+// One-shot enrichment: derive returns-schema columns for the Fox Sports
+// "Bifrost" (`fox_bifrost`) family from captured response payloads.
+//
+// 14 of the 38 fox_bifrost returns schemas already carry real columns (typed
+// from the spec's `components.schemas`); this script only fills the 24 that
+// start as `columns: []`. It:
+//
+//   1. reads the endpoint YAML (short / path / parser / returns_schema);
+//   2. matches each EMPTY-schema endpoint to its capture(s) under
+//      <refs>/fox/captures/<sport>/ (or _sample/). Capture filenames encode the
+//      endpoint as `<sport>_<path-suffix>.json` (IDs inlined), so each empty
+//      short maps to a filename matcher. When multiple sport captures match the
+//      same template, the one whose parse yields the MOST rows is used (richest
+//      column union); ties keep the first.
+//   3. runs the endpoint's REGISTERED parser over the chosen payload and takes
+//      the union of row keys (first 200 rows) as the column set;
+//   4. OVERWRITES only the 24 empty schemas — the 14 already-typed schemas are
+//      left untouched. Endpoints with no matching capture (or a 0-row parse)
+//      stay `columns: []` and are logged.
+//
+// Run:  node tools/codegen/_enrich_fox_bifrost_schemas.mjs
+// (requires `npm run build` first — imports compiled parsers from dist/).
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+import * as foxParsers from "../../dist/parsers/fox_bifrost.js";
+
+// fox_bifrost.ts exports named parser functions (no aggregated registry object
+// like cbs_napi's CBS_NAPI_PARSERS), so key them by function name here.
+const FOX_BIFROST_PARSERS = Object.fromEntries(
+  Object.entries(foxParsers).filter(([, v]) => typeof v === "function")
+);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const endpointsYaml = join(__dirname, "endpoints", "fox_bifrost.yaml");
+const schemasDir = join(__dirname, "schemas");
+const capturesRoot = "c:/Users/saiem/Documents/sdv-internal-refs/fox/captures";
+const SPORT_DIRS = ["cbk", "cfb", "mlb", "nba", "nfl", "nhl", "soccer", "ufl", "wbc", "wcbk", "wnba", "_sample"];
+
+// Endpoint `short` -> a regex matched against capture BASENAMES (sport prefix
+// already stripped). Only the 24 currently-empty shorts are listed; absence
+// means "no capture" and the schema is left as columns: []. The capture
+// filename pattern encodes the path suffix with any path IDs inlined.
+const MATCHERS = {
+  event_odds: /^event_\d+_odds\.json$/,
+  event_recap: /^event_\d+_recap\.json$/,
+  event_standings: /^event_\d+_standings\.json$/,
+  league_conferences: /^league_conferences\.json$/,
+  league_header: /^league_header\.json$/,
+  league_playernews: /^league_playernews\.json$/,
+  league_stats: /^league_stats\.json$/,
+  // stats-con tables ship as league_stats-con__<who>__<cat>__p<page>.json
+  league_stats_con: /^league_stats-con__.+\.json$/,
+  team_header: /^team_\d+_header\.json$/,
+  team_standings: /^team_\d+_standings\.json$/,
+  team_stats: /^team_\d+_stats\.json$/,
+  explore_browse: /^explore_browse_.+_main\.json$/,
+  explore_odds: /^explore_odds_main\.json$/,
+  search_popular: /^search_popular\.json$/,
+  trending_articles: /^trending_articles\.json$/,
+  trending_videos: /^trending_videos\.json$/,
+  // No capture in the corpus for these (logged, left empty):
+  //   explore_favorite, foxpolls, fs_feed, fs_images, fs_layouts, fs_videos,
+  //   league_scores_segment, scorechip
+};
+
+// Strip the leading sport directory token from a basename so the path-suffix
+// matchers above are sport-agnostic.
+const SPORT_PREFIX = /^(cbk|cfb|mlb|nba|nfl|nhl|soccer|ufl|wbc|wcbk|wnba)_/;
+
+/** All capture files (abs path) whose sport-stripped basename matches `re`. */
+function findCaptures(re) {
+  const hits = [];
+  for (const d of SPORT_DIRS) {
+    const dir = join(capturesRoot, d);
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const f of entries) {
+      const stripped = f.replace(SPORT_PREFIX, "");
+      if (re.test(stripped)) hits.push(join(dir, f));
+    }
+  }
+  return hits;
+}
+
+// ---- helpers (shared shape with the CBS enrichment script) ----------------
+
+function inferType(v) {
+  if (typeof v === "boolean") return "logical";
+  if (typeof v === "number") return Number.isInteger(v) ? "integer" : "number";
+  if (typeof v === "string") return "character";
+  if (v === null || v === undefined) return "character";
+  if (typeof v === "object") return "object";
+  return "character";
+}
+
+function describe(name) {
+  const map = {
+    id: "ID",
+    url: "URL",
+    abbr: "abbreviation",
+    uri: "URI",
+    cta: "call-to-action",
+    pbp: "play-by-play",
+  };
+  const words = name.split("_").map((w) => map[w] ?? w).join(" ");
+  if (!words) return "";
+  return `Bifrost field \`${name}\`: ${words}.`;
+}
+
+function deriveColumns(rows, cap = 200) {
+  const order = [];
+  const sample = new Map();
+  for (const row of rows.slice(0, cap)) {
+    for (const [k, v] of Object.entries(row)) {
+      if (!sample.has(k)) {
+        order.push(k);
+        sample.set(k, v);
+      } else if (sample.get(k) === null || sample.get(k) === undefined) {
+        if (v !== null && v !== undefined) sample.set(k, v);
+      }
+    }
+  }
+  return order.map((name) => ({
+    name,
+    type: inferType(sample.get(name)),
+    description: describe(name),
+  }));
+}
+
+const HEADER = `# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (\`object\`), so the columns are enumerated here from
+# a representative capture. \`type\` is inferred from the captured JS value;
+# \`description\` is best-effort from the snake_cased key. Endpoints with no
+# capture remain \`columns: []\`.
+`;
+
+function dumpYaml(short, columns) {
+  let out = HEADER;
+  out += `schema: ${short}\n`;
+  out += `kind: dataframe\n`;
+  out += `columns:\n`;
+  for (const c of columns) {
+    out += `- name: ${c.name}\n`;
+    out += `  type: ${c.type}\n`;
+    const d = c.description ?? "";
+    out += `  description: ${JSON.stringify(d)}\n`;
+  }
+  return out;
+}
+
+// ---- main ------------------------------------------------------------------
+
+const doc = parse(readFileSync(endpointsYaml, "utf8"));
+const endpoints = doc.endpoints ?? [];
+
+let typed = 0;
+let leftEmpty = 0;
+const emptyReasons = [];
+
+for (const ep of endpoints) {
+  const { short, parser, returns_schema } = ep;
+  const schemaFile = join(schemasDir, `${returns_schema}.yaml`);
+  if (!existsSync(schemaFile)) {
+    emptyReasons.push(`${short}: schema file missing`);
+    continue;
+  }
+  const existing = parse(readFileSync(schemaFile, "utf8"));
+  if (Array.isArray(existing?.columns) && existing.columns.length > 0) continue; // already typed — leave it
+
+  const re = MATCHERS[short];
+  if (!re) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: no capture`);
+    continue;
+  }
+  const candidates = findCaptures(re);
+  if (candidates.length === 0) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: no capture`);
+    continue;
+  }
+  const parseFn = FOX_BIFROST_PARSERS[parser];
+  if (!parseFn) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: parser ${parser} not found`);
+    continue;
+  }
+
+  // Pick the candidate whose parse yields the most rows (richest column union).
+  let best = null;
+  for (const c of candidates) {
+    let rows;
+    try {
+      rows = parseFn(JSON.parse(readFileSync(c, "utf8")));
+    } catch {
+      continue;
+    }
+    if (Array.isArray(rows) && (!best || rows.length > best.rows.length)) {
+      best = { path: c, rows };
+    }
+  }
+  if (!best || best.rows.length === 0) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: parser yielded 0 rows`);
+    continue;
+  }
+  const columns = deriveColumns(best.rows);
+  if (columns.length === 0) {
+    leftEmpty++;
+    emptyReasons.push(`${short}: 0 columns derived`);
+    continue;
+  }
+  writeFileSync(schemaFile, dumpYaml(short, columns));
+  typed++;
+  console.log(
+    `  typed ${short.padEnd(24)} <- ${best.path.replace(capturesRoot + "/", "").replace(capturesRoot + "\\", "")} (${best.rows.length} rows, ${columns.length} cols)`
+  );
+}
+
+console.log("");
+console.log(`Fox Bifrost enrichment: ${typed} schemas newly typed, ${leftEmpty} left empty (of 24 empty / 38 total).`);
+console.log("Left empty (no capture / 0 rows):");
+for (const r of emptyReasons) console.log(`  - ${r}`);

--- a/tools/codegen/_enrich_fox_bifrost_schemas.mjs
+++ b/tools/codegen/_enrich_fox_bifrost_schemas.mjs
@@ -110,7 +110,9 @@ function inferType(v) {
   if (typeof v === "number") return Number.isInteger(v) ? "integer" : "number";
   if (typeof v === "string") return "character";
   if (v === null || v === undefined) return "character";
-  if (typeof v === "object") return "object";
+  // Non-scalar -> "list" to match the rest of the returns-schema corpus (the
+  // parsers stringify arrays/objects, so this is a rare safety branch).
+  if (typeof v === "object") return "list";
   return "character";
 }
 

--- a/tools/codegen/_enrich_fox_bifrost_schemas.mjs
+++ b/tools/codegen/_enrich_fox_bifrost_schemas.mjs
@@ -36,10 +36,18 @@ const FOX_BIFROST_PARSERS = Object.fromEntries(
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const endpointsYaml = join(__dirname, "endpoints", "fox_bifrost.yaml");
 const schemasDir = join(__dirname, "schemas");
-// External capture corpus (the sdv-internal-refs checkout); override its root
-// with the SDV_REFS_ROOT env var. Defaults to the author's local path; when the
-// corpus is absent the script types nothing.
-const REFS_ROOT = process.env.SDV_REFS_ROOT || "c:/Users/saiem/Documents/sdv-internal-refs";
+// External capture corpus (the sdv-internal-refs checkout). Point SDV_REFS_ROOT
+// at it; no default (a hard-coded path would be non-portable + leak a local
+// username). Absent the env var there's nothing to enrich — exit cleanly so the
+// already-committed schemas are untouched.
+const REFS_ROOT = process.env.SDV_REFS_ROOT;
+if (!REFS_ROOT) {
+  console.log(
+    "SDV_REFS_ROOT is not set — set it to your sdv-internal-refs checkout to " +
+      "re-derive columns from the capture corpus. Nothing to do; exiting."
+  );
+  process.exit(0);
+}
 const capturesRoot = join(REFS_ROOT, "fox", "captures");
 const SPORT_DIRS = ["cbk", "cfb", "mlb", "nba", "nfl", "nhl", "soccer", "ufl", "wbc", "wcbk", "wnba", "_sample"];
 

--- a/tools/codegen/_enrich_fox_bifrost_schemas.mjs
+++ b/tools/codegen/_enrich_fox_bifrost_schemas.mjs
@@ -36,7 +36,11 @@ const FOX_BIFROST_PARSERS = Object.fromEntries(
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const endpointsYaml = join(__dirname, "endpoints", "fox_bifrost.yaml");
 const schemasDir = join(__dirname, "schemas");
-const capturesRoot = "c:/Users/saiem/Documents/sdv-internal-refs/fox/captures";
+// External capture corpus (the sdv-internal-refs checkout); override its root
+// with the SDV_REFS_ROOT env var. Defaults to the author's local path; when the
+// corpus is absent the script types nothing.
+const REFS_ROOT = process.env.SDV_REFS_ROOT || "c:/Users/saiem/Documents/sdv-internal-refs";
+const capturesRoot = join(REFS_ROOT, "fox", "captures");
 const SPORT_DIRS = ["cbk", "cfb", "mlb", "nba", "nfl", "nhl", "soccer", "ufl", "wbc", "wcbk", "wnba", "_sample"];
 
 // Endpoint `short` -> a regex matched against capture BASENAMES (sport prefix
@@ -77,7 +81,9 @@ function findCaptures(re) {
     const dir = join(capturesRoot, d);
     let entries;
     try {
-      entries = readdirSync(dir);
+      // Sort for deterministic candidate ordering across platforms/filesystems
+      // (richest-candidate tie-break depends on a stable scan order).
+      entries = readdirSync(dir).sort();
     } catch {
       continue;
     }

--- a/tools/codegen/_enrich_fox_bifrost_schemas.mjs
+++ b/tools/codegen/_enrich_fox_bifrost_schemas.mjs
@@ -175,6 +175,7 @@ for (const ep of endpoints) {
   const { short, parser, returns_schema } = ep;
   const schemaFile = join(schemasDir, `${returns_schema}.yaml`);
   if (!existsSync(schemaFile)) {
+    leftEmpty++;
     emptyReasons.push(`${short}: schema file missing`);
     continue;
   }

--- a/tools/codegen/schemas/native/cbs_napi/endpoint_registry.yaml
+++ b/tools/codegen/schemas/native/cbs_napi/endpoint_registry.yaml
@@ -1,8 +1,4068 @@
-# CBS NAPI endpoint registry resource (/resource/endpoint/registry). Generic flattened frame parsed
-# by parse_cbs_napi_list.
-# The CBS NAPI OpenAPI spec ships no typed 200-response schema (every resource is
-# a free-form {data: ...} envelope), so columns are not enumerable ahead of a
-# live capture; the parser snake_cases + flattens whatever keys the payload ships.
+# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. `type` is
+# inferred from the captured JS value; `description` is best-effort from the
+# snake_cased key. Endpoints with no capture remain `columns: []`.
 schema: endpoint_registry
 kind: dataframe
-columns: []
+columns:
+- name: boxscore_resource_location
+  type: character
+  description: Boxscore resource location.
+- name: boxscore_resource_route
+  type: character
+  description: Boxscore resource route.
+- name: boxscore_resource_path
+  type: character
+  description: Boxscore resource path.
+- name: boxscore_resource_summary
+  type: character
+  description: Boxscore resource summary.
+- name: boxscore_resource_notes
+  type: character
+  description: Boxscore resource notes.
+- name: boxscore_resource_versions_allowed
+  type: character
+  description: Boxscore resource versions allowed.
+- name: boxscore_resource_versions_current
+  type: character
+  description: Boxscore resource versions current.
+- name: boxscore_resource_methods
+  type: character
+  description: Boxscore resource methods.
+- name: boxscore_resource_formats
+  type: character
+  description: Boxscore resource formats.
+- name: boxscore_resource_parameters
+  type: character
+  description: Boxscore resource parameters.
+- name: boxscore_resource_auth_settings_require_auth
+  type: logical
+  description: Boxscore resource auth settings require auth.
+- name: boxscore_resource_auth_settings_allow_only
+  type: character
+  description: Boxscore resource auth settings allow only.
+- name: boxscore_resource_resource_cache_ns
+  type: character
+  description: Boxscore resource resource cache ns.
+- name: boxscore_resource_resource_cache_cache_keys
+  type: character
+  description: Boxscore resource resource cache cache keys.
+- name: boxscore_resource_resource_cache_cache_buster
+  type: integer
+  description: Boxscore resource resource cache cache buster.
+- name: boxscore_resource_expiration_message_object_key_name
+  type: character
+  description: Boxscore resource expiration message object key name.
+- name: player_resource_location
+  type: character
+  description: Player resource location.
+- name: player_resource_route
+  type: character
+  description: Player resource route.
+- name: player_resource_path
+  type: character
+  description: Player resource path.
+- name: player_resource_summary
+  type: character
+  description: Player resource summary.
+- name: player_resource_notes
+  type: character
+  description: Player resource notes.
+- name: player_resource_versions_allowed
+  type: character
+  description: Player resource versions allowed.
+- name: player_resource_versions_current
+  type: character
+  description: Player resource versions current.
+- name: player_resource_methods
+  type: character
+  description: Player resource methods.
+- name: player_resource_formats
+  type: character
+  description: Player resource formats.
+- name: player_resource_parameters
+  type: character
+  description: Player resource parameters.
+- name: player_resource_auth_settings_require_auth
+  type: logical
+  description: Player resource auth settings require auth.
+- name: player_resource_auth_settings_allow_only
+  type: character
+  description: Player resource auth settings allow only.
+- name: player_resource_resource_cache_ns
+  type: character
+  description: Player resource resource cache ns.
+- name: player_resource_resource_cache_cache_keys
+  type: character
+  description: Player resource resource cache cache keys.
+- name: player_resource_resource_cache_cache_buster
+  type: integer
+  description: Player resource resource cache cache buster.
+- name: player_resource_expiration_message_object_key_name
+  type: character
+  description: Player resource expiration message object key name.
+- name: player_team_associations_resource_location
+  type: character
+  description: Player team associations resource location.
+- name: player_team_associations_resource_route
+  type: character
+  description: Player team associations resource route.
+- name: player_team_associations_resource_path
+  type: character
+  description: Player team associations resource path.
+- name: player_team_associations_resource_summary
+  type: character
+  description: Player team associations resource summary.
+- name: player_team_associations_resource_notes
+  type: character
+  description: Player team associations resource notes.
+- name: player_team_associations_resource_versions_allowed
+  type: character
+  description: Player team associations resource versions allowed.
+- name: player_team_associations_resource_versions_current
+  type: character
+  description: Player team associations resource versions current.
+- name: player_team_associations_resource_methods
+  type: character
+  description: Player team associations resource methods.
+- name: player_team_associations_resource_formats
+  type: character
+  description: Player team associations resource formats.
+- name: player_team_associations_resource_parameters
+  type: character
+  description: Player team associations resource parameters.
+- name: player_team_associations_resource_auth_settings_require_auth
+  type: logical
+  description: Player team associations resource auth settings require auth.
+- name: player_team_associations_resource_auth_settings_allow_only
+  type: character
+  description: Player team associations resource auth settings allow only.
+- name: player_team_associations_resource_resource_cache_ns
+  type: character
+  description: Player team associations resource resource cache ns.
+- name: player_team_associations_resource_resource_cache_cache_keys
+  type: character
+  description: Player team associations resource resource cache cache keys.
+- name: player_team_associations_resource_resource_cache_cache_buster
+  type: integer
+  description: Player team associations resource resource cache cache buster.
+- name: player_team_associations_resource_expiration_message_object_key_name
+  type: character
+  description: Player team associations resource expiration message object key name.
+- name: recruit_team_associations_resource_location
+  type: character
+  description: Recruit team associations resource location.
+- name: recruit_team_associations_resource_route
+  type: character
+  description: Recruit team associations resource route.
+- name: recruit_team_associations_resource_path
+  type: character
+  description: Recruit team associations resource path.
+- name: recruit_team_associations_resource_summary
+  type: character
+  description: Recruit team associations resource summary.
+- name: recruit_team_associations_resource_notes
+  type: character
+  description: Recruit team associations resource notes.
+- name: recruit_team_associations_resource_versions_allowed
+  type: character
+  description: Recruit team associations resource versions allowed.
+- name: recruit_team_associations_resource_versions_current
+  type: character
+  description: Recruit team associations resource versions current.
+- name: recruit_team_associations_resource_methods
+  type: character
+  description: Recruit team associations resource methods.
+- name: recruit_team_associations_resource_formats
+  type: character
+  description: Recruit team associations resource formats.
+- name: recruit_team_associations_resource_parameters
+  type: character
+  description: Recruit team associations resource parameters.
+- name: recruit_team_associations_resource_auth_settings_require_auth
+  type: logical
+  description: Recruit team associations resource auth settings require auth.
+- name: recruit_team_associations_resource_auth_settings_allow_only
+  type: character
+  description: Recruit team associations resource auth settings allow only.
+- name: recruit_team_associations_resource_resource_cache_ns
+  type: character
+  description: Recruit team associations resource resource cache ns.
+- name: recruit_team_associations_resource_resource_cache_cache_keys
+  type: character
+  description: Recruit team associations resource resource cache cache keys.
+- name: recruit_team_associations_resource_resource_cache_cache_buster
+  type: integer
+  description: Recruit team associations resource resource cache cache buster.
+- name: recruit_team_associations_resource_expiration_message_object_key_name
+  type: character
+  description: Recruit team associations resource expiration message object key name.
+- name: coach_team_associations_resource_location
+  type: character
+  description: Coach team associations resource location.
+- name: coach_team_associations_resource_route
+  type: character
+  description: Coach team associations resource route.
+- name: coach_team_associations_resource_path
+  type: character
+  description: Coach team associations resource path.
+- name: coach_team_associations_resource_summary
+  type: character
+  description: Coach team associations resource summary.
+- name: coach_team_associations_resource_notes
+  type: character
+  description: Coach team associations resource notes.
+- name: coach_team_associations_resource_versions_allowed
+  type: character
+  description: Coach team associations resource versions allowed.
+- name: coach_team_associations_resource_versions_current
+  type: character
+  description: Coach team associations resource versions current.
+- name: coach_team_associations_resource_methods
+  type: character
+  description: Coach team associations resource methods.
+- name: coach_team_associations_resource_formats
+  type: character
+  description: Coach team associations resource formats.
+- name: coach_team_associations_resource_parameters
+  type: character
+  description: Coach team associations resource parameters.
+- name: coach_team_associations_resource_auth_settings_require_auth
+  type: logical
+  description: Coach team associations resource auth settings require auth.
+- name: coach_team_associations_resource_auth_settings_allow_only
+  type: character
+  description: Coach team associations resource auth settings allow only.
+- name: coach_team_associations_resource_resource_cache_ns
+  type: character
+  description: Coach team associations resource resource cache ns.
+- name: coach_team_associations_resource_resource_cache_cache_keys
+  type: character
+  description: Coach team associations resource resource cache cache keys.
+- name: coach_team_associations_resource_resource_cache_cache_buster
+  type: integer
+  description: Coach team associations resource resource cache cache buster.
+- name: coach_team_associations_resource_expiration_message_object_key_name
+  type: character
+  description: Coach team associations resource expiration message object key name.
+- name: player_draft_info_resource_location
+  type: character
+  description: Player draft info resource location.
+- name: player_draft_info_resource_route
+  type: character
+  description: Player draft info resource route.
+- name: player_draft_info_resource_path
+  type: character
+  description: Player draft info resource path.
+- name: player_draft_info_resource_summary
+  type: character
+  description: Player draft info resource summary.
+- name: player_draft_info_resource_notes
+  type: character
+  description: Player draft info resource notes.
+- name: player_draft_info_resource_versions_allowed
+  type: character
+  description: Player draft info resource versions allowed.
+- name: player_draft_info_resource_versions_current
+  type: character
+  description: Player draft info resource versions current.
+- name: player_draft_info_resource_methods
+  type: character
+  description: Player draft info resource methods.
+- name: player_draft_info_resource_formats
+  type: character
+  description: Player draft info resource formats.
+- name: player_draft_info_resource_parameters
+  type: character
+  description: Player draft info resource parameters.
+- name: player_draft_info_resource_auth_settings_require_auth
+  type: logical
+  description: Player draft info resource auth settings require auth.
+- name: player_draft_info_resource_auth_settings_allow_only
+  type: character
+  description: Player draft info resource auth settings allow only.
+- name: player_draft_info_resource_resource_cache_ns
+  type: character
+  description: Player draft info resource resource cache ns.
+- name: player_draft_info_resource_resource_cache_cache_keys
+  type: character
+  description: Player draft info resource resource cache cache keys.
+- name: player_draft_info_resource_resource_cache_cache_buster
+  type: integer
+  description: Player draft info resource resource cache cache buster.
+- name: player_draft_info_resource_expiration_message_object_key_name
+  type: character
+  description: Player draft info resource expiration message object key name.
+- name: player_combine_data_resource_location
+  type: character
+  description: Player combine data resource location.
+- name: player_combine_data_resource_route
+  type: character
+  description: Player combine data resource route.
+- name: player_combine_data_resource_path
+  type: character
+  description: Player combine data resource path.
+- name: player_combine_data_resource_summary
+  type: character
+  description: Player combine data resource summary.
+- name: player_combine_data_resource_notes
+  type: character
+  description: Player combine data resource notes.
+- name: player_combine_data_resource_versions_allowed
+  type: character
+  description: Player combine data resource versions allowed.
+- name: player_combine_data_resource_versions_current
+  type: character
+  description: Player combine data resource versions current.
+- name: player_combine_data_resource_methods
+  type: character
+  description: Player combine data resource methods.
+- name: player_combine_data_resource_formats
+  type: character
+  description: Player combine data resource formats.
+- name: player_combine_data_resource_parameters
+  type: character
+  description: Player combine data resource parameters.
+- name: player_combine_data_resource_auth_settings_require_auth
+  type: logical
+  description: Player combine data resource auth settings require auth.
+- name: player_combine_data_resource_auth_settings_allow_only
+  type: character
+  description: Player combine data resource auth settings allow only.
+- name: player_combine_data_resource_resource_cache_ns
+  type: character
+  description: Player combine data resource resource cache ns.
+- name: player_combine_data_resource_resource_cache_cache_keys
+  type: character
+  description: Player combine data resource resource cache cache keys.
+- name: player_combine_data_resource_resource_cache_cache_buster
+  type: integer
+  description: Player combine data resource resource cache cache buster.
+- name: player_combine_data_resource_expiration_message_object_key_name
+  type: character
+  description: Player combine data resource expiration message object key name.
+- name: player_injuries_resource_location
+  type: character
+  description: Player injuries resource location.
+- name: player_injuries_resource_route
+  type: character
+  description: Player injuries resource route.
+- name: player_injuries_resource_path
+  type: character
+  description: Player injuries resource path.
+- name: player_injuries_resource_summary
+  type: character
+  description: Player injuries resource summary.
+- name: player_injuries_resource_notes
+  type: character
+  description: Player injuries resource notes.
+- name: player_injuries_resource_versions_allowed
+  type: character
+  description: Player injuries resource versions allowed.
+- name: player_injuries_resource_versions_current
+  type: character
+  description: Player injuries resource versions current.
+- name: player_injuries_resource_methods
+  type: character
+  description: Player injuries resource methods.
+- name: player_injuries_resource_formats
+  type: character
+  description: Player injuries resource formats.
+- name: player_injuries_resource_parameters
+  type: character
+  description: Player injuries resource parameters.
+- name: player_injuries_resource_auth_settings_require_auth
+  type: logical
+  description: Player injuries resource auth settings require auth.
+- name: player_injuries_resource_auth_settings_allow_only
+  type: character
+  description: Player injuries resource auth settings allow only.
+- name: player_injuries_resource_resource_cache_ns
+  type: character
+  description: Player injuries resource resource cache ns.
+- name: player_injuries_resource_resource_cache_cache_keys
+  type: character
+  description: Player injuries resource resource cache cache keys.
+- name: player_injuries_resource_resource_cache_cache_buster
+  type: integer
+  description: Player injuries resource resource cache cache buster.
+- name: player_injuries_resource_expiration_message_object_key_name
+  type: character
+  description: Player injuries resource expiration message object key name.
+- name: player_transactions_resource_location
+  type: character
+  description: Player transactions resource location.
+- name: player_transactions_resource_route
+  type: character
+  description: Player transactions resource route.
+- name: player_transactions_resource_path
+  type: character
+  description: Player transactions resource path.
+- name: player_transactions_resource_summary
+  type: character
+  description: Player transactions resource summary.
+- name: player_transactions_resource_notes
+  type: character
+  description: Player transactions resource notes.
+- name: player_transactions_resource_versions_allowed
+  type: character
+  description: Player transactions resource versions allowed.
+- name: player_transactions_resource_versions_current
+  type: character
+  description: Player transactions resource versions current.
+- name: player_transactions_resource_methods
+  type: character
+  description: Player transactions resource methods.
+- name: player_transactions_resource_formats
+  type: character
+  description: Player transactions resource formats.
+- name: player_transactions_resource_parameters
+  type: character
+  description: Player transactions resource parameters.
+- name: player_transactions_resource_auth_settings_require_auth
+  type: logical
+  description: Player transactions resource auth settings require auth.
+- name: player_transactions_resource_auth_settings_allow_only
+  type: character
+  description: Player transactions resource auth settings allow only.
+- name: player_transactions_resource_resource_cache_ns
+  type: character
+  description: Player transactions resource resource cache ns.
+- name: player_transactions_resource_resource_cache_cache_keys
+  type: character
+  description: Player transactions resource resource cache cache keys.
+- name: player_transactions_resource_resource_cache_cache_buster
+  type: integer
+  description: Player transactions resource resource cache cache buster.
+- name: player_transactions_resource_expiration_message_object_key_name
+  type: character
+  description: Player transactions resource expiration message object key name.
+- name: player_encyclopedia_resource_location
+  type: character
+  description: Player encyclopedia resource location.
+- name: player_encyclopedia_resource_route
+  type: character
+  description: Player encyclopedia resource route.
+- name: player_encyclopedia_resource_path
+  type: character
+  description: Player encyclopedia resource path.
+- name: player_encyclopedia_resource_summary
+  type: character
+  description: Player encyclopedia resource summary.
+- name: player_encyclopedia_resource_notes
+  type: character
+  description: Player encyclopedia resource notes.
+- name: player_encyclopedia_resource_versions_allowed
+  type: character
+  description: Player encyclopedia resource versions allowed.
+- name: player_encyclopedia_resource_versions_current
+  type: character
+  description: Player encyclopedia resource versions current.
+- name: player_encyclopedia_resource_methods
+  type: character
+  description: Player encyclopedia resource methods.
+- name: player_encyclopedia_resource_formats
+  type: character
+  description: Player encyclopedia resource formats.
+- name: player_encyclopedia_resource_parameters
+  type: character
+  description: Player encyclopedia resource parameters.
+- name: player_encyclopedia_resource_auth_settings_require_auth
+  type: logical
+  description: Player encyclopedia resource auth settings require auth.
+- name: player_encyclopedia_resource_auth_settings_allow_only
+  type: character
+  description: Player encyclopedia resource auth settings allow only.
+- name: player_encyclopedia_resource_resource_cache_ns
+  type: character
+  description: Player encyclopedia resource resource cache ns.
+- name: player_encyclopedia_resource_resource_cache_cache_keys
+  type: character
+  description: Player encyclopedia resource resource cache cache keys.
+- name: player_encyclopedia_resource_resource_cache_cache_buster
+  type: integer
+  description: Player encyclopedia resource resource cache cache buster.
+- name: player_encyclopedia_resource_expiration_message_object_key_name
+  type: character
+  description: Player encyclopedia resource expiration message object key name.
+- name: golfer_results_resource_location
+  type: character
+  description: Golfer results resource location.
+- name: golfer_results_resource_route
+  type: character
+  description: Golfer results resource route.
+- name: golfer_results_resource_path
+  type: character
+  description: Golfer results resource path.
+- name: golfer_results_resource_summary
+  type: character
+  description: Golfer results resource summary.
+- name: golfer_results_resource_notes
+  type: character
+  description: Golfer results resource notes.
+- name: golfer_results_resource_versions_allowed
+  type: character
+  description: Golfer results resource versions allowed.
+- name: golfer_results_resource_versions_current
+  type: character
+  description: Golfer results resource versions current.
+- name: golfer_results_resource_methods
+  type: character
+  description: Golfer results resource methods.
+- name: golfer_results_resource_formats
+  type: character
+  description: Golfer results resource formats.
+- name: golfer_results_resource_parameters
+  type: character
+  description: Golfer results resource parameters.
+- name: golfer_results_resource_auth_settings_require_auth
+  type: logical
+  description: Golfer results resource auth settings require auth.
+- name: golfer_results_resource_auth_settings_allow_only
+  type: character
+  description: Golfer results resource auth settings allow only.
+- name: golfer_results_resource_resource_cache_ns
+  type: character
+  description: Golfer results resource resource cache ns.
+- name: golfer_results_resource_resource_cache_cache_keys
+  type: character
+  description: Golfer results resource resource cache cache keys.
+- name: golfer_results_resource_resource_cache_cache_buster
+  type: integer
+  description: Golfer results resource resource cache cache buster.
+- name: golfer_results_resource_expiration_message_object_key_name
+  type: character
+  description: Golfer results resource expiration message object key name.
+- name: depth_charts_resource_location
+  type: character
+  description: Depth charts resource location.
+- name: depth_charts_resource_route
+  type: character
+  description: Depth charts resource route.
+- name: depth_charts_resource_path
+  type: character
+  description: Depth charts resource path.
+- name: depth_charts_resource_summary
+  type: character
+  description: Depth charts resource summary.
+- name: depth_charts_resource_notes
+  type: character
+  description: Depth charts resource notes.
+- name: depth_charts_resource_versions_allowed
+  type: character
+  description: Depth charts resource versions allowed.
+- name: depth_charts_resource_versions_current
+  type: character
+  description: Depth charts resource versions current.
+- name: depth_charts_resource_methods
+  type: character
+  description: Depth charts resource methods.
+- name: depth_charts_resource_formats
+  type: character
+  description: Depth charts resource formats.
+- name: depth_charts_resource_parameters
+  type: character
+  description: Depth charts resource parameters.
+- name: depth_charts_resource_auth_settings_require_auth
+  type: logical
+  description: Depth charts resource auth settings require auth.
+- name: depth_charts_resource_auth_settings_allow_only
+  type: character
+  description: Depth charts resource auth settings allow only.
+- name: depth_charts_resource_resource_cache_ns
+  type: character
+  description: Depth charts resource resource cache ns.
+- name: depth_charts_resource_resource_cache_cache_keys
+  type: character
+  description: Depth charts resource resource cache cache keys.
+- name: depth_charts_resource_resource_cache_cache_buster
+  type: integer
+  description: Depth charts resource resource cache cache buster.
+- name: depth_charts_resource_expiration_message_object_key_name
+  type: character
+  description: Depth charts resource expiration message object key name.
+- name: team_players_resource_location
+  type: character
+  description: Team players resource location.
+- name: team_players_resource_route
+  type: character
+  description: Team players resource route.
+- name: team_players_resource_path
+  type: character
+  description: Team players resource path.
+- name: team_players_resource_summary
+  type: character
+  description: Team players resource summary.
+- name: team_players_resource_notes
+  type: character
+  description: Team players resource notes.
+- name: team_players_resource_versions_allowed
+  type: character
+  description: Team players resource versions allowed.
+- name: team_players_resource_versions_current
+  type: character
+  description: Team players resource versions current.
+- name: team_players_resource_methods
+  type: character
+  description: Team players resource methods.
+- name: team_players_resource_formats
+  type: character
+  description: Team players resource formats.
+- name: team_players_resource_parameters
+  type: character
+  description: Team players resource parameters.
+- name: team_players_resource_auth_settings_require_auth
+  type: logical
+  description: Team players resource auth settings require auth.
+- name: team_players_resource_auth_settings_allow_only
+  type: character
+  description: Team players resource auth settings allow only.
+- name: team_players_resource_resource_cache_ns
+  type: character
+  description: Team players resource resource cache ns.
+- name: team_players_resource_resource_cache_cache_keys
+  type: character
+  description: Team players resource resource cache cache keys.
+- name: team_players_resource_resource_cache_cache_buster
+  type: integer
+  description: Team players resource resource cache cache buster.
+- name: team_players_resource_expiration_message_object_key_name
+  type: character
+  description: Team players resource expiration message object key name.
+- name: team_standings_resource_location
+  type: character
+  description: Team standings resource location.
+- name: team_standings_resource_route
+  type: character
+  description: Team standings resource route.
+- name: team_standings_resource_path
+  type: character
+  description: Team standings resource path.
+- name: team_standings_resource_summary
+  type: character
+  description: Team standings resource summary.
+- name: team_standings_resource_notes
+  type: character
+  description: Team standings resource notes.
+- name: team_standings_resource_versions_allowed
+  type: character
+  description: Team standings resource versions allowed.
+- name: team_standings_resource_versions_current
+  type: character
+  description: Team standings resource versions current.
+- name: team_standings_resource_methods
+  type: character
+  description: Team standings resource methods.
+- name: team_standings_resource_formats
+  type: character
+  description: Team standings resource formats.
+- name: team_standings_resource_parameters
+  type: character
+  description: Team standings resource parameters.
+- name: team_standings_resource_auth_settings_require_auth
+  type: logical
+  description: Team standings resource auth settings require auth.
+- name: team_standings_resource_auth_settings_allow_only
+  type: character
+  description: Team standings resource auth settings allow only.
+- name: team_standings_resource_resource_cache_ns
+  type: character
+  description: Team standings resource resource cache ns.
+- name: team_standings_resource_resource_cache_cache_keys
+  type: character
+  description: Team standings resource resource cache cache keys.
+- name: team_standings_resource_resource_cache_cache_buster
+  type: integer
+  description: Team standings resource resource cache cache buster.
+- name: team_standings_resource_expiration_message_object_key_name
+  type: character
+  description: Team standings resource expiration message object key name.
+- name: sports_line_team_standings_resource_location
+  type: character
+  description: Sports line team standings resource location.
+- name: sports_line_team_standings_resource_route
+  type: character
+  description: Sports line team standings resource route.
+- name: sports_line_team_standings_resource_path
+  type: character
+  description: Sports line team standings resource path.
+- name: sports_line_team_standings_resource_summary
+  type: character
+  description: Sports line team standings resource summary.
+- name: sports_line_team_standings_resource_notes
+  type: character
+  description: Sports line team standings resource notes.
+- name: sports_line_team_standings_resource_versions_allowed
+  type: character
+  description: Sports line team standings resource versions allowed.
+- name: sports_line_team_standings_resource_versions_current
+  type: character
+  description: Sports line team standings resource versions current.
+- name: sports_line_team_standings_resource_methods
+  type: character
+  description: Sports line team standings resource methods.
+- name: sports_line_team_standings_resource_formats
+  type: character
+  description: Sports line team standings resource formats.
+- name: sports_line_team_standings_resource_parameters
+  type: character
+  description: Sports line team standings resource parameters.
+- name: sports_line_team_standings_resource_auth_settings_require_auth
+  type: logical
+  description: Sports line team standings resource auth settings require auth.
+- name: sports_line_team_standings_resource_auth_settings_allow_only
+  type: character
+  description: Sports line team standings resource auth settings allow only.
+- name: sports_line_team_standings_resource_resource_cache_ns
+  type: character
+  description: Sports line team standings resource resource cache ns.
+- name: sports_line_team_standings_resource_resource_cache_cache_keys
+  type: character
+  description: Sports line team standings resource resource cache cache keys.
+- name: sports_line_team_standings_resource_resource_cache_cache_buster
+  type: integer
+  description: Sports line team standings resource resource cache cache buster.
+- name: sports_line_team_standings_resource_expiration_message_object_key_name
+  type: character
+  description: Sports line team standings resource expiration message object key name.
+- name: league_resource_location
+  type: character
+  description: League resource location.
+- name: league_resource_route
+  type: character
+  description: League resource route.
+- name: league_resource_path
+  type: character
+  description: League resource path.
+- name: league_resource_summary
+  type: character
+  description: League resource summary.
+- name: league_resource_notes
+  type: character
+  description: League resource notes.
+- name: league_resource_versions_allowed
+  type: character
+  description: League resource versions allowed.
+- name: league_resource_versions_current
+  type: character
+  description: League resource versions current.
+- name: league_resource_methods
+  type: character
+  description: League resource methods.
+- name: league_resource_formats
+  type: character
+  description: League resource formats.
+- name: league_resource_parameters
+  type: character
+  description: League resource parameters.
+- name: league_resource_auth_settings_require_auth
+  type: logical
+  description: League resource auth settings require auth.
+- name: league_resource_auth_settings_allow_only
+  type: character
+  description: League resource auth settings allow only.
+- name: league_resource_resource_cache_ns
+  type: character
+  description: League resource resource cache ns.
+- name: league_resource_resource_cache_cache_keys
+  type: character
+  description: League resource resource cache cache keys.
+- name: league_resource_resource_cache_cache_buster
+  type: integer
+  description: League resource resource cache cache buster.
+- name: league_resource_expiration_message_object_key_name
+  type: character
+  description: League resource expiration message object key name.
+- name: league_teams_resource_location
+  type: character
+  description: League teams resource location.
+- name: league_teams_resource_route
+  type: character
+  description: League teams resource route.
+- name: league_teams_resource_path
+  type: character
+  description: League teams resource path.
+- name: league_teams_resource_summary
+  type: character
+  description: League teams resource summary.
+- name: league_teams_resource_notes
+  type: character
+  description: League teams resource notes.
+- name: league_teams_resource_versions_allowed
+  type: character
+  description: League teams resource versions allowed.
+- name: league_teams_resource_versions_current
+  type: character
+  description: League teams resource versions current.
+- name: league_teams_resource_methods
+  type: character
+  description: League teams resource methods.
+- name: league_teams_resource_formats
+  type: character
+  description: League teams resource formats.
+- name: league_teams_resource_parameters
+  type: character
+  description: League teams resource parameters.
+- name: league_teams_resource_auth_settings_require_auth
+  type: logical
+  description: League teams resource auth settings require auth.
+- name: league_teams_resource_auth_settings_allow_only
+  type: character
+  description: League teams resource auth settings allow only.
+- name: league_teams_resource_resource_cache_ns
+  type: character
+  description: League teams resource resource cache ns.
+- name: league_teams_resource_resource_cache_cache_keys
+  type: character
+  description: League teams resource resource cache cache keys.
+- name: league_teams_resource_resource_cache_cache_buster
+  type: integer
+  description: League teams resource resource cache cache buster.
+- name: league_teams_resource_expiration_message_object_key_name
+  type: character
+  description: League teams resource expiration message object key name.
+- name: season_teams_resource_location
+  type: character
+  description: Season teams resource location.
+- name: season_teams_resource_route
+  type: character
+  description: Season teams resource route.
+- name: season_teams_resource_path
+  type: character
+  description: Season teams resource path.
+- name: season_teams_resource_summary
+  type: character
+  description: Season teams resource summary.
+- name: season_teams_resource_notes
+  type: character
+  description: Season teams resource notes.
+- name: season_teams_resource_versions_allowed
+  type: character
+  description: Season teams resource versions allowed.
+- name: season_teams_resource_versions_current
+  type: character
+  description: Season teams resource versions current.
+- name: season_teams_resource_methods
+  type: character
+  description: Season teams resource methods.
+- name: season_teams_resource_formats
+  type: character
+  description: Season teams resource formats.
+- name: season_teams_resource_parameters
+  type: character
+  description: Season teams resource parameters.
+- name: season_teams_resource_auth_settings_require_auth
+  type: logical
+  description: Season teams resource auth settings require auth.
+- name: season_teams_resource_auth_settings_allow_only
+  type: character
+  description: Season teams resource auth settings allow only.
+- name: season_teams_resource_resource_cache_ns
+  type: character
+  description: Season teams resource resource cache ns.
+- name: season_teams_resource_resource_cache_cache_keys
+  type: character
+  description: Season teams resource resource cache cache keys.
+- name: season_teams_resource_resource_cache_cache_buster
+  type: integer
+  description: Season teams resource resource cache cache buster.
+- name: season_teams_resource_expiration_message_object_key_name
+  type: character
+  description: Season teams resource expiration message object key name.
+- name: game_resource_location
+  type: character
+  description: Game resource location.
+- name: game_resource_route
+  type: character
+  description: Game resource route.
+- name: game_resource_path
+  type: character
+  description: Game resource path.
+- name: game_resource_summary
+  type: character
+  description: Game resource summary.
+- name: game_resource_notes
+  type: character
+  description: Game resource notes.
+- name: game_resource_versions_allowed
+  type: character
+  description: Game resource versions allowed.
+- name: game_resource_versions_current
+  type: character
+  description: Game resource versions current.
+- name: game_resource_methods
+  type: character
+  description: Game resource methods.
+- name: game_resource_formats
+  type: character
+  description: Game resource formats.
+- name: game_resource_parameters
+  type: character
+  description: Game resource parameters.
+- name: game_resource_auth_settings_require_auth
+  type: logical
+  description: Game resource auth settings require auth.
+- name: game_resource_auth_settings_allow_only
+  type: character
+  description: Game resource auth settings allow only.
+- name: game_resource_resource_cache_ns
+  type: character
+  description: Game resource resource cache ns.
+- name: game_resource_resource_cache_cache_keys
+  type: character
+  description: Game resource resource cache cache keys.
+- name: game_resource_resource_cache_cache_buster
+  type: integer
+  description: Game resource resource cache cache buster.
+- name: game_resource_expiration_message_object_key_name
+  type: character
+  description: Game resource expiration message object key name.
+- name: game_lineup_resource_location
+  type: character
+  description: Game lineup resource location.
+- name: game_lineup_resource_route
+  type: character
+  description: Game lineup resource route.
+- name: game_lineup_resource_path
+  type: character
+  description: Game lineup resource path.
+- name: game_lineup_resource_summary
+  type: character
+  description: Game lineup resource summary.
+- name: game_lineup_resource_notes
+  type: character
+  description: Game lineup resource notes.
+- name: game_lineup_resource_versions_allowed
+  type: character
+  description: Game lineup resource versions allowed.
+- name: game_lineup_resource_versions_current
+  type: character
+  description: Game lineup resource versions current.
+- name: game_lineup_resource_methods
+  type: character
+  description: Game lineup resource methods.
+- name: game_lineup_resource_formats
+  type: character
+  description: Game lineup resource formats.
+- name: game_lineup_resource_parameters
+  type: character
+  description: Game lineup resource parameters.
+- name: game_lineup_resource_auth_settings_require_auth
+  type: logical
+  description: Game lineup resource auth settings require auth.
+- name: game_lineup_resource_auth_settings_allow_only
+  type: character
+  description: Game lineup resource auth settings allow only.
+- name: game_lineup_resource_resource_cache_ns
+  type: character
+  description: Game lineup resource resource cache ns.
+- name: game_lineup_resource_resource_cache_cache_keys
+  type: character
+  description: Game lineup resource resource cache cache keys.
+- name: game_lineup_resource_resource_cache_cache_buster
+  type: integer
+  description: Game lineup resource resource cache cache buster.
+- name: game_lineup_resource_expiration_message_object_key_name
+  type: character
+  description: Game lineup resource expiration message object key name.
+- name: odds_resource_location
+  type: character
+  description: Odds resource location.
+- name: odds_resource_route
+  type: character
+  description: Odds resource route.
+- name: odds_resource_path
+  type: character
+  description: Odds resource path.
+- name: odds_resource_summary
+  type: character
+  description: Odds resource summary.
+- name: odds_resource_notes
+  type: character
+  description: Odds resource notes.
+- name: odds_resource_versions_allowed
+  type: character
+  description: Odds resource versions allowed.
+- name: odds_resource_versions_current
+  type: character
+  description: Odds resource versions current.
+- name: odds_resource_methods
+  type: character
+  description: Odds resource methods.
+- name: odds_resource_formats
+  type: character
+  description: Odds resource formats.
+- name: odds_resource_parameters
+  type: character
+  description: Odds resource parameters.
+- name: odds_resource_auth_settings_require_auth
+  type: logical
+  description: Odds resource auth settings require auth.
+- name: odds_resource_auth_settings_allow_only
+  type: character
+  description: Odds resource auth settings allow only.
+- name: odds_resource_resource_cache_ns
+  type: character
+  description: Odds resource resource cache ns.
+- name: odds_resource_resource_cache_cache_keys
+  type: character
+  description: Odds resource resource cache cache keys.
+- name: odds_resource_resource_cache_cache_buster
+  type: integer
+  description: Odds resource resource cache cache buster.
+- name: odds_resource_expiration_message_object_key_name
+  type: character
+  description: Odds resource expiration message object key name.
+- name: game_outcomes_resource_location
+  type: character
+  description: Game outcomes resource location.
+- name: game_outcomes_resource_route
+  type: character
+  description: Game outcomes resource route.
+- name: game_outcomes_resource_path
+  type: character
+  description: Game outcomes resource path.
+- name: game_outcomes_resource_summary
+  type: character
+  description: Game outcomes resource summary.
+- name: game_outcomes_resource_notes
+  type: character
+  description: Game outcomes resource notes.
+- name: game_outcomes_resource_versions_allowed
+  type: character
+  description: Game outcomes resource versions allowed.
+- name: game_outcomes_resource_versions_current
+  type: character
+  description: Game outcomes resource versions current.
+- name: game_outcomes_resource_methods
+  type: character
+  description: Game outcomes resource methods.
+- name: game_outcomes_resource_formats
+  type: character
+  description: Game outcomes resource formats.
+- name: game_outcomes_resource_parameters
+  type: character
+  description: Game outcomes resource parameters.
+- name: game_outcomes_resource_auth_settings_require_auth
+  type: logical
+  description: Game outcomes resource auth settings require auth.
+- name: game_outcomes_resource_auth_settings_allow_only
+  type: character
+  description: Game outcomes resource auth settings allow only.
+- name: game_outcomes_resource_resource_cache_ns
+  type: character
+  description: Game outcomes resource resource cache ns.
+- name: game_outcomes_resource_resource_cache_cache_keys
+  type: character
+  description: Game outcomes resource resource cache cache keys.
+- name: game_outcomes_resource_resource_cache_cache_buster
+  type: integer
+  description: Game outcomes resource resource cache cache buster.
+- name: game_outcomes_resource_expiration_message_object_key_name
+  type: character
+  description: Game outcomes resource expiration message object key name.
+- name: game_odds_resource_location
+  type: character
+  description: Game odds resource location.
+- name: game_odds_resource_route
+  type: character
+  description: Game odds resource route.
+- name: game_odds_resource_path
+  type: character
+  description: Game odds resource path.
+- name: game_odds_resource_summary
+  type: character
+  description: Game odds resource summary.
+- name: game_odds_resource_notes
+  type: character
+  description: Game odds resource notes.
+- name: game_odds_resource_versions_allowed
+  type: character
+  description: Game odds resource versions allowed.
+- name: game_odds_resource_versions_current
+  type: character
+  description: Game odds resource versions current.
+- name: game_odds_resource_methods
+  type: character
+  description: Game odds resource methods.
+- name: game_odds_resource_formats
+  type: character
+  description: Game odds resource formats.
+- name: game_odds_resource_parameters
+  type: character
+  description: Game odds resource parameters.
+- name: game_odds_resource_auth_settings_require_auth
+  type: logical
+  description: Game odds resource auth settings require auth.
+- name: game_odds_resource_auth_settings_allow_only
+  type: character
+  description: Game odds resource auth settings allow only.
+- name: game_odds_resource_resource_cache_ns
+  type: character
+  description: Game odds resource resource cache ns.
+- name: game_odds_resource_resource_cache_cache_keys
+  type: character
+  description: Game odds resource resource cache cache keys.
+- name: game_odds_resource_resource_cache_cache_buster
+  type: integer
+  description: Game odds resource resource cache cache buster.
+- name: game_odds_resource_expiration_message_object_key_name
+  type: character
+  description: Game odds resource expiration message object key name.
+- name: game_hq_odds_resource_location
+  type: character
+  description: Game hq odds resource location.
+- name: game_hq_odds_resource_route
+  type: character
+  description: Game hq odds resource route.
+- name: game_hq_odds_resource_path
+  type: character
+  description: Game hq odds resource path.
+- name: game_hq_odds_resource_summary
+  type: character
+  description: Game hq odds resource summary.
+- name: game_hq_odds_resource_notes
+  type: character
+  description: Game hq odds resource notes.
+- name: game_hq_odds_resource_versions_allowed
+  type: character
+  description: Game hq odds resource versions allowed.
+- name: game_hq_odds_resource_versions_current
+  type: character
+  description: Game hq odds resource versions current.
+- name: game_hq_odds_resource_methods
+  type: character
+  description: Game hq odds resource methods.
+- name: game_hq_odds_resource_formats
+  type: character
+  description: Game hq odds resource formats.
+- name: game_hq_odds_resource_parameters
+  type: character
+  description: Game hq odds resource parameters.
+- name: game_hq_odds_resource_auth_settings_require_auth
+  type: logical
+  description: Game hq odds resource auth settings require auth.
+- name: game_hq_odds_resource_auth_settings_allow_only
+  type: character
+  description: Game hq odds resource auth settings allow only.
+- name: game_hq_odds_resource_resource_cache_ns
+  type: character
+  description: Game hq odds resource resource cache ns.
+- name: game_hq_odds_resource_resource_cache_cache_keys
+  type: character
+  description: Game hq odds resource resource cache cache keys.
+- name: game_hq_odds_resource_resource_cache_cache_buster
+  type: integer
+  description: Game hq odds resource resource cache cache buster.
+- name: game_hq_odds_resource_expiration_message_object_key_name
+  type: character
+  description: Game hq odds resource expiration message object key name.
+- name: weather_resource_location
+  type: character
+  description: Weather resource location.
+- name: weather_resource_route
+  type: character
+  description: Weather resource route.
+- name: weather_resource_path
+  type: character
+  description: Weather resource path.
+- name: weather_resource_summary
+  type: character
+  description: Weather resource summary.
+- name: weather_resource_notes
+  type: character
+  description: Weather resource notes.
+- name: weather_resource_versions_allowed
+  type: character
+  description: Weather resource versions allowed.
+- name: weather_resource_versions_current
+  type: character
+  description: Weather resource versions current.
+- name: weather_resource_methods
+  type: character
+  description: Weather resource methods.
+- name: weather_resource_formats
+  type: character
+  description: Weather resource formats.
+- name: weather_resource_parameters
+  type: character
+  description: Weather resource parameters.
+- name: weather_resource_auth_settings_require_auth
+  type: logical
+  description: Weather resource auth settings require auth.
+- name: weather_resource_auth_settings_allow_only
+  type: character
+  description: Weather resource auth settings allow only.
+- name: weather_resource_resource_cache_ns
+  type: character
+  description: Weather resource resource cache ns.
+- name: weather_resource_resource_cache_cache_keys
+  type: character
+  description: Weather resource resource cache cache keys.
+- name: weather_resource_resource_cache_cache_buster
+  type: integer
+  description: Weather resource resource cache cache buster.
+- name: weather_resource_expiration_message_object_key_name
+  type: character
+  description: Weather resource expiration message object key name.
+- name: game_betting_splits_resource_location
+  type: character
+  description: Game betting splits resource location.
+- name: game_betting_splits_resource_route
+  type: character
+  description: Game betting splits resource route.
+- name: game_betting_splits_resource_path
+  type: character
+  description: Game betting splits resource path.
+- name: game_betting_splits_resource_summary
+  type: character
+  description: Game betting splits resource summary.
+- name: game_betting_splits_resource_notes
+  type: character
+  description: Game betting splits resource notes.
+- name: game_betting_splits_resource_versions_allowed
+  type: character
+  description: Game betting splits resource versions allowed.
+- name: game_betting_splits_resource_versions_current
+  type: character
+  description: Game betting splits resource versions current.
+- name: game_betting_splits_resource_methods
+  type: character
+  description: Game betting splits resource methods.
+- name: game_betting_splits_resource_formats
+  type: character
+  description: Game betting splits resource formats.
+- name: game_betting_splits_resource_parameters
+  type: character
+  description: Game betting splits resource parameters.
+- name: game_betting_splits_resource_auth_settings_require_auth
+  type: logical
+  description: Game betting splits resource auth settings require auth.
+- name: game_betting_splits_resource_auth_settings_allow_only
+  type: character
+  description: Game betting splits resource auth settings allow only.
+- name: game_betting_splits_resource_resource_cache_ns
+  type: character
+  description: Game betting splits resource resource cache ns.
+- name: game_betting_splits_resource_resource_cache_cache_keys
+  type: character
+  description: Game betting splits resource resource cache cache keys.
+- name: game_betting_splits_resource_resource_cache_cache_buster
+  type: integer
+  description: Game betting splits resource resource cache cache buster.
+- name: game_betting_splits_resource_expiration_message_object_key_name
+  type: character
+  description: Game betting splits resource expiration message object key name.
+- name: featured_game_resource_location
+  type: character
+  description: Featured game resource location.
+- name: featured_game_resource_route
+  type: character
+  description: Featured game resource route.
+- name: featured_game_resource_path
+  type: character
+  description: Featured game resource path.
+- name: featured_game_resource_summary
+  type: character
+  description: Featured game resource summary.
+- name: featured_game_resource_notes
+  type: character
+  description: Featured game resource notes.
+- name: featured_game_resource_versions_allowed
+  type: character
+  description: Featured game resource versions allowed.
+- name: featured_game_resource_versions_current
+  type: character
+  description: Featured game resource versions current.
+- name: featured_game_resource_methods
+  type: character
+  description: Featured game resource methods.
+- name: featured_game_resource_formats
+  type: character
+  description: Featured game resource formats.
+- name: featured_game_resource_parameters
+  type: character
+  description: Featured game resource parameters.
+- name: featured_game_resource_auth_settings_require_auth
+  type: logical
+  description: Featured game resource auth settings require auth.
+- name: featured_game_resource_auth_settings_allow_only
+  type: character
+  description: Featured game resource auth settings allow only.
+- name: featured_game_resource_resource_cache_ns
+  type: character
+  description: Featured game resource resource cache ns.
+- name: featured_game_resource_resource_cache_cache_keys
+  type: character
+  description: Featured game resource resource cache cache keys.
+- name: featured_game_resource_resource_cache_cache_buster
+  type: integer
+  description: Featured game resource resource cache cache buster.
+- name: featured_game_resource_expiration_message_object_key_name
+  type: character
+  description: Featured game resource expiration message object key name.
+- name: game_scoring_leaders_resource_location
+  type: character
+  description: Game scoring leaders resource location.
+- name: game_scoring_leaders_resource_route
+  type: character
+  description: Game scoring leaders resource route.
+- name: game_scoring_leaders_resource_path
+  type: character
+  description: Game scoring leaders resource path.
+- name: game_scoring_leaders_resource_summary
+  type: character
+  description: Game scoring leaders resource summary.
+- name: game_scoring_leaders_resource_notes
+  type: character
+  description: Game scoring leaders resource notes.
+- name: game_scoring_leaders_resource_versions_allowed
+  type: character
+  description: Game scoring leaders resource versions allowed.
+- name: game_scoring_leaders_resource_versions_current
+  type: character
+  description: Game scoring leaders resource versions current.
+- name: game_scoring_leaders_resource_methods
+  type: character
+  description: Game scoring leaders resource methods.
+- name: game_scoring_leaders_resource_formats
+  type: character
+  description: Game scoring leaders resource formats.
+- name: game_scoring_leaders_resource_parameters
+  type: character
+  description: Game scoring leaders resource parameters.
+- name: game_scoring_leaders_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring leaders resource auth settings require auth.
+- name: game_scoring_leaders_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring leaders resource auth settings allow only.
+- name: game_scoring_leaders_resource_resource_cache_ns
+  type: character
+  description: Game scoring leaders resource resource cache ns.
+- name: game_scoring_leaders_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring leaders resource resource cache cache keys.
+- name: game_scoring_leaders_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring leaders resource resource cache cache buster.
+- name: game_scoring_leaders_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring leaders resource expiration message object key name.
+- name: game_scoring_player_stats_resource_location
+  type: character
+  description: Game scoring player stats resource location.
+- name: game_scoring_player_stats_resource_route
+  type: character
+  description: Game scoring player stats resource route.
+- name: game_scoring_player_stats_resource_path
+  type: character
+  description: Game scoring player stats resource path.
+- name: game_scoring_player_stats_resource_summary
+  type: character
+  description: Game scoring player stats resource summary.
+- name: game_scoring_player_stats_resource_notes
+  type: character
+  description: Game scoring player stats resource notes.
+- name: game_scoring_player_stats_resource_versions_allowed
+  type: character
+  description: Game scoring player stats resource versions allowed.
+- name: game_scoring_player_stats_resource_versions_current
+  type: character
+  description: Game scoring player stats resource versions current.
+- name: game_scoring_player_stats_resource_methods
+  type: character
+  description: Game scoring player stats resource methods.
+- name: game_scoring_player_stats_resource_formats
+  type: character
+  description: Game scoring player stats resource formats.
+- name: game_scoring_player_stats_resource_parameters
+  type: character
+  description: Game scoring player stats resource parameters.
+- name: game_scoring_player_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring player stats resource auth settings require auth.
+- name: game_scoring_player_stats_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring player stats resource auth settings allow only.
+- name: game_scoring_player_stats_resource_resource_cache_ns
+  type: character
+  description: Game scoring player stats resource resource cache ns.
+- name: game_scoring_player_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring player stats resource resource cache cache keys.
+- name: game_scoring_player_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring player stats resource resource cache cache buster.
+- name: game_scoring_player_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring player stats resource expiration message object key name.
+- name: game_scoring_scoreboard_resource_location
+  type: character
+  description: Game scoring scoreboard resource location.
+- name: game_scoring_scoreboard_resource_route
+  type: character
+  description: Game scoring scoreboard resource route.
+- name: game_scoring_scoreboard_resource_path
+  type: character
+  description: Game scoring scoreboard resource path.
+- name: game_scoring_scoreboard_resource_summary
+  type: character
+  description: Game scoring scoreboard resource summary.
+- name: game_scoring_scoreboard_resource_notes
+  type: character
+  description: Game scoring scoreboard resource notes.
+- name: game_scoring_scoreboard_resource_versions_allowed
+  type: character
+  description: Game scoring scoreboard resource versions allowed.
+- name: game_scoring_scoreboard_resource_versions_current
+  type: character
+  description: Game scoring scoreboard resource versions current.
+- name: game_scoring_scoreboard_resource_methods
+  type: character
+  description: Game scoring scoreboard resource methods.
+- name: game_scoring_scoreboard_resource_formats
+  type: character
+  description: Game scoring scoreboard resource formats.
+- name: game_scoring_scoreboard_resource_parameters
+  type: character
+  description: Game scoring scoreboard resource parameters.
+- name: game_scoring_scoreboard_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring scoreboard resource auth settings require auth.
+- name: game_scoring_scoreboard_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring scoreboard resource auth settings allow only.
+- name: game_scoring_scoreboard_resource_resource_cache_ns
+  type: character
+  description: Game scoring scoreboard resource resource cache ns.
+- name: game_scoring_scoreboard_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring scoreboard resource resource cache cache keys.
+- name: game_scoring_scoreboard_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring scoreboard resource resource cache cache buster.
+- name: game_scoring_scoreboard_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring scoreboard resource expiration message object key name.
+- name: game_scoring_scores_resource_location
+  type: character
+  description: Game scoring scores resource location.
+- name: game_scoring_scores_resource_route
+  type: character
+  description: Game scoring scores resource route.
+- name: game_scoring_scores_resource_path
+  type: character
+  description: Game scoring scores resource path.
+- name: game_scoring_scores_resource_summary
+  type: character
+  description: Game scoring scores resource summary.
+- name: game_scoring_scores_resource_notes
+  type: character
+  description: Game scoring scores resource notes.
+- name: game_scoring_scores_resource_versions_allowed
+  type: character
+  description: Game scoring scores resource versions allowed.
+- name: game_scoring_scores_resource_versions_current
+  type: character
+  description: Game scoring scores resource versions current.
+- name: game_scoring_scores_resource_methods
+  type: character
+  description: Game scoring scores resource methods.
+- name: game_scoring_scores_resource_formats
+  type: character
+  description: Game scoring scores resource formats.
+- name: game_scoring_scores_resource_parameters
+  type: character
+  description: Game scoring scores resource parameters.
+- name: game_scoring_scores_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring scores resource auth settings require auth.
+- name: game_scoring_scores_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring scores resource auth settings allow only.
+- name: game_scoring_scores_resource_resource_cache_ns
+  type: character
+  description: Game scoring scores resource resource cache ns.
+- name: game_scoring_scores_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring scores resource resource cache cache keys.
+- name: game_scoring_scores_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring scores resource resource cache cache buster.
+- name: game_scoring_scores_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring scores resource expiration message object key name.
+- name: game_scoring_ytd_player_stats_resource_location
+  type: character
+  description: Game scoring year-to-date player stats resource location.
+- name: game_scoring_ytd_player_stats_resource_route
+  type: character
+  description: Game scoring year-to-date player stats resource route.
+- name: game_scoring_ytd_player_stats_resource_path
+  type: character
+  description: Game scoring year-to-date player stats resource path.
+- name: game_scoring_ytd_player_stats_resource_summary
+  type: character
+  description: Game scoring year-to-date player stats resource summary.
+- name: game_scoring_ytd_player_stats_resource_notes
+  type: character
+  description: Game scoring year-to-date player stats resource notes.
+- name: game_scoring_ytd_player_stats_resource_versions_allowed
+  type: character
+  description: Game scoring year-to-date player stats resource versions allowed.
+- name: game_scoring_ytd_player_stats_resource_versions_current
+  type: character
+  description: Game scoring year-to-date player stats resource versions current.
+- name: game_scoring_ytd_player_stats_resource_methods
+  type: character
+  description: Game scoring year-to-date player stats resource methods.
+- name: game_scoring_ytd_player_stats_resource_formats
+  type: character
+  description: Game scoring year-to-date player stats resource formats.
+- name: game_scoring_ytd_player_stats_resource_parameters
+  type: character
+  description: Game scoring year-to-date player stats resource parameters.
+- name: game_scoring_ytd_player_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring year-to-date player stats resource auth settings require auth.
+- name: game_scoring_ytd_player_stats_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring year-to-date player stats resource auth settings allow only.
+- name: game_scoring_ytd_player_stats_resource_resource_cache_ns
+  type: character
+  description: Game scoring year-to-date player stats resource resource cache ns.
+- name: game_scoring_ytd_player_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring year-to-date player stats resource resource cache cache keys.
+- name: game_scoring_ytd_player_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring year-to-date player stats resource resource cache cache buster.
+- name: game_scoring_ytd_player_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring year-to-date player stats resource expiration message object key name.
+- name: game_scoring_plays_resource_location
+  type: character
+  description: Game scoring plays resource location.
+- name: game_scoring_plays_resource_route
+  type: character
+  description: Game scoring plays resource route.
+- name: game_scoring_plays_resource_path
+  type: character
+  description: Game scoring plays resource path.
+- name: game_scoring_plays_resource_summary
+  type: character
+  description: Game scoring plays resource summary.
+- name: game_scoring_plays_resource_notes
+  type: character
+  description: Game scoring plays resource notes.
+- name: game_scoring_plays_resource_versions_allowed
+  type: character
+  description: Game scoring plays resource versions allowed.
+- name: game_scoring_plays_resource_versions_current
+  type: character
+  description: Game scoring plays resource versions current.
+- name: game_scoring_plays_resource_methods
+  type: character
+  description: Game scoring plays resource methods.
+- name: game_scoring_plays_resource_formats
+  type: character
+  description: Game scoring plays resource formats.
+- name: game_scoring_plays_resource_parameters
+  type: character
+  description: Game scoring plays resource parameters.
+- name: game_scoring_plays_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring plays resource auth settings require auth.
+- name: game_scoring_plays_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring plays resource auth settings allow only.
+- name: game_scoring_plays_resource_resource_cache_ns
+  type: character
+  description: Game scoring plays resource resource cache ns.
+- name: game_scoring_plays_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring plays resource resource cache cache keys.
+- name: game_scoring_plays_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring plays resource resource cache cache buster.
+- name: game_scoring_plays_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring plays resource expiration message object key name.
+- name: game_scoring_drives_resource_location
+  type: character
+  description: Game scoring drives resource location.
+- name: game_scoring_drives_resource_route
+  type: character
+  description: Game scoring drives resource route.
+- name: game_scoring_drives_resource_path
+  type: character
+  description: Game scoring drives resource path.
+- name: game_scoring_drives_resource_summary
+  type: character
+  description: Game scoring drives resource summary.
+- name: game_scoring_drives_resource_notes
+  type: character
+  description: Game scoring drives resource notes.
+- name: game_scoring_drives_resource_versions_allowed
+  type: character
+  description: Game scoring drives resource versions allowed.
+- name: game_scoring_drives_resource_versions_current
+  type: character
+  description: Game scoring drives resource versions current.
+- name: game_scoring_drives_resource_methods
+  type: character
+  description: Game scoring drives resource methods.
+- name: game_scoring_drives_resource_formats
+  type: character
+  description: Game scoring drives resource formats.
+- name: game_scoring_drives_resource_parameters
+  type: character
+  description: Game scoring drives resource parameters.
+- name: game_scoring_drives_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring drives resource auth settings require auth.
+- name: game_scoring_drives_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring drives resource auth settings allow only.
+- name: game_scoring_drives_resource_resource_cache_ns
+  type: character
+  description: Game scoring drives resource resource cache ns.
+- name: game_scoring_drives_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring drives resource resource cache cache keys.
+- name: game_scoring_drives_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring drives resource resource cache cache buster.
+- name: game_scoring_drives_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring drives resource expiration message object key name.
+- name: game_scoring_rosters_resource_location
+  type: character
+  description: Game scoring rosters resource location.
+- name: game_scoring_rosters_resource_route
+  type: character
+  description: Game scoring rosters resource route.
+- name: game_scoring_rosters_resource_path
+  type: character
+  description: Game scoring rosters resource path.
+- name: game_scoring_rosters_resource_summary
+  type: character
+  description: Game scoring rosters resource summary.
+- name: game_scoring_rosters_resource_notes
+  type: character
+  description: Game scoring rosters resource notes.
+- name: game_scoring_rosters_resource_versions_allowed
+  type: character
+  description: Game scoring rosters resource versions allowed.
+- name: game_scoring_rosters_resource_versions_current
+  type: character
+  description: Game scoring rosters resource versions current.
+- name: game_scoring_rosters_resource_methods
+  type: character
+  description: Game scoring rosters resource methods.
+- name: game_scoring_rosters_resource_formats
+  type: character
+  description: Game scoring rosters resource formats.
+- name: game_scoring_rosters_resource_parameters
+  type: character
+  description: Game scoring rosters resource parameters.
+- name: game_scoring_rosters_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring rosters resource auth settings require auth.
+- name: game_scoring_rosters_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring rosters resource auth settings allow only.
+- name: game_scoring_rosters_resource_resource_cache_ns
+  type: character
+  description: Game scoring rosters resource resource cache ns.
+- name: game_scoring_rosters_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring rosters resource resource cache cache keys.
+- name: game_scoring_rosters_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring rosters resource resource cache cache buster.
+- name: game_scoring_rosters_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring rosters resource expiration message object key name.
+- name: recruit_rankings_resource_location
+  type: character
+  description: Recruit rankings resource location.
+- name: recruit_rankings_resource_route
+  type: character
+  description: Recruit rankings resource route.
+- name: recruit_rankings_resource_path
+  type: character
+  description: Recruit rankings resource path.
+- name: recruit_rankings_resource_summary
+  type: character
+  description: Recruit rankings resource summary.
+- name: recruit_rankings_resource_notes
+  type: character
+  description: Recruit rankings resource notes.
+- name: recruit_rankings_resource_versions_allowed
+  type: character
+  description: Recruit rankings resource versions allowed.
+- name: recruit_rankings_resource_versions_current
+  type: character
+  description: Recruit rankings resource versions current.
+- name: recruit_rankings_resource_methods
+  type: character
+  description: Recruit rankings resource methods.
+- name: recruit_rankings_resource_formats
+  type: character
+  description: Recruit rankings resource formats.
+- name: recruit_rankings_resource_parameters
+  type: character
+  description: Recruit rankings resource parameters.
+- name: recruit_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Recruit rankings resource auth settings require auth.
+- name: recruit_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Recruit rankings resource auth settings allow only.
+- name: recruit_rankings_resource_resource_cache_ns
+  type: character
+  description: Recruit rankings resource resource cache ns.
+- name: recruit_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Recruit rankings resource resource cache cache keys.
+- name: recruit_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Recruit rankings resource resource cache cache buster.
+- name: recruit_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Recruit rankings resource expiration message object key name.
+- name: coach_rankings_resource_location
+  type: character
+  description: Coach rankings resource location.
+- name: coach_rankings_resource_route
+  type: character
+  description: Coach rankings resource route.
+- name: coach_rankings_resource_path
+  type: character
+  description: Coach rankings resource path.
+- name: coach_rankings_resource_summary
+  type: character
+  description: Coach rankings resource summary.
+- name: coach_rankings_resource_notes
+  type: character
+  description: Coach rankings resource notes.
+- name: coach_rankings_resource_versions_allowed
+  type: character
+  description: Coach rankings resource versions allowed.
+- name: coach_rankings_resource_versions_current
+  type: character
+  description: Coach rankings resource versions current.
+- name: coach_rankings_resource_methods
+  type: character
+  description: Coach rankings resource methods.
+- name: coach_rankings_resource_formats
+  type: character
+  description: Coach rankings resource formats.
+- name: coach_rankings_resource_parameters
+  type: character
+  description: Coach rankings resource parameters.
+- name: coach_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Coach rankings resource auth settings require auth.
+- name: coach_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Coach rankings resource auth settings allow only.
+- name: coach_rankings_resource_resource_cache_ns
+  type: character
+  description: Coach rankings resource resource cache ns.
+- name: coach_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Coach rankings resource resource cache cache keys.
+- name: coach_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Coach rankings resource resource cache cache buster.
+- name: coach_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Coach rankings resource expiration message object key name.
+- name: player_golf_metadata_resource_location
+  type: character
+  description: Player golf metadata resource location.
+- name: player_golf_metadata_resource_route
+  type: character
+  description: Player golf metadata resource route.
+- name: player_golf_metadata_resource_path
+  type: character
+  description: Player golf metadata resource path.
+- name: player_golf_metadata_resource_summary
+  type: character
+  description: Player golf metadata resource summary.
+- name: player_golf_metadata_resource_notes
+  type: character
+  description: Player golf metadata resource notes.
+- name: player_golf_metadata_resource_versions_allowed
+  type: character
+  description: Player golf metadata resource versions allowed.
+- name: player_golf_metadata_resource_versions_current
+  type: character
+  description: Player golf metadata resource versions current.
+- name: player_golf_metadata_resource_methods
+  type: character
+  description: Player golf metadata resource methods.
+- name: player_golf_metadata_resource_formats
+  type: character
+  description: Player golf metadata resource formats.
+- name: player_golf_metadata_resource_parameters
+  type: character
+  description: Player golf metadata resource parameters.
+- name: player_golf_metadata_resource_auth_settings_require_auth
+  type: logical
+  description: Player golf metadata resource auth settings require auth.
+- name: player_golf_metadata_resource_auth_settings_allow_only
+  type: character
+  description: Player golf metadata resource auth settings allow only.
+- name: player_golf_metadata_resource_resource_cache_ns
+  type: character
+  description: Player golf metadata resource resource cache ns.
+- name: player_golf_metadata_resource_resource_cache_cache_keys
+  type: character
+  description: Player golf metadata resource resource cache cache keys.
+- name: player_golf_metadata_resource_resource_cache_cache_buster
+  type: integer
+  description: Player golf metadata resource resource cache cache buster.
+- name: player_golf_metadata_resource_expiration_message_object_key_name
+  type: character
+  description: Player golf metadata resource expiration message object key name.
+- name: game_scoring_ytd_team_stats_resource_location
+  type: character
+  description: Game scoring year-to-date team stats resource location.
+- name: game_scoring_ytd_team_stats_resource_route
+  type: character
+  description: Game scoring year-to-date team stats resource route.
+- name: game_scoring_ytd_team_stats_resource_path
+  type: character
+  description: Game scoring year-to-date team stats resource path.
+- name: game_scoring_ytd_team_stats_resource_summary
+  type: character
+  description: Game scoring year-to-date team stats resource summary.
+- name: game_scoring_ytd_team_stats_resource_notes
+  type: character
+  description: Game scoring year-to-date team stats resource notes.
+- name: game_scoring_ytd_team_stats_resource_versions_allowed
+  type: character
+  description: Game scoring year-to-date team stats resource versions allowed.
+- name: game_scoring_ytd_team_stats_resource_versions_current
+  type: character
+  description: Game scoring year-to-date team stats resource versions current.
+- name: game_scoring_ytd_team_stats_resource_methods
+  type: character
+  description: Game scoring year-to-date team stats resource methods.
+- name: game_scoring_ytd_team_stats_resource_formats
+  type: character
+  description: Game scoring year-to-date team stats resource formats.
+- name: game_scoring_ytd_team_stats_resource_parameters
+  type: character
+  description: Game scoring year-to-date team stats resource parameters.
+- name: game_scoring_ytd_team_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring year-to-date team stats resource auth settings require auth.
+- name: game_scoring_ytd_team_stats_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring year-to-date team stats resource auth settings allow only.
+- name: game_scoring_ytd_team_stats_resource_resource_cache_ns
+  type: character
+  description: Game scoring year-to-date team stats resource resource cache ns.
+- name: game_scoring_ytd_team_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring year-to-date team stats resource resource cache cache keys.
+- name: game_scoring_ytd_team_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring year-to-date team stats resource resource cache cache buster.
+- name: game_scoring_ytd_team_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring year-to-date team stats resource expiration message object key name.
+- name: game_scoring_team_stats_resource_location
+  type: character
+  description: Game scoring team stats resource location.
+- name: game_scoring_team_stats_resource_route
+  type: character
+  description: Game scoring team stats resource route.
+- name: game_scoring_team_stats_resource_path
+  type: character
+  description: Game scoring team stats resource path.
+- name: game_scoring_team_stats_resource_summary
+  type: character
+  description: Game scoring team stats resource summary.
+- name: game_scoring_team_stats_resource_notes
+  type: character
+  description: Game scoring team stats resource notes.
+- name: game_scoring_team_stats_resource_versions_allowed
+  type: character
+  description: Game scoring team stats resource versions allowed.
+- name: game_scoring_team_stats_resource_versions_current
+  type: character
+  description: Game scoring team stats resource versions current.
+- name: game_scoring_team_stats_resource_methods
+  type: character
+  description: Game scoring team stats resource methods.
+- name: game_scoring_team_stats_resource_formats
+  type: character
+  description: Game scoring team stats resource formats.
+- name: game_scoring_team_stats_resource_parameters
+  type: character
+  description: Game scoring team stats resource parameters.
+- name: game_scoring_team_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring team stats resource auth settings require auth.
+- name: game_scoring_team_stats_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring team stats resource auth settings allow only.
+- name: game_scoring_team_stats_resource_resource_cache_ns
+  type: character
+  description: Game scoring team stats resource resource cache ns.
+- name: game_scoring_team_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring team stats resource resource cache cache keys.
+- name: game_scoring_team_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring team stats resource resource cache cache buster.
+- name: game_scoring_team_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring team stats resource expiration message object key name.
+- name: game_scoring_winprob_resource_location
+  type: character
+  description: Game scoring winprob resource location.
+- name: game_scoring_winprob_resource_route
+  type: character
+  description: Game scoring winprob resource route.
+- name: game_scoring_winprob_resource_path
+  type: character
+  description: Game scoring winprob resource path.
+- name: game_scoring_winprob_resource_summary
+  type: character
+  description: Game scoring winprob resource summary.
+- name: game_scoring_winprob_resource_notes
+  type: character
+  description: Game scoring winprob resource notes.
+- name: game_scoring_winprob_resource_versions_allowed
+  type: character
+  description: Game scoring winprob resource versions allowed.
+- name: game_scoring_winprob_resource_versions_current
+  type: character
+  description: Game scoring winprob resource versions current.
+- name: game_scoring_winprob_resource_methods
+  type: character
+  description: Game scoring winprob resource methods.
+- name: game_scoring_winprob_resource_formats
+  type: character
+  description: Game scoring winprob resource formats.
+- name: game_scoring_winprob_resource_parameters
+  type: character
+  description: Game scoring winprob resource parameters.
+- name: game_scoring_winprob_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring winprob resource auth settings require auth.
+- name: game_scoring_winprob_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring winprob resource auth settings allow only.
+- name: game_scoring_winprob_resource_resource_cache_ns
+  type: character
+  description: Game scoring winprob resource resource cache ns.
+- name: game_scoring_winprob_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring winprob resource resource cache cache keys.
+- name: game_scoring_winprob_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring winprob resource resource cache cache buster.
+- name: game_scoring_winprob_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring winprob resource expiration message object key name.
+- name: game_rtwp_resource_location
+  type: character
+  description: Game real-time win probability resource location.
+- name: game_rtwp_resource_route
+  type: character
+  description: Game real-time win probability resource route.
+- name: game_rtwp_resource_path
+  type: character
+  description: Game real-time win probability resource path.
+- name: game_rtwp_resource_summary
+  type: character
+  description: Game real-time win probability resource summary.
+- name: game_rtwp_resource_notes
+  type: character
+  description: Game real-time win probability resource notes.
+- name: game_rtwp_resource_versions_allowed
+  type: character
+  description: Game real-time win probability resource versions allowed.
+- name: game_rtwp_resource_versions_current
+  type: character
+  description: Game real-time win probability resource versions current.
+- name: game_rtwp_resource_methods
+  type: character
+  description: Game real-time win probability resource methods.
+- name: game_rtwp_resource_formats
+  type: character
+  description: Game real-time win probability resource formats.
+- name: game_rtwp_resource_parameters
+  type: character
+  description: Game real-time win probability resource parameters.
+- name: game_rtwp_resource_auth_settings_require_auth
+  type: logical
+  description: Game real-time win probability resource auth settings require auth.
+- name: game_rtwp_resource_auth_settings_allow_only
+  type: character
+  description: Game real-time win probability resource auth settings allow only.
+- name: game_rtwp_resource_resource_cache_ns
+  type: character
+  description: Game real-time win probability resource resource cache ns.
+- name: game_rtwp_resource_resource_cache_cache_keys
+  type: character
+  description: Game real-time win probability resource resource cache cache keys.
+- name: game_rtwp_resource_resource_cache_cache_buster
+  type: integer
+  description: Game real-time win probability resource resource cache cache buster.
+- name: game_rtwp_resource_expiration_message_object_key_name
+  type: character
+  description: Game real-time win probability resource expiration message object key name.
+- name: game_ticket_resource_location
+  type: character
+  description: Game ticket resource location.
+- name: game_ticket_resource_route
+  type: character
+  description: Game ticket resource route.
+- name: game_ticket_resource_path
+  type: character
+  description: Game ticket resource path.
+- name: game_ticket_resource_summary
+  type: character
+  description: Game ticket resource summary.
+- name: game_ticket_resource_notes
+  type: character
+  description: Game ticket resource notes.
+- name: game_ticket_resource_versions_allowed
+  type: character
+  description: Game ticket resource versions allowed.
+- name: game_ticket_resource_versions_current
+  type: character
+  description: Game ticket resource versions current.
+- name: game_ticket_resource_methods
+  type: character
+  description: Game ticket resource methods.
+- name: game_ticket_resource_formats
+  type: character
+  description: Game ticket resource formats.
+- name: game_ticket_resource_parameters
+  type: character
+  description: Game ticket resource parameters.
+- name: game_ticket_resource_auth_settings_require_auth
+  type: logical
+  description: Game ticket resource auth settings require auth.
+- name: game_ticket_resource_auth_settings_allow_only
+  type: character
+  description: Game ticket resource auth settings allow only.
+- name: game_ticket_resource_resource_cache_ns
+  type: character
+  description: Game ticket resource resource cache ns.
+- name: game_ticket_resource_resource_cache_cache_keys
+  type: character
+  description: Game ticket resource resource cache cache keys.
+- name: game_ticket_resource_resource_cache_cache_buster
+  type: integer
+  description: Game ticket resource resource cache cache buster.
+- name: game_ticket_resource_expiration_message_object_key_name
+  type: character
+  description: Game ticket resource expiration message object key name.
+- name: game_content_preview_resource_location
+  type: character
+  description: Game content preview resource location.
+- name: game_content_preview_resource_route
+  type: character
+  description: Game content preview resource route.
+- name: game_content_preview_resource_path
+  type: character
+  description: Game content preview resource path.
+- name: game_content_preview_resource_summary
+  type: character
+  description: Game content preview resource summary.
+- name: game_content_preview_resource_notes
+  type: character
+  description: Game content preview resource notes.
+- name: game_content_preview_resource_versions_allowed
+  type: character
+  description: Game content preview resource versions allowed.
+- name: game_content_preview_resource_versions_current
+  type: character
+  description: Game content preview resource versions current.
+- name: game_content_preview_resource_methods
+  type: character
+  description: Game content preview resource methods.
+- name: game_content_preview_resource_formats
+  type: character
+  description: Game content preview resource formats.
+- name: game_content_preview_resource_parameters
+  type: character
+  description: Game content preview resource parameters.
+- name: game_content_preview_resource_auth_settings_require_auth
+  type: logical
+  description: Game content preview resource auth settings require auth.
+- name: game_content_preview_resource_auth_settings_allow_only
+  type: character
+  description: Game content preview resource auth settings allow only.
+- name: game_content_preview_resource_resource_cache_ns
+  type: character
+  description: Game content preview resource resource cache ns.
+- name: game_content_preview_resource_resource_cache_cache_keys
+  type: character
+  description: Game content preview resource resource cache cache keys.
+- name: game_content_preview_resource_resource_cache_cache_buster
+  type: integer
+  description: Game content preview resource resource cache cache buster.
+- name: game_content_preview_resource_expiration_message_object_key_name
+  type: character
+  description: Game content preview resource expiration message object key name.
+- name: game_content_recap_resource_location
+  type: character
+  description: Game content recap resource location.
+- name: game_content_recap_resource_route
+  type: character
+  description: Game content recap resource route.
+- name: game_content_recap_resource_path
+  type: character
+  description: Game content recap resource path.
+- name: game_content_recap_resource_summary
+  type: character
+  description: Game content recap resource summary.
+- name: game_content_recap_resource_notes
+  type: character
+  description: Game content recap resource notes.
+- name: game_content_recap_resource_versions_allowed
+  type: character
+  description: Game content recap resource versions allowed.
+- name: game_content_recap_resource_versions_current
+  type: character
+  description: Game content recap resource versions current.
+- name: game_content_recap_resource_methods
+  type: character
+  description: Game content recap resource methods.
+- name: game_content_recap_resource_formats
+  type: character
+  description: Game content recap resource formats.
+- name: game_content_recap_resource_parameters
+  type: character
+  description: Game content recap resource parameters.
+- name: game_content_recap_resource_auth_settings_require_auth
+  type: logical
+  description: Game content recap resource auth settings require auth.
+- name: game_content_recap_resource_auth_settings_allow_only
+  type: character
+  description: Game content recap resource auth settings allow only.
+- name: game_content_recap_resource_resource_cache_ns
+  type: character
+  description: Game content recap resource resource cache ns.
+- name: game_content_recap_resource_resource_cache_cache_keys
+  type: character
+  description: Game content recap resource resource cache cache keys.
+- name: game_content_recap_resource_resource_cache_cache_buster
+  type: integer
+  description: Game content recap resource resource cache cache buster.
+- name: game_content_recap_resource_expiration_message_object_key_name
+  type: character
+  description: Game content recap resource expiration message object key name.
+- name: game_content_story_resource_location
+  type: character
+  description: Game content story resource location.
+- name: game_content_story_resource_route
+  type: character
+  description: Game content story resource route.
+- name: game_content_story_resource_path
+  type: character
+  description: Game content story resource path.
+- name: game_content_story_resource_summary
+  type: character
+  description: Game content story resource summary.
+- name: game_content_story_resource_notes
+  type: character
+  description: Game content story resource notes.
+- name: game_content_story_resource_versions_allowed
+  type: character
+  description: Game content story resource versions allowed.
+- name: game_content_story_resource_versions_current
+  type: character
+  description: Game content story resource versions current.
+- name: game_content_story_resource_methods
+  type: character
+  description: Game content story resource methods.
+- name: game_content_story_resource_formats
+  type: character
+  description: Game content story resource formats.
+- name: game_content_story_resource_parameters
+  type: character
+  description: Game content story resource parameters.
+- name: game_content_story_resource_auth_settings_require_auth
+  type: logical
+  description: Game content story resource auth settings require auth.
+- name: game_content_story_resource_auth_settings_allow_only
+  type: character
+  description: Game content story resource auth settings allow only.
+- name: game_content_story_resource_resource_cache_ns
+  type: character
+  description: Game content story resource resource cache ns.
+- name: game_content_story_resource_resource_cache_cache_keys
+  type: character
+  description: Game content story resource resource cache cache keys.
+- name: game_content_story_resource_resource_cache_cache_buster
+  type: integer
+  description: Game content story resource resource cache cache buster.
+- name: game_content_story_resource_expiration_message_object_key_name
+  type: character
+  description: Game content story resource expiration message object key name.
+- name: game_scoring_boxscores_resource_location
+  type: character
+  description: Game scoring boxscores resource location.
+- name: game_scoring_boxscores_resource_route
+  type: character
+  description: Game scoring boxscores resource route.
+- name: game_scoring_boxscores_resource_path
+  type: character
+  description: Game scoring boxscores resource path.
+- name: game_scoring_boxscores_resource_summary
+  type: character
+  description: Game scoring boxscores resource summary.
+- name: game_scoring_boxscores_resource_notes
+  type: character
+  description: Game scoring boxscores resource notes.
+- name: game_scoring_boxscores_resource_versions_allowed
+  type: character
+  description: Game scoring boxscores resource versions allowed.
+- name: game_scoring_boxscores_resource_versions_current
+  type: character
+  description: Game scoring boxscores resource versions current.
+- name: game_scoring_boxscores_resource_methods
+  type: character
+  description: Game scoring boxscores resource methods.
+- name: game_scoring_boxscores_resource_formats
+  type: character
+  description: Game scoring boxscores resource formats.
+- name: game_scoring_boxscores_resource_parameters
+  type: character
+  description: Game scoring boxscores resource parameters.
+- name: game_scoring_boxscores_resource_auth_settings_require_auth
+  type: logical
+  description: Game scoring boxscores resource auth settings require auth.
+- name: game_scoring_boxscores_resource_auth_settings_allow_only
+  type: character
+  description: Game scoring boxscores resource auth settings allow only.
+- name: game_scoring_boxscores_resource_resource_cache_ns
+  type: character
+  description: Game scoring boxscores resource resource cache ns.
+- name: game_scoring_boxscores_resource_resource_cache_cache_keys
+  type: character
+  description: Game scoring boxscores resource resource cache cache keys.
+- name: game_scoring_boxscores_resource_resource_cache_cache_buster
+  type: integer
+  description: Game scoring boxscores resource resource cache cache buster.
+- name: game_scoring_boxscores_resource_expiration_message_object_key_name
+  type: character
+  description: Game scoring boxscores resource expiration message object key name.
+- name: event_leaderboard_resource_location
+  type: character
+  description: Event leaderboard resource location.
+- name: event_leaderboard_resource_route
+  type: character
+  description: Event leaderboard resource route.
+- name: event_leaderboard_resource_path
+  type: character
+  description: Event leaderboard resource path.
+- name: event_leaderboard_resource_summary
+  type: character
+  description: Event leaderboard resource summary.
+- name: event_leaderboard_resource_notes
+  type: character
+  description: Event leaderboard resource notes.
+- name: event_leaderboard_resource_versions_allowed
+  type: character
+  description: Event leaderboard resource versions allowed.
+- name: event_leaderboard_resource_versions_current
+  type: character
+  description: Event leaderboard resource versions current.
+- name: event_leaderboard_resource_methods
+  type: character
+  description: Event leaderboard resource methods.
+- name: event_leaderboard_resource_formats
+  type: character
+  description: Event leaderboard resource formats.
+- name: event_leaderboard_resource_parameters
+  type: character
+  description: Event leaderboard resource parameters.
+- name: event_leaderboard_resource_auth_settings_require_auth
+  type: logical
+  description: Event leaderboard resource auth settings require auth.
+- name: event_leaderboard_resource_auth_settings_allow_only
+  type: character
+  description: Event leaderboard resource auth settings allow only.
+- name: event_leaderboard_resource_resource_cache_ns
+  type: character
+  description: Event leaderboard resource resource cache ns.
+- name: event_leaderboard_resource_resource_cache_cache_keys
+  type: character
+  description: Event leaderboard resource resource cache cache keys.
+- name: event_leaderboard_resource_resource_cache_cache_buster
+  type: integer
+  description: Event leaderboard resource resource cache cache buster.
+- name: event_leaderboard_resource_expiration_message_object_key_name
+  type: character
+  description: Event leaderboard resource expiration message object key name.
+- name: probable_players_resource_location
+  type: character
+  description: Probable players resource location.
+- name: probable_players_resource_route
+  type: character
+  description: Probable players resource route.
+- name: probable_players_resource_path
+  type: character
+  description: Probable players resource path.
+- name: probable_players_resource_summary
+  type: character
+  description: Probable players resource summary.
+- name: probable_players_resource_notes
+  type: character
+  description: Probable players resource notes.
+- name: probable_players_resource_versions_allowed
+  type: character
+  description: Probable players resource versions allowed.
+- name: probable_players_resource_versions_current
+  type: character
+  description: Probable players resource versions current.
+- name: probable_players_resource_methods
+  type: character
+  description: Probable players resource methods.
+- name: probable_players_resource_formats
+  type: character
+  description: Probable players resource formats.
+- name: probable_players_resource_parameters
+  type: character
+  description: Probable players resource parameters.
+- name: probable_players_resource_auth_settings_require_auth
+  type: logical
+  description: Probable players resource auth settings require auth.
+- name: probable_players_resource_auth_settings_allow_only
+  type: character
+  description: Probable players resource auth settings allow only.
+- name: probable_players_resource_resource_cache_ns
+  type: character
+  description: Probable players resource resource cache ns.
+- name: probable_players_resource_resource_cache_cache_keys
+  type: character
+  description: Probable players resource resource cache cache keys.
+- name: probable_players_resource_resource_cache_cache_buster
+  type: integer
+  description: Probable players resource resource cache cache buster.
+- name: probable_players_resource_expiration_message_object_key_name
+  type: character
+  description: Probable players resource expiration message object key name.
+- name: conference_resource_location
+  type: character
+  description: Conference resource location.
+- name: conference_resource_routes
+  type: character
+  description: Conference resource routes.
+- name: conference_resource_paths
+  type: character
+  description: Conference resource paths.
+- name: conference_resource_summary
+  type: character
+  description: Conference resource summary.
+- name: conference_resource_notes
+  type: character
+  description: Conference resource notes.
+- name: conference_resource_versions_allowed
+  type: character
+  description: Conference resource versions allowed.
+- name: conference_resource_versions_current
+  type: character
+  description: Conference resource versions current.
+- name: conference_resource_methods
+  type: character
+  description: Conference resource methods.
+- name: conference_resource_formats
+  type: character
+  description: Conference resource formats.
+- name: conference_resource_parameters
+  type: character
+  description: Conference resource parameters.
+- name: conference_resource_auth_settings_require_auth
+  type: logical
+  description: Conference resource auth settings require auth.
+- name: conference_resource_auth_settings_allow_only
+  type: character
+  description: Conference resource auth settings allow only.
+- name: conference_resource_resource_cache_ns
+  type: character
+  description: Conference resource resource cache ns.
+- name: conference_resource_resource_cache_cache_keys
+  type: character
+  description: Conference resource resource cache cache keys.
+- name: conference_resource_resource_cache_cache_buster
+  type: integer
+  description: Conference resource resource cache cache buster.
+- name: conference_resource_expiration_message_object_key_name
+  type: character
+  description: Conference resource expiration message object key name.
+- name: division_resource_location
+  type: character
+  description: Division resource location.
+- name: division_resource_routes
+  type: character
+  description: Division resource routes.
+- name: division_resource_paths
+  type: character
+  description: Division resource paths.
+- name: division_resource_summary
+  type: character
+  description: Division resource summary.
+- name: division_resource_notes
+  type: character
+  description: Division resource notes.
+- name: division_resource_versions_allowed
+  type: character
+  description: Division resource versions allowed.
+- name: division_resource_versions_current
+  type: character
+  description: Division resource versions current.
+- name: division_resource_methods
+  type: character
+  description: Division resource methods.
+- name: division_resource_formats
+  type: character
+  description: Division resource formats.
+- name: division_resource_parameters
+  type: character
+  description: Division resource parameters.
+- name: division_resource_auth_settings_require_auth
+  type: logical
+  description: Division resource auth settings require auth.
+- name: division_resource_auth_settings_allow_only
+  type: character
+  description: Division resource auth settings allow only.
+- name: division_resource_resource_cache_ns
+  type: character
+  description: Division resource resource cache ns.
+- name: division_resource_resource_cache_cache_keys
+  type: character
+  description: Division resource resource cache cache keys.
+- name: division_resource_resource_cache_cache_buster
+  type: integer
+  description: Division resource resource cache cache buster.
+- name: division_resource_expiration_message_object_key_name
+  type: character
+  description: Division resource expiration message object key name.
+- name: sub_divisions_resource_location
+  type: character
+  description: Sub divisions resource location.
+- name: sub_divisions_resource_route
+  type: character
+  description: Sub divisions resource route.
+- name: sub_divisions_resource_path
+  type: character
+  description: Sub divisions resource path.
+- name: sub_divisions_resource_summary
+  type: character
+  description: Sub divisions resource summary.
+- name: sub_divisions_resource_notes
+  type: character
+  description: Sub divisions resource notes.
+- name: sub_divisions_resource_versions_allowed
+  type: character
+  description: Sub divisions resource versions allowed.
+- name: sub_divisions_resource_versions_current
+  type: character
+  description: Sub divisions resource versions current.
+- name: sub_divisions_resource_methods
+  type: character
+  description: Sub divisions resource methods.
+- name: sub_divisions_resource_formats
+  type: character
+  description: Sub divisions resource formats.
+- name: sub_divisions_resource_parameters
+  type: character
+  description: Sub divisions resource parameters.
+- name: sub_divisions_resource_auth_settings_require_auth
+  type: logical
+  description: Sub divisions resource auth settings require auth.
+- name: sub_divisions_resource_auth_settings_allow_only
+  type: character
+  description: Sub divisions resource auth settings allow only.
+- name: sub_divisions_resource_resource_cache_ns
+  type: character
+  description: Sub divisions resource resource cache ns.
+- name: sub_divisions_resource_resource_cache_cache_keys
+  type: character
+  description: Sub divisions resource resource cache cache keys.
+- name: sub_divisions_resource_resource_cache_cache_buster
+  type: integer
+  description: Sub divisions resource resource cache cache buster.
+- name: sub_divisions_resource_expiration_message_object_key_name
+  type: character
+  description: Sub divisions resource expiration message object key name.
+- name: sport_resource_location
+  type: character
+  description: Sport resource location.
+- name: sport_resource_route
+  type: character
+  description: Sport resource route.
+- name: sport_resource_path
+  type: character
+  description: Sport resource path.
+- name: sport_resource_summary
+  type: character
+  description: Sport resource summary.
+- name: sport_resource_notes
+  type: character
+  description: Sport resource notes.
+- name: sport_resource_versions_allowed
+  type: character
+  description: Sport resource versions allowed.
+- name: sport_resource_versions_current
+  type: character
+  description: Sport resource versions current.
+- name: sport_resource_methods
+  type: character
+  description: Sport resource methods.
+- name: sport_resource_formats
+  type: character
+  description: Sport resource formats.
+- name: sport_resource_parameters
+  type: character
+  description: Sport resource parameters.
+- name: sport_resource_auth_settings_require_auth
+  type: logical
+  description: Sport resource auth settings require auth.
+- name: sport_resource_auth_settings_allow_only
+  type: character
+  description: Sport resource auth settings allow only.
+- name: sport_resource_resource_cache_ns
+  type: character
+  description: Sport resource resource cache ns.
+- name: sport_resource_resource_cache_cache_keys
+  type: character
+  description: Sport resource resource cache cache keys.
+- name: sport_resource_resource_cache_cache_buster
+  type: integer
+  description: Sport resource resource cache cache buster.
+- name: sport_resource_expiration_message
+  type: character
+  description: Sport resource expiration message.
+- name: sport_leagues_resource_location
+  type: character
+  description: Sport leagues resource location.
+- name: sport_leagues_resource_route
+  type: character
+  description: Sport leagues resource route.
+- name: sport_leagues_resource_path
+  type: character
+  description: Sport leagues resource path.
+- name: sport_leagues_resource_summary
+  type: character
+  description: Sport leagues resource summary.
+- name: sport_leagues_resource_notes
+  type: character
+  description: Sport leagues resource notes.
+- name: sport_leagues_resource_versions_allowed
+  type: character
+  description: Sport leagues resource versions allowed.
+- name: sport_leagues_resource_versions_current
+  type: character
+  description: Sport leagues resource versions current.
+- name: sport_leagues_resource_methods
+  type: character
+  description: Sport leagues resource methods.
+- name: sport_leagues_resource_formats
+  type: character
+  description: Sport leagues resource formats.
+- name: sport_leagues_resource_parameters
+  type: character
+  description: Sport leagues resource parameters.
+- name: sport_leagues_resource_auth_settings_require_auth
+  type: logical
+  description: Sport leagues resource auth settings require auth.
+- name: sport_leagues_resource_auth_settings_allow_only
+  type: character
+  description: Sport leagues resource auth settings allow only.
+- name: sport_leagues_resource_resource_cache_ns
+  type: character
+  description: Sport leagues resource resource cache ns.
+- name: sport_leagues_resource_resource_cache_cache_keys
+  type: character
+  description: Sport leagues resource resource cache cache keys.
+- name: sport_leagues_resource_resource_cache_cache_buster
+  type: integer
+  description: Sport leagues resource resource cache cache buster.
+- name: sport_leagues_resource_expiration_message
+  type: character
+  description: Sport leagues resource expiration message.
+- name: baseball_player_meta_resource_location
+  type: character
+  description: Baseball player meta resource location.
+- name: baseball_player_meta_resource_route
+  type: character
+  description: Baseball player meta resource route.
+- name: baseball_player_meta_resource_path
+  type: character
+  description: Baseball player meta resource path.
+- name: baseball_player_meta_resource_summary
+  type: character
+  description: Baseball player meta resource summary.
+- name: baseball_player_meta_resource_notes
+  type: character
+  description: Baseball player meta resource notes.
+- name: baseball_player_meta_resource_versions_allowed
+  type: character
+  description: Baseball player meta resource versions allowed.
+- name: baseball_player_meta_resource_versions_current
+  type: character
+  description: Baseball player meta resource versions current.
+- name: baseball_player_meta_resource_methods
+  type: character
+  description: Baseball player meta resource methods.
+- name: baseball_player_meta_resource_formats
+  type: character
+  description: Baseball player meta resource formats.
+- name: baseball_player_meta_resource_parameters
+  type: character
+  description: Baseball player meta resource parameters.
+- name: baseball_player_meta_resource_auth_settings_require_auth
+  type: logical
+  description: Baseball player meta resource auth settings require auth.
+- name: baseball_player_meta_resource_auth_settings_allow_only
+  type: character
+  description: Baseball player meta resource auth settings allow only.
+- name: baseball_player_meta_resource_resource_cache_ns
+  type: character
+  description: Baseball player meta resource resource cache ns.
+- name: baseball_player_meta_resource_resource_cache_cache_keys
+  type: character
+  description: Baseball player meta resource resource cache cache keys.
+- name: baseball_player_meta_resource_resource_cache_cache_buster
+  type: integer
+  description: Baseball player meta resource resource cache cache buster.
+- name: baseball_player_meta_resource_expiration_message_object_key_name
+  type: character
+  description: Baseball player meta resource expiration message object key name.
+- name: season_resource_location
+  type: character
+  description: Season resource location.
+- name: season_resource_route
+  type: character
+  description: Season resource route.
+- name: season_resource_path
+  type: character
+  description: Season resource path.
+- name: season_resource_summary
+  type: character
+  description: Season resource summary.
+- name: season_resource_notes
+  type: character
+  description: Season resource notes.
+- name: season_resource_versions_allowed
+  type: character
+  description: Season resource versions allowed.
+- name: season_resource_versions_current
+  type: character
+  description: Season resource versions current.
+- name: season_resource_methods
+  type: character
+  description: Season resource methods.
+- name: season_resource_formats
+  type: character
+  description: Season resource formats.
+- name: season_resource_parameters
+  type: character
+  description: Season resource parameters.
+- name: season_resource_auth_settings_require_auth
+  type: logical
+  description: Season resource auth settings require auth.
+- name: season_resource_auth_settings_allow_only
+  type: character
+  description: Season resource auth settings allow only.
+- name: season_resource_resource_cache_ns
+  type: character
+  description: Season resource resource cache ns.
+- name: season_resource_resource_cache_cache_keys
+  type: character
+  description: Season resource resource cache cache keys.
+- name: season_resource_resource_cache_cache_buster
+  type: integer
+  description: Season resource resource cache cache buster.
+- name: season_resource_expiration_message_object_key_name
+  type: character
+  description: Season resource expiration message object key name.
+- name: team_seasons_resource_location
+  type: character
+  description: Team seasons resource location.
+- name: team_seasons_resource_route
+  type: character
+  description: Team seasons resource route.
+- name: team_seasons_resource_path
+  type: character
+  description: Team seasons resource path.
+- name: team_seasons_resource_summary
+  type: character
+  description: Team seasons resource summary.
+- name: team_seasons_resource_notes
+  type: character
+  description: Team seasons resource notes.
+- name: team_seasons_resource_versions_allowed
+  type: character
+  description: Team seasons resource versions allowed.
+- name: team_seasons_resource_versions_current
+  type: character
+  description: Team seasons resource versions current.
+- name: team_seasons_resource_methods
+  type: character
+  description: Team seasons resource methods.
+- name: team_seasons_resource_formats
+  type: character
+  description: Team seasons resource formats.
+- name: team_seasons_resource_parameters
+  type: character
+  description: Team seasons resource parameters.
+- name: team_seasons_resource_auth_settings_require_auth
+  type: logical
+  description: Team seasons resource auth settings require auth.
+- name: team_seasons_resource_auth_settings_allow_only
+  type: character
+  description: Team seasons resource auth settings allow only.
+- name: team_seasons_resource_resource_cache_ns
+  type: character
+  description: Team seasons resource resource cache ns.
+- name: team_seasons_resource_resource_cache_cache_keys
+  type: character
+  description: Team seasons resource resource cache cache keys.
+- name: team_seasons_resource_resource_cache_cache_buster
+  type: integer
+  description: Team seasons resource resource cache cache buster.
+- name: team_seasons_resource_expiration_message_object_key_name
+  type: character
+  description: Team seasons resource expiration message object key name.
+- name: team_polls_resource_location
+  type: character
+  description: Team polls resource location.
+- name: team_polls_resource_route
+  type: character
+  description: Team polls resource route.
+- name: team_polls_resource_path
+  type: character
+  description: Team polls resource path.
+- name: team_polls_resource_summary
+  type: character
+  description: Team polls resource summary.
+- name: team_polls_resource_notes
+  type: character
+  description: Team polls resource notes.
+- name: team_polls_resource_versions_allowed
+  type: character
+  description: Team polls resource versions allowed.
+- name: team_polls_resource_versions_current
+  type: character
+  description: Team polls resource versions current.
+- name: team_polls_resource_methods
+  type: character
+  description: Team polls resource methods.
+- name: team_polls_resource_formats
+  type: character
+  description: Team polls resource formats.
+- name: team_polls_resource_parameters
+  type: character
+  description: Team polls resource parameters.
+- name: team_polls_resource_auth_settings_require_auth
+  type: logical
+  description: Team polls resource auth settings require auth.
+- name: team_polls_resource_auth_settings_allow_only
+  type: character
+  description: Team polls resource auth settings allow only.
+- name: team_polls_resource_resource_cache_ns
+  type: character
+  description: Team polls resource resource cache ns.
+- name: team_polls_resource_resource_cache_cache_keys
+  type: character
+  description: Team polls resource resource cache cache keys.
+- name: team_polls_resource_resource_cache_cache_buster
+  type: integer
+  description: Team polls resource resource cache cache buster.
+- name: team_polls_resource_expiration_message_object_key_name
+  type: character
+  description: Team polls resource expiration message object key name.
+- name: client_configuration_resource_location
+  type: character
+  description: Client configuration resource location.
+- name: client_configuration_resource_route
+  type: character
+  description: Client configuration resource route.
+- name: client_configuration_resource_path
+  type: character
+  description: Client configuration resource path.
+- name: client_configuration_resource_summary
+  type: character
+  description: Client configuration resource summary.
+- name: client_configuration_resource_notes
+  type: character
+  description: Client configuration resource notes.
+- name: client_configuration_resource_versions_allowed
+  type: character
+  description: Client configuration resource versions allowed.
+- name: client_configuration_resource_versions_current
+  type: character
+  description: Client configuration resource versions current.
+- name: client_configuration_resource_methods
+  type: character
+  description: Client configuration resource methods.
+- name: client_configuration_resource_formats
+  type: character
+  description: Client configuration resource formats.
+- name: client_configuration_resource_parameters
+  type: character
+  description: Client configuration resource parameters.
+- name: client_configuration_resource_auth_settings_require_auth
+  type: logical
+  description: Client configuration resource auth settings require auth.
+- name: client_configuration_resource_resource_cache_ns
+  type: character
+  description: Client configuration resource resource cache ns.
+- name: client_configuration_resource_resource_cache_cache_keys
+  type: character
+  description: Client configuration resource resource cache cache keys.
+- name: client_configuration_resource_resource_cache_cache_buster
+  type: integer
+  description: Client configuration resource resource cache cache buster.
+- name: client_configuration_resource_expiration_message_object_key_name
+  type: character
+  description: Client configuration resource expiration message object key name.
+- name: player_stats_resource_location
+  type: character
+  description: Player stats resource location.
+- name: player_stats_resource_route
+  type: character
+  description: Player stats resource route.
+- name: player_stats_resource_path
+  type: character
+  description: Player stats resource path.
+- name: player_stats_resource_summary
+  type: character
+  description: Player stats resource summary.
+- name: player_stats_resource_notes
+  type: character
+  description: Player stats resource notes.
+- name: player_stats_resource_versions_allowed
+  type: character
+  description: Player stats resource versions allowed.
+- name: player_stats_resource_versions_current
+  type: character
+  description: Player stats resource versions current.
+- name: player_stats_resource_methods
+  type: character
+  description: Player stats resource methods.
+- name: player_stats_resource_formats
+  type: character
+  description: Player stats resource formats.
+- name: player_stats_resource_parameters
+  type: character
+  description: Player stats resource parameters.
+- name: player_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Player stats resource auth settings require auth.
+- name: player_stats_resource_auth_settings_allow_only
+  type: character
+  description: Player stats resource auth settings allow only.
+- name: player_stats_resource_resource_cache_ns
+  type: character
+  description: Player stats resource resource cache ns.
+- name: player_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Player stats resource resource cache cache keys.
+- name: player_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Player stats resource resource cache cache buster.
+- name: player_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Player stats resource expiration message object key name.
+- name: team_stats_resource_location
+  type: character
+  description: Team stats resource location.
+- name: team_stats_resource_route
+  type: character
+  description: Team stats resource route.
+- name: team_stats_resource_path
+  type: character
+  description: Team stats resource path.
+- name: team_stats_resource_summary
+  type: character
+  description: Team stats resource summary.
+- name: team_stats_resource_notes
+  type: character
+  description: Team stats resource notes.
+- name: team_stats_resource_versions_allowed
+  type: character
+  description: Team stats resource versions allowed.
+- name: team_stats_resource_versions_current
+  type: character
+  description: Team stats resource versions current.
+- name: team_stats_resource_methods
+  type: character
+  description: Team stats resource methods.
+- name: team_stats_resource_formats
+  type: character
+  description: Team stats resource formats.
+- name: team_stats_resource_parameters
+  type: character
+  description: Team stats resource parameters.
+- name: team_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Team stats resource auth settings require auth.
+- name: team_stats_resource_auth_settings_allow_only
+  type: character
+  description: Team stats resource auth settings allow only.
+- name: team_stats_resource_resource_cache_ns
+  type: character
+  description: Team stats resource resource cache ns.
+- name: team_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Team stats resource resource cache cache keys.
+- name: team_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Team stats resource resource cache cache buster.
+- name: team_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Team stats resource expiration message object key name.
+- name: team_futures_resource_location
+  type: character
+  description: Team futures resource location.
+- name: team_futures_resource_route
+  type: character
+  description: Team futures resource route.
+- name: team_futures_resource_path
+  type: character
+  description: Team futures resource path.
+- name: team_futures_resource_summary
+  type: character
+  description: Team futures resource summary.
+- name: team_futures_resource_notes
+  type: character
+  description: Team futures resource notes.
+- name: team_futures_resource_versions_allowed
+  type: character
+  description: Team futures resource versions allowed.
+- name: team_futures_resource_versions_current
+  type: character
+  description: Team futures resource versions current.
+- name: team_futures_resource_methods
+  type: character
+  description: Team futures resource methods.
+- name: team_futures_resource_formats
+  type: character
+  description: Team futures resource formats.
+- name: team_futures_resource_parameters
+  type: character
+  description: Team futures resource parameters.
+- name: team_futures_resource_auth_settings_require_auth
+  type: logical
+  description: Team futures resource auth settings require auth.
+- name: team_futures_resource_auth_settings_allow_only
+  type: character
+  description: Team futures resource auth settings allow only.
+- name: team_futures_resource_resource_cache_ns
+  type: character
+  description: Team futures resource resource cache ns.
+- name: team_futures_resource_resource_cache_cache_keys
+  type: character
+  description: Team futures resource resource cache cache keys.
+- name: team_futures_resource_resource_cache_cache_buster
+  type: integer
+  description: Team futures resource resource cache cache buster.
+- name: team_futures_resource_expiration_message_object_key_name
+  type: character
+  description: Team futures resource expiration message object key name.
+- name: player_futures_resource_location
+  type: character
+  description: Player futures resource location.
+- name: player_futures_resource_route
+  type: character
+  description: Player futures resource route.
+- name: player_futures_resource_path
+  type: character
+  description: Player futures resource path.
+- name: player_futures_resource_summary
+  type: character
+  description: Player futures resource summary.
+- name: player_futures_resource_notes
+  type: character
+  description: Player futures resource notes.
+- name: player_futures_resource_versions_allowed
+  type: character
+  description: Player futures resource versions allowed.
+- name: player_futures_resource_versions_current
+  type: character
+  description: Player futures resource versions current.
+- name: player_futures_resource_methods
+  type: character
+  description: Player futures resource methods.
+- name: player_futures_resource_formats
+  type: character
+  description: Player futures resource formats.
+- name: player_futures_resource_parameters
+  type: character
+  description: Player futures resource parameters.
+- name: player_futures_resource_auth_settings_require_auth
+  type: logical
+  description: Player futures resource auth settings require auth.
+- name: player_futures_resource_auth_settings_allow_only
+  type: character
+  description: Player futures resource auth settings allow only.
+- name: player_futures_resource_resource_cache_ns
+  type: character
+  description: Player futures resource resource cache ns.
+- name: player_futures_resource_resource_cache_cache_keys
+  type: character
+  description: Player futures resource resource cache cache keys.
+- name: player_futures_resource_resource_cache_cache_buster
+  type: integer
+  description: Player futures resource resource cache cache buster.
+- name: player_futures_resource_expiration_message_object_key_name
+  type: character
+  description: Player futures resource expiration message object key name.
+- name: game_props_resource_location
+  type: character
+  description: Game props resource location.
+- name: game_props_resource_route
+  type: character
+  description: Game props resource route.
+- name: game_props_resource_path
+  type: character
+  description: Game props resource path.
+- name: game_props_resource_summary
+  type: character
+  description: Game props resource summary.
+- name: game_props_resource_notes
+  type: character
+  description: Game props resource notes.
+- name: game_props_resource_versions_allowed
+  type: character
+  description: Game props resource versions allowed.
+- name: game_props_resource_versions_current
+  type: character
+  description: Game props resource versions current.
+- name: game_props_resource_methods
+  type: character
+  description: Game props resource methods.
+- name: game_props_resource_formats
+  type: character
+  description: Game props resource formats.
+- name: game_props_resource_parameters
+  type: character
+  description: Game props resource parameters.
+- name: game_props_resource_auth_settings_require_auth
+  type: logical
+  description: Game props resource auth settings require auth.
+- name: game_props_resource_auth_settings_allow_only
+  type: character
+  description: Game props resource auth settings allow only.
+- name: game_props_resource_resource_cache_ns
+  type: character
+  description: Game props resource resource cache ns.
+- name: game_props_resource_resource_cache_cache_keys
+  type: character
+  description: Game props resource resource cache cache keys.
+- name: game_props_resource_resource_cache_cache_buster
+  type: integer
+  description: Game props resource resource cache cache buster.
+- name: game_props_resource_expiration_message_object_key_name
+  type: character
+  description: Game props resource expiration message object key name.
+- name: player_standings_resource_location
+  type: character
+  description: Player standings resource location.
+- name: player_standings_resource_route
+  type: character
+  description: Player standings resource route.
+- name: player_standings_resource_path
+  type: character
+  description: Player standings resource path.
+- name: player_standings_resource_summary
+  type: character
+  description: Player standings resource summary.
+- name: player_standings_resource_notes
+  type: character
+  description: Player standings resource notes.
+- name: player_standings_resource_versions_allowed
+  type: character
+  description: Player standings resource versions allowed.
+- name: player_standings_resource_versions_current
+  type: character
+  description: Player standings resource versions current.
+- name: player_standings_resource_methods
+  type: character
+  description: Player standings resource methods.
+- name: player_standings_resource_formats
+  type: character
+  description: Player standings resource formats.
+- name: player_standings_resource_parameters
+  type: character
+  description: Player standings resource parameters.
+- name: player_standings_resource_auth_settings_require_auth
+  type: logical
+  description: Player standings resource auth settings require auth.
+- name: player_standings_resource_auth_settings_allow_only
+  type: character
+  description: Player standings resource auth settings allow only.
+- name: player_standings_resource_resource_cache_ns
+  type: character
+  description: Player standings resource resource cache ns.
+- name: player_standings_resource_resource_cache_cache_keys
+  type: character
+  description: Player standings resource resource cache cache keys.
+- name: player_standings_resource_resource_cache_cache_buster
+  type: integer
+  description: Player standings resource resource cache cache buster.
+- name: player_standings_resource_expiration_message_object_key_name
+  type: character
+  description: Player standings resource expiration message object key name.
+- name: golf_event_markets_resource_location
+  type: character
+  description: Golf event markets resource location.
+- name: golf_event_markets_resource_route
+  type: character
+  description: Golf event markets resource route.
+- name: golf_event_markets_resource_path
+  type: character
+  description: Golf event markets resource path.
+- name: golf_event_markets_resource_summary
+  type: character
+  description: Golf event markets resource summary.
+- name: golf_event_markets_resource_notes
+  type: character
+  description: Golf event markets resource notes.
+- name: golf_event_markets_resource_versions_allowed
+  type: character
+  description: Golf event markets resource versions allowed.
+- name: golf_event_markets_resource_versions_current
+  type: character
+  description: Golf event markets resource versions current.
+- name: golf_event_markets_resource_methods
+  type: character
+  description: Golf event markets resource methods.
+- name: golf_event_markets_resource_formats
+  type: character
+  description: Golf event markets resource formats.
+- name: golf_event_markets_resource_parameters
+  type: character
+  description: Golf event markets resource parameters.
+- name: golf_event_markets_resource_auth_settings_require_auth
+  type: logical
+  description: Golf event markets resource auth settings require auth.
+- name: golf_event_markets_resource_auth_settings_allow_only
+  type: character
+  description: Golf event markets resource auth settings allow only.
+- name: golf_event_markets_resource_resource_cache_ns
+  type: character
+  description: Golf event markets resource resource cache ns.
+- name: golf_event_markets_resource_resource_cache_cache_keys
+  type: character
+  description: Golf event markets resource resource cache cache keys.
+- name: golf_event_markets_resource_resource_cache_cache_buster
+  type: integer
+  description: Golf event markets resource resource cache cache buster.
+- name: golf_event_markets_resource_expiration_message_object_key_name
+  type: character
+  description: Golf event markets resource expiration message object key name.
+- name: golf_player_markets_resource_location
+  type: character
+  description: Golf player markets resource location.
+- name: golf_player_markets_resource_route
+  type: character
+  description: Golf player markets resource route.
+- name: golf_player_markets_resource_path
+  type: character
+  description: Golf player markets resource path.
+- name: golf_player_markets_resource_summary
+  type: character
+  description: Golf player markets resource summary.
+- name: golf_player_markets_resource_notes
+  type: character
+  description: Golf player markets resource notes.
+- name: golf_player_markets_resource_versions_allowed
+  type: character
+  description: Golf player markets resource versions allowed.
+- name: golf_player_markets_resource_versions_current
+  type: character
+  description: Golf player markets resource versions current.
+- name: golf_player_markets_resource_methods
+  type: character
+  description: Golf player markets resource methods.
+- name: golf_player_markets_resource_formats
+  type: character
+  description: Golf player markets resource formats.
+- name: golf_player_markets_resource_parameters
+  type: character
+  description: Golf player markets resource parameters.
+- name: golf_player_markets_resource_auth_settings_require_auth
+  type: logical
+  description: Golf player markets resource auth settings require auth.
+- name: golf_player_markets_resource_auth_settings_allow_only
+  type: character
+  description: Golf player markets resource auth settings allow only.
+- name: golf_player_markets_resource_resource_cache_ns
+  type: character
+  description: Golf player markets resource resource cache ns.
+- name: golf_player_markets_resource_resource_cache_cache_keys
+  type: character
+  description: Golf player markets resource resource cache cache keys.
+- name: golf_player_markets_resource_resource_cache_cache_buster
+  type: integer
+  description: Golf player markets resource resource cache cache buster.
+- name: golf_player_markets_resource_expiration_message_object_key_name
+  type: character
+  description: Golf player markets resource expiration message object key name.
+- name: bulk_resource_controller_is_active
+  type: logical
+  description: Bulk resource controller is active.
+- name: bulk_resource_controller_location
+  type: character
+  description: Bulk resource controller location.
+- name: bulk_resource_controller_route
+  type: character
+  description: Bulk resource controller route.
+- name: bulk_resource_controller_path
+  type: character
+  description: Bulk resource controller path.
+- name: bulk_resource_controller_summary
+  type: character
+  description: Bulk resource controller summary.
+- name: bulk_resource_controller_notes
+  type: character
+  description: Bulk resource controller notes.
+- name: bulk_resource_controller_versions_allowed
+  type: character
+  description: Bulk resource controller versions allowed.
+- name: bulk_resource_controller_versions_current
+  type: character
+  description: Bulk resource controller versions current.
+- name: bulk_resource_controller_methods
+  type: character
+  description: Bulk resource controller methods.
+- name: bulk_resource_controller_formats
+  type: character
+  description: Bulk resource controller formats.
+- name: bulk_resource_controller_parameters
+  type: character
+  description: Bulk resource controller parameters.
+- name: bulk_resource_controller_auth_settings_require_auth
+  type: logical
+  description: Bulk resource controller auth settings require auth.
+- name: bulk_resource_controller_auth_settings_allow_only
+  type: character
+  description: Bulk resource controller auth settings allow only.
+- name: bulk_resource_controller_resource_cache_no_cache
+  type: logical
+  description: Bulk resource controller resource cache no cache.
+- name: bulk_resource_controller_expiration_message
+  type: character
+  description: Bulk resource controller expiration message.
+- name: endpoint_registry_resource_location
+  type: character
+  description: Endpoint registry resource location.
+- name: endpoint_registry_resource_route
+  type: character
+  description: Endpoint registry resource route.
+- name: endpoint_registry_resource_path
+  type: character
+  description: Endpoint registry resource path.
+- name: endpoint_registry_resource_summary
+  type: character
+  description: Endpoint registry resource summary.
+- name: endpoint_registry_resource_notes
+  type: character
+  description: Endpoint registry resource notes.
+- name: endpoint_registry_resource_versions_allowed
+  type: character
+  description: Endpoint registry resource versions allowed.
+- name: endpoint_registry_resource_versions_current
+  type: character
+  description: Endpoint registry resource versions current.
+- name: endpoint_registry_resource_methods
+  type: character
+  description: Endpoint registry resource methods.
+- name: endpoint_registry_resource_formats
+  type: character
+  description: Endpoint registry resource formats.
+- name: endpoint_registry_resource_parameters
+  type: character
+  description: Endpoint registry resource parameters.
+- name: endpoint_registry_resource_auth_settings_require_auth
+  type: logical
+  description: Endpoint registry resource auth settings require auth.
+- name: endpoint_registry_resource_auth_settings_allow_only
+  type: character
+  description: Endpoint registry resource auth settings allow only.
+- name: endpoint_registry_resource_resource_cache_no_cache
+  type: logical
+  description: Endpoint registry resource resource cache no cache.
+- name: endpoint_registry_resource_expiration_message
+  type: character
+  description: Endpoint registry resource expiration message.
+- name: event_resource_location
+  type: character
+  description: Event resource location.
+- name: event_resource_route
+  type: character
+  description: Event resource route.
+- name: event_resource_path
+  type: character
+  description: Event resource path.
+- name: event_resource_summary
+  type: character
+  description: Event resource summary.
+- name: event_resource_notes
+  type: character
+  description: Event resource notes.
+- name: event_resource_versions_allowed
+  type: character
+  description: Event resource versions allowed.
+- name: event_resource_versions_current
+  type: character
+  description: Event resource versions current.
+- name: event_resource_methods
+  type: character
+  description: Event resource methods.
+- name: event_resource_formats
+  type: character
+  description: Event resource formats.
+- name: event_resource_parameters
+  type: character
+  description: Event resource parameters.
+- name: event_resource_auth_settings_require_auth
+  type: logical
+  description: Event resource auth settings require auth.
+- name: event_resource_auth_settings_allow_only
+  type: character
+  description: Event resource auth settings allow only.
+- name: event_resource_resource_cache_ns
+  type: character
+  description: Event resource resource cache ns.
+- name: event_resource_resource_cache_cache_keys
+  type: character
+  description: Event resource resource cache cache keys.
+- name: event_resource_resource_cache_cache_buster
+  type: integer
+  description: Event resource resource cache cache buster.
+- name: event_resource_expiration_message_object_key_name
+  type: character
+  description: Event resource expiration message object key name.
+- name: venue_resource_location
+  type: character
+  description: Venue resource location.
+- name: venue_resource_route
+  type: character
+  description: Venue resource route.
+- name: venue_resource_path
+  type: character
+  description: Venue resource path.
+- name: venue_resource_summary
+  type: character
+  description: Venue resource summary.
+- name: venue_resource_notes
+  type: character
+  description: Venue resource notes.
+- name: venue_resource_versions_allowed
+  type: character
+  description: Venue resource versions allowed.
+- name: venue_resource_versions_current
+  type: character
+  description: Venue resource versions current.
+- name: venue_resource_methods
+  type: character
+  description: Venue resource methods.
+- name: venue_resource_formats
+  type: character
+  description: Venue resource formats.
+- name: venue_resource_parameters
+  type: character
+  description: Venue resource parameters.
+- name: venue_resource_auth_settings_require_auth
+  type: logical
+  description: Venue resource auth settings require auth.
+- name: venue_resource_auth_settings_allow_only
+  type: character
+  description: Venue resource auth settings allow only.
+- name: venue_resource_resource_cache_ns
+  type: character
+  description: Venue resource resource cache ns.
+- name: venue_resource_resource_cache_cache_keys
+  type: character
+  description: Venue resource resource cache cache keys.
+- name: venue_resource_resource_cache_cache_buster
+  type: integer
+  description: Venue resource resource cache cache buster.
+- name: venue_resource_expiration_message_object_key_name
+  type: character
+  description: Venue resource expiration message object key name.
+- name: venue_metadata_resource_location
+  type: character
+  description: Venue metadata resource location.
+- name: venue_metadata_resource_route
+  type: character
+  description: Venue metadata resource route.
+- name: venue_metadata_resource_path
+  type: character
+  description: Venue metadata resource path.
+- name: venue_metadata_resource_summary
+  type: character
+  description: Venue metadata resource summary.
+- name: venue_metadata_resource_notes
+  type: character
+  description: Venue metadata resource notes.
+- name: venue_metadata_resource_versions_allowed
+  type: character
+  description: Venue metadata resource versions allowed.
+- name: venue_metadata_resource_versions_current
+  type: character
+  description: Venue metadata resource versions current.
+- name: venue_metadata_resource_methods
+  type: character
+  description: Venue metadata resource methods.
+- name: venue_metadata_resource_formats
+  type: character
+  description: Venue metadata resource formats.
+- name: venue_metadata_resource_parameters
+  type: character
+  description: Venue metadata resource parameters.
+- name: venue_metadata_resource_auth_settings_require_auth
+  type: logical
+  description: Venue metadata resource auth settings require auth.
+- name: venue_metadata_resource_auth_settings_allow_only
+  type: character
+  description: Venue metadata resource auth settings allow only.
+- name: venue_metadata_resource_resource_cache_ns
+  type: character
+  description: Venue metadata resource resource cache ns.
+- name: venue_metadata_resource_resource_cache_cache_keys
+  type: character
+  description: Venue metadata resource resource cache cache keys.
+- name: venue_metadata_resource_resource_cache_cache_buster
+  type: integer
+  description: Venue metadata resource resource cache cache buster.
+- name: venue_metadata_resource_expiration_message_object_key_name
+  type: character
+  description: Venue metadata resource expiration message object key name.
+- name: event_entrants_resource_location
+  type: character
+  description: Event entrants resource location.
+- name: event_entrants_resource_route
+  type: character
+  description: Event entrants resource route.
+- name: event_entrants_resource_path
+  type: character
+  description: Event entrants resource path.
+- name: event_entrants_resource_summary
+  type: character
+  description: Event entrants resource summary.
+- name: event_entrants_resource_notes
+  type: character
+  description: Event entrants resource notes.
+- name: event_entrants_resource_versions_allowed
+  type: character
+  description: Event entrants resource versions allowed.
+- name: event_entrants_resource_versions_current
+  type: character
+  description: Event entrants resource versions current.
+- name: event_entrants_resource_methods
+  type: character
+  description: Event entrants resource methods.
+- name: event_entrants_resource_formats
+  type: character
+  description: Event entrants resource formats.
+- name: event_entrants_resource_parameters
+  type: character
+  description: Event entrants resource parameters.
+- name: event_entrants_resource_auth_settings_require_auth
+  type: logical
+  description: Event entrants resource auth settings require auth.
+- name: event_entrants_resource_auth_settings_allow_only
+  type: character
+  description: Event entrants resource auth settings allow only.
+- name: event_entrants_resource_resource_cache_ns
+  type: character
+  description: Event entrants resource resource cache ns.
+- name: event_entrants_resource_resource_cache_cache_keys
+  type: character
+  description: Event entrants resource resource cache cache keys.
+- name: event_entrants_resource_resource_cache_cache_buster
+  type: integer
+  description: Event entrants resource resource cache cache buster.
+- name: event_seasons_resource_location
+  type: character
+  description: Event seasons resource location.
+- name: event_seasons_resource_route
+  type: character
+  description: Event seasons resource route.
+- name: event_seasons_resource_path
+  type: character
+  description: Event seasons resource path.
+- name: event_seasons_resource_summary
+  type: character
+  description: Event seasons resource summary.
+- name: event_seasons_resource_notes
+  type: character
+  description: Event seasons resource notes.
+- name: event_seasons_resource_versions_allowed
+  type: character
+  description: Event seasons resource versions allowed.
+- name: event_seasons_resource_versions_current
+  type: character
+  description: Event seasons resource versions current.
+- name: event_seasons_resource_methods
+  type: character
+  description: Event seasons resource methods.
+- name: event_seasons_resource_formats
+  type: character
+  description: Event seasons resource formats.
+- name: event_seasons_resource_parameters
+  type: character
+  description: Event seasons resource parameters.
+- name: event_seasons_resource_auth_settings_require_auth
+  type: logical
+  description: Event seasons resource auth settings require auth.
+- name: event_seasons_resource_auth_settings_allow_only
+  type: character
+  description: Event seasons resource auth settings allow only.
+- name: event_seasons_resource_resource_cache_ns
+  type: character
+  description: Event seasons resource resource cache ns.
+- name: event_seasons_resource_resource_cache_cache_keys
+  type: character
+  description: Event seasons resource resource cache cache keys.
+- name: event_seasons_resource_resource_cache_cache_buster
+  type: integer
+  description: Event seasons resource resource cache cache buster.
+- name: event_venues_resource_location
+  type: character
+  description: Event venues resource location.
+- name: event_venues_resource_route
+  type: character
+  description: Event venues resource route.
+- name: event_venues_resource_path
+  type: character
+  description: Event venues resource path.
+- name: event_venues_resource_summary
+  type: character
+  description: Event venues resource summary.
+- name: event_venues_resource_notes
+  type: character
+  description: Event venues resource notes.
+- name: event_venues_resource_versions_allowed
+  type: character
+  description: Event venues resource versions allowed.
+- name: event_venues_resource_versions_current
+  type: character
+  description: Event venues resource versions current.
+- name: event_venues_resource_methods
+  type: character
+  description: Event venues resource methods.
+- name: event_venues_resource_formats
+  type: character
+  description: Event venues resource formats.
+- name: event_venues_resource_parameters
+  type: character
+  description: Event venues resource parameters.
+- name: event_venues_resource_auth_settings_require_auth
+  type: logical
+  description: Event venues resource auth settings require auth.
+- name: event_venues_resource_auth_settings_allow_only
+  type: character
+  description: Event venues resource auth settings allow only.
+- name: event_venues_resource_resource_cache_ns
+  type: character
+  description: Event venues resource resource cache ns.
+- name: event_venues_resource_resource_cache_cache_keys
+  type: character
+  description: Event venues resource resource cache cache keys.
+- name: event_venues_resource_resource_cache_cache_buster
+  type: integer
+  description: Event venues resource resource cache cache buster.
+- name: event_venues_resource_expiration_message_object_key_name
+  type: character
+  description: Event venues resource expiration message object key name.
+- name: player_rankings_resource_location
+  type: character
+  description: Player rankings resource location.
+- name: player_rankings_resource_route
+  type: character
+  description: Player rankings resource route.
+- name: player_rankings_resource_path
+  type: character
+  description: Player rankings resource path.
+- name: player_rankings_resource_summary
+  type: character
+  description: Player rankings resource summary.
+- name: player_rankings_resource_notes
+  type: character
+  description: Player rankings resource notes.
+- name: player_rankings_resource_versions_allowed
+  type: character
+  description: Player rankings resource versions allowed.
+- name: player_rankings_resource_versions_current
+  type: character
+  description: Player rankings resource versions current.
+- name: player_rankings_resource_methods
+  type: character
+  description: Player rankings resource methods.
+- name: player_rankings_resource_formats
+  type: character
+  description: Player rankings resource formats.
+- name: player_rankings_resource_parameters
+  type: character
+  description: Player rankings resource parameters.
+- name: player_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Player rankings resource auth settings require auth.
+- name: player_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Player rankings resource auth settings allow only.
+- name: player_rankings_resource_resource_cache_ns
+  type: character
+  description: Player rankings resource resource cache ns.
+- name: player_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Player rankings resource resource cache cache keys.
+- name: player_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Player rankings resource resource cache cache buster.
+- name: player_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Player rankings resource expiration message object key name.
+- name: player_outlook_resource_location
+  type: character
+  description: Player outlook resource location.
+- name: player_outlook_resource_route
+  type: character
+  description: Player outlook resource route.
+- name: player_outlook_resource_path
+  type: character
+  description: Player outlook resource path.
+- name: player_outlook_resource_summary
+  type: character
+  description: Player outlook resource summary.
+- name: player_outlook_resource_notes
+  type: character
+  description: Player outlook resource notes.
+- name: player_outlook_resource_versions_allowed
+  type: character
+  description: Player outlook resource versions allowed.
+- name: player_outlook_resource_versions_current
+  type: character
+  description: Player outlook resource versions current.
+- name: player_outlook_resource_methods
+  type: character
+  description: Player outlook resource methods.
+- name: player_outlook_resource_formats
+  type: character
+  description: Player outlook resource formats.
+- name: player_outlook_resource_parameters
+  type: character
+  description: Player outlook resource parameters.
+- name: player_outlook_resource_auth_settings_require_auth
+  type: logical
+  description: Player outlook resource auth settings require auth.
+- name: player_outlook_resource_auth_settings_allow_only
+  type: character
+  description: Player outlook resource auth settings allow only.
+- name: player_outlook_resource_resource_cache_ns
+  type: character
+  description: Player outlook resource resource cache ns.
+- name: player_outlook_resource_resource_cache_cache_keys
+  type: character
+  description: Player outlook resource resource cache cache keys.
+- name: player_outlook_resource_resource_cache_cache_buster
+  type: integer
+  description: Player outlook resource resource cache cache buster.
+- name: player_outlook_resource_expiration_message_object_key_name
+  type: character
+  description: Player outlook resource expiration message object key name.
+- name: team_rankings_resource_location
+  type: character
+  description: Team rankings resource location.
+- name: team_rankings_resource_route
+  type: character
+  description: Team rankings resource route.
+- name: team_rankings_resource_path
+  type: character
+  description: Team rankings resource path.
+- name: team_rankings_resource_summary
+  type: character
+  description: Team rankings resource summary.
+- name: team_rankings_resource_notes
+  type: character
+  description: Team rankings resource notes.
+- name: team_rankings_resource_versions_allowed
+  type: character
+  description: Team rankings resource versions allowed.
+- name: team_rankings_resource_versions_current
+  type: character
+  description: Team rankings resource versions current.
+- name: team_rankings_resource_methods
+  type: character
+  description: Team rankings resource methods.
+- name: team_rankings_resource_formats
+  type: character
+  description: Team rankings resource formats.
+- name: team_rankings_resource_parameters
+  type: character
+  description: Team rankings resource parameters.
+- name: team_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Team rankings resource auth settings require auth.
+- name: team_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Team rankings resource auth settings allow only.
+- name: team_rankings_resource_resource_cache_ns
+  type: character
+  description: Team rankings resource resource cache ns.
+- name: team_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Team rankings resource resource cache cache keys.
+- name: team_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Team rankings resource resource cache cache buster.
+- name: team_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Team rankings resource expiration message object key name.
+- name: sports_line_team_rankings_resource_location
+  type: character
+  description: Sports line team rankings resource location.
+- name: sports_line_team_rankings_resource_route
+  type: character
+  description: Sports line team rankings resource route.
+- name: sports_line_team_rankings_resource_path
+  type: character
+  description: Sports line team rankings resource path.
+- name: sports_line_team_rankings_resource_summary
+  type: character
+  description: Sports line team rankings resource summary.
+- name: sports_line_team_rankings_resource_notes
+  type: character
+  description: Sports line team rankings resource notes.
+- name: sports_line_team_rankings_resource_versions_allowed
+  type: character
+  description: Sports line team rankings resource versions allowed.
+- name: sports_line_team_rankings_resource_versions_current
+  type: character
+  description: Sports line team rankings resource versions current.
+- name: sports_line_team_rankings_resource_methods
+  type: character
+  description: Sports line team rankings resource methods.
+- name: sports_line_team_rankings_resource_formats
+  type: character
+  description: Sports line team rankings resource formats.
+- name: sports_line_team_rankings_resource_parameters
+  type: character
+  description: Sports line team rankings resource parameters.
+- name: sports_line_team_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Sports line team rankings resource auth settings require auth.
+- name: sports_line_team_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Sports line team rankings resource auth settings allow only.
+- name: sports_line_team_rankings_resource_resource_cache_ns
+  type: character
+  description: Sports line team rankings resource resource cache ns.
+- name: sports_line_team_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Sports line team rankings resource resource cache cache keys.
+- name: sports_line_team_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Sports line team rankings resource resource cache cache buster.
+- name: sports_line_team_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Sports line team rankings resource expiration message object key name.
+- name: team_metadata_resource_location
+  type: character
+  description: Team metadata resource location.
+- name: team_metadata_resource_route
+  type: character
+  description: Team metadata resource route.
+- name: team_metadata_resource_path
+  type: character
+  description: Team metadata resource path.
+- name: team_metadata_resource_summary
+  type: character
+  description: Team metadata resource summary.
+- name: team_metadata_resource_notes
+  type: character
+  description: Team metadata resource notes.
+- name: team_metadata_resource_versions_allowed
+  type: character
+  description: Team metadata resource versions allowed.
+- name: team_metadata_resource_versions_current
+  type: character
+  description: Team metadata resource versions current.
+- name: team_metadata_resource_methods
+  type: character
+  description: Team metadata resource methods.
+- name: team_metadata_resource_formats
+  type: character
+  description: Team metadata resource formats.
+- name: team_metadata_resource_parameters
+  type: character
+  description: Team metadata resource parameters.
+- name: team_metadata_resource_auth_settings_require_auth
+  type: logical
+  description: Team metadata resource auth settings require auth.
+- name: team_metadata_resource_auth_settings_allow_only
+  type: character
+  description: Team metadata resource auth settings allow only.
+- name: team_metadata_resource_resource_cache_ns
+  type: character
+  description: Team metadata resource resource cache ns.
+- name: team_metadata_resource_resource_cache_cache_keys
+  type: character
+  description: Team metadata resource resource cache cache keys.
+- name: team_metadata_resource_resource_cache_cache_buster
+  type: integer
+  description: Team metadata resource resource cache cache buster.
+- name: team_resource_location
+  type: character
+  description: Team resource location.
+- name: team_resource_routes
+  type: character
+  description: Team resource routes.
+- name: team_resource_paths
+  type: character
+  description: Team resource paths.
+- name: team_resource_summary
+  type: character
+  description: Team resource summary.
+- name: team_resource_notes
+  type: character
+  description: Team resource notes.
+- name: team_resource_versions_allowed
+  type: character
+  description: Team resource versions allowed.
+- name: team_resource_versions_current
+  type: character
+  description: Team resource versions current.
+- name: team_resource_methods
+  type: character
+  description: Team resource methods.
+- name: team_resource_formats
+  type: character
+  description: Team resource formats.
+- name: team_resource_parameters
+  type: character
+  description: Team resource parameters.
+- name: team_resource_auth_settings_require_auth
+  type: logical
+  description: Team resource auth settings require auth.
+- name: team_resource_auth_settings_allow_only
+  type: character
+  description: Team resource auth settings allow only.
+- name: team_resource_resource_cache_ns
+  type: character
+  description: Team resource resource cache ns.
+- name: team_resource_resource_cache_cache_keys
+  type: character
+  description: Team resource resource cache cache keys.
+- name: team_resource_resource_cache_cache_buster
+  type: integer
+  description: Team resource resource cache cache buster.
+- name: team_resource_expiration_message_object_key_name
+  type: character
+  description: Team resource expiration message object key name.
+- name: position_rankings_resource_location
+  type: character
+  description: Position rankings resource location.
+- name: position_rankings_resource_route
+  type: character
+  description: Position rankings resource route.
+- name: position_rankings_resource_path
+  type: character
+  description: Position rankings resource path.
+- name: position_rankings_resource_summary
+  type: character
+  description: Position rankings resource summary.
+- name: position_rankings_resource_notes
+  type: character
+  description: Position rankings resource notes.
+- name: position_rankings_resource_versions_allowed
+  type: character
+  description: Position rankings resource versions allowed.
+- name: position_rankings_resource_versions_current
+  type: character
+  description: Position rankings resource versions current.
+- name: position_rankings_resource_methods
+  type: character
+  description: Position rankings resource methods.
+- name: position_rankings_resource_formats
+  type: character
+  description: Position rankings resource formats.
+- name: position_rankings_resource_parameters
+  type: character
+  description: Position rankings resource parameters.
+- name: position_rankings_resource_auth_settings_require_auth
+  type: logical
+  description: Position rankings resource auth settings require auth.
+- name: position_rankings_resource_auth_settings_allow_only
+  type: character
+  description: Position rankings resource auth settings allow only.
+- name: position_rankings_resource_resource_cache_ns
+  type: character
+  description: Position rankings resource resource cache ns.
+- name: position_rankings_resource_resource_cache_cache_keys
+  type: character
+  description: Position rankings resource resource cache cache keys.
+- name: position_rankings_resource_resource_cache_cache_buster
+  type: integer
+  description: Position rankings resource resource cache cache buster.
+- name: position_rankings_resource_expiration_message_object_key_name
+  type: character
+  description: Position rankings resource expiration message object key name.
+- name: player_game_stats_resource_location
+  type: character
+  description: Player game stats resource location.
+- name: player_game_stats_resource_route
+  type: character
+  description: Player game stats resource route.
+- name: player_game_stats_resource_path
+  type: character
+  description: Player game stats resource path.
+- name: player_game_stats_resource_summary
+  type: character
+  description: Player game stats resource summary.
+- name: player_game_stats_resource_notes
+  type: character
+  description: Player game stats resource notes.
+- name: player_game_stats_resource_versions_allowed
+  type: character
+  description: Player game stats resource versions allowed.
+- name: player_game_stats_resource_versions_current
+  type: character
+  description: Player game stats resource versions current.
+- name: player_game_stats_resource_methods
+  type: character
+  description: Player game stats resource methods.
+- name: player_game_stats_resource_formats
+  type: character
+  description: Player game stats resource formats.
+- name: player_game_stats_resource_parameters
+  type: character
+  description: Player game stats resource parameters.
+- name: player_game_stats_resource_auth_settings_require_auth
+  type: logical
+  description: Player game stats resource auth settings require auth.
+- name: player_game_stats_resource_auth_settings_allow_only
+  type: character
+  description: Player game stats resource auth settings allow only.
+- name: player_game_stats_resource_resource_cache_ns
+  type: character
+  description: Player game stats resource resource cache ns.
+- name: player_game_stats_resource_resource_cache_cache_keys
+  type: character
+  description: Player game stats resource resource cache cache keys.
+- name: player_game_stats_resource_resource_cache_cache_buster
+  type: integer
+  description: Player game stats resource resource cache cache buster.
+- name: player_game_stats_resource_expiration_message_object_key_name
+  type: character
+  description: Player game stats resource expiration message object key name.
+- name: ruwt_highlights_resource_location
+  type: character
+  description: Ruwt highlights resource location.
+- name: ruwt_highlights_resource_route
+  type: character
+  description: Ruwt highlights resource route.
+- name: ruwt_highlights_resource_path
+  type: character
+  description: Ruwt highlights resource path.
+- name: ruwt_highlights_resource_summary
+  type: character
+  description: Ruwt highlights resource summary.
+- name: ruwt_highlights_resource_notes
+  type: character
+  description: Ruwt highlights resource notes.
+- name: ruwt_highlights_resource_versions_allowed
+  type: character
+  description: Ruwt highlights resource versions allowed.
+- name: ruwt_highlights_resource_versions_current
+  type: character
+  description: Ruwt highlights resource versions current.
+- name: ruwt_highlights_resource_methods
+  type: character
+  description: Ruwt highlights resource methods.
+- name: ruwt_highlights_resource_formats
+  type: character
+  description: Ruwt highlights resource formats.
+- name: ruwt_highlights_resource_parameters
+  type: character
+  description: Ruwt highlights resource parameters.
+- name: ruwt_highlights_resource_auth_settings_require_auth
+  type: logical
+  description: Ruwt highlights resource auth settings require auth.
+- name: ruwt_highlights_resource_auth_settings_allow_only
+  type: character
+  description: Ruwt highlights resource auth settings allow only.
+- name: ruwt_highlights_resource_resource_cache_ns
+  type: character
+  description: Ruwt highlights resource resource cache ns.
+- name: ruwt_highlights_resource_resource_cache_cache_keys
+  type: character
+  description: Ruwt highlights resource resource cache cache keys.
+- name: ruwt_highlights_resource_resource_cache_cache_buster
+  type: integer
+  description: Ruwt highlights resource resource cache cache buster.
+- name: ruwt_highlights_resource_expiration_message_object_key_name
+  type: character
+  description: Ruwt highlights resource expiration message object key name.
+- name: hockey_player_meta_resource_location
+  type: character
+  description: Hockey player meta resource location.
+- name: hockey_player_meta_resource_route
+  type: character
+  description: Hockey player meta resource route.
+- name: hockey_player_meta_resource_path
+  type: character
+  description: Hockey player meta resource path.
+- name: hockey_player_meta_resource_summary
+  type: character
+  description: Hockey player meta resource summary.
+- name: hockey_player_meta_resource_notes
+  type: character
+  description: Hockey player meta resource notes.
+- name: hockey_player_meta_resource_versions_allowed
+  type: character
+  description: Hockey player meta resource versions allowed.
+- name: hockey_player_meta_resource_versions_current
+  type: character
+  description: Hockey player meta resource versions current.
+- name: hockey_player_meta_resource_methods
+  type: character
+  description: Hockey player meta resource methods.
+- name: hockey_player_meta_resource_formats
+  type: character
+  description: Hockey player meta resource formats.
+- name: hockey_player_meta_resource_parameters
+  type: character
+  description: Hockey player meta resource parameters.
+- name: hockey_player_meta_resource_auth_settings_require_auth
+  type: logical
+  description: Hockey player meta resource auth settings require auth.
+- name: hockey_player_meta_resource_auth_settings_allow_only
+  type: character
+  description: Hockey player meta resource auth settings allow only.
+- name: hockey_player_meta_resource_resource_cache_ns
+  type: character
+  description: Hockey player meta resource resource cache ns.
+- name: hockey_player_meta_resource_resource_cache_cache_keys
+  type: character
+  description: Hockey player meta resource resource cache cache keys.
+- name: hockey_player_meta_resource_resource_cache_cache_buster
+  type: integer
+  description: Hockey player meta resource resource cache cache buster.
+- name: hockey_player_meta_resource_expiration_message_object_key_name
+  type: character
+  description: Hockey player meta resource expiration message object key name.

--- a/tools/codegen/schemas/native/cbs_napi/league.yaml
+++ b/tools/codegen/schemas/native/cbs_napi/league.yaml
@@ -1,8 +1,33 @@
-# CBS NAPI league resource (/resource/league/{league_id}). Generic flattened frame parsed
-# by parse_cbs_napi_list.
-# The CBS NAPI OpenAPI spec ships no typed 200-response schema (every resource is
-# a free-form {data: ...} envelope), so columns are not enumerable ahead of a
-# live capture; the parser snake_cases + flattens whatever keys the payload ships.
+# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. `type` is
+# inferred from the captured JS value; `description` is best-effort from the
+# snake_cased key. Endpoints with no capture remain `columns: []`.
 schema: league
 kind: dataframe
-columns: []
+columns:
+- name: league_id
+  type: integer
+  description: League ID.
+- name: league_abbr
+  type: character
+  description: League abbreviation.
+- name: league_name
+  type: character
+  description: League name.
+- name: sport_id
+  type: integer
+  description: Sport ID.
+- name: league_type
+  type: character
+  description: League type.
+- name: teams
+  type: character
+  description: Teams.
+- name: color_primary
+  type: character
+  description: Color primary.
+- name: color_secondary
+  type: character
+  description: Color secondary.

--- a/tools/codegen/schemas/native/cbs_napi/season_teams.yaml
+++ b/tools/codegen/schemas/native/cbs_napi/season_teams.yaml
@@ -1,8 +1,99 @@
-# CBS NAPI season teams resource (/resource/season/teams/{season_id}). Generic flattened frame parsed
-# by parse_cbs_napi_list.
-# The CBS NAPI OpenAPI spec ships no typed 200-response schema (every resource is
-# a free-form {data: ...} envelope), so columns are not enumerable ahead of a
-# live capture; the parser snake_cases + flattens whatever keys the payload ships.
+# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. `type` is
+# inferred from the captured JS value; `description` is best-effort from the
+# snake_cased key. Endpoints with no capture remain `columns: []`.
 schema: season_teams
 kind: dataframe
-columns: []
+columns:
+- name: team_id
+  type: integer
+  description: Team ID.
+- name: stub_hub_team_id
+  type: character
+  description: Stub hub team ID.
+- name: location
+  type: character
+  description: Location.
+- name: nick_name
+  type: character
+  description: Nick name.
+- name: medium_name
+  type: character
+  description: Medium name.
+- name: short_name
+  type: character
+  description: Short name.
+- name: abbrev
+  type: character
+  description: Abbrev.
+- name: status
+  type: character
+  description: Status.
+- name: home_venue_id
+  type: integer
+  description: Home venue ID.
+- name: conference_id
+  type: integer
+  description: Conference ID.
+- name: league_id
+  type: integer
+  description: League ID.
+- name: division_id
+  type: character
+  description: Division ID.
+- name: ticket_url
+  type: character
+  description: Ticket URL.
+- name: color_hex_dex
+  type: character
+  description: Color hex dex.
+- name: color_primary_hex
+  type: character
+  description: Color primary hex.
+- name: color_secondary_hex
+  type: character
+  description: Color secondary hex.
+- name: players
+  type: character
+  description: Players.
+- name: league
+  type: character
+  description: League.
+- name: standings
+  type: character
+  description: Standings.
+- name: conference
+  type: character
+  description: Conference.
+- name: division
+  type: character
+  description: Division.
+- name: team_seasons
+  type: character
+  description: Team seasons.
+- name: polls
+  type: character
+  description: Polls.
+- name: home_venue
+  type: character
+  description: Home venue.
+- name: sports_line_standings
+  type: character
+  description: Sports line standings.
+- name: team_stats
+  type: character
+  description: Team stats.
+- name: team_rankings
+  type: character
+  description: Team rankings.
+- name: sports_line_rankings
+  type: character
+  description: Sports line rankings.
+- name: meta_tsa_overlay
+  type: logical
+  description: Meta tsa overlay.
+- name: meta_season_id
+  type: integer
+  description: Meta season ID.

--- a/tools/codegen/schemas/native/cbs_napi/team_players.yaml
+++ b/tools/codegen/schemas/native/cbs_napi/team_players.yaml
@@ -1,8 +1,102 @@
-# CBS NAPI team players resource (/resource/team/players/{team_id}). Generic flattened frame parsed
-# by parse_cbs_napi_list.
-# The CBS NAPI OpenAPI spec ships no typed 200-response schema (every resource is
-# a free-form {data: ...} envelope), so columns are not enumerable ahead of a
-# live capture; the parser snake_cases + flattens whatever keys the payload ships.
+# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. `type` is
+# inferred from the captured JS value; `description` is best-effort from the
+# snake_cased key. Endpoints with no capture remain `columns: []`.
 schema: team_players
 kind: dataframe
-columns: []
+columns:
+- name: player_id
+  type: integer
+  description: Player ID.
+- name: first_name
+  type: character
+  description: First name.
+- name: full_first_name
+  type: character
+  description: Full first name.
+- name: last_name
+  type: character
+  description: Last name.
+- name: full_last_name
+  type: character
+  description: Full last name.
+- name: nick_name
+  type: character
+  description: Nick name.
+- name: height
+  type: character
+  description: Height.
+- name: weight
+  type: integer
+  description: Weight.
+- name: experience
+  type: integer
+  description: Experience.
+- name: school
+  type: character
+  description: School.
+- name: home_town
+  type: character
+  description: Home town.
+- name: debut
+  type: character
+  description: Debut.
+- name: birth_date
+  type: character
+  description: Birth date.
+- name: birth_country
+  type: character
+  description: Birth country.
+- name: birth_country_code
+  type: character
+  description: Birth country code.
+- name: nationality_country
+  type: character
+  description: Nationality country.
+- name: nationality_country_code
+  type: character
+  description: Nationality country code.
+- name: locked
+  type: integer
+  description: Locked.
+- name: player_team_associations
+  type: character
+  description: Player team associations.
+- name: injuries
+  type: character
+  description: Injuries.
+- name: transactions
+  type: character
+  description: Transactions.
+- name: depth_charts
+  type: character
+  description: Depth charts.
+- name: position_rankings
+  type: character
+  description: Position rankings.
+- name: player_stats
+  type: character
+  description: Player stats.
+- name: standings
+  type: character
+  description: Standings.
+- name: rankings
+  type: character
+  description: Rankings.
+- name: player_outlook
+  type: character
+  description: Player outlook.
+- name: meta_data
+  type: character
+  description: Meta data.
+- name: draft_info
+  type: character
+  description: Draft info.
+- name: game_stats
+  type: character
+  description: Game stats.
+- name: combine_data
+  type: character
+  description: Combine data.

--- a/tools/codegen/schemas/native/cbs_napi/team_standings.yaml
+++ b/tools/codegen/schemas/native/cbs_napi/team_standings.yaml
@@ -1,8 +1,1206 @@
-# CBS NAPI standings resource (/resource/team/standings/{team_id}). One row per standings entry, parsed
-# by parse_cbs_napi_standings.
-# The CBS NAPI OpenAPI spec ships no typed 200-response schema (every resource is
-# a free-form {data: ...} envelope), so columns are not enumerable ahead of a
-# live capture; the parser snake_cases + flattens whatever keys the payload ships.
+# CBS NAPI returns schema — columns DERIVED from a captured live response run
+# through the registered parser (parse_cbs_napi_*). The CBS NAPI OpenAPI spec
+# ships no typed 200-response schema, so columns are not enumerable from the
+# spec; they are enumerated here from a representative capture. `type` is
+# inferred from the captured JS value; `description` is best-effort from the
+# snake_cased key. Endpoints with no capture remain `columns: []`.
 schema: team_standings
 kind: dataframe
-columns: []
+columns:
+- name: 2016_regular_wins_number
+  type: integer
+  description: 2016 regular wins number.
+- name: 2016_regular_goals_for_goals
+  type: integer
+  description: 2016 regular goals for goals.
+- name: 2016_regular_last_results_r2
+  type: character
+  description: 2016 regular last results r2.
+- name: 2016_regular_last_results_r3
+  type: character
+  description: 2016 regular last results r3.
+- name: 2016_regular_last_results_r4
+  type: character
+  description: 2016 regular last results r4.
+- name: 2016_regular_last_results_r5
+  type: character
+  description: 2016 regular last results r5.
+- name: 2016_regular_last_results_r1
+  type: character
+  description: 2016 regular last results r1.
+- name: 2016_regular_winning_percentage_percentage
+  type: character
+  description: 2016 regular winning percentage percentage.
+- name: 2016_regular_goals_against_goals
+  type: integer
+  description: 2016 regular goals against goals.
+- name: 2016_regular_streak
+  type: character
+  description: 2016 regular streak.
+- name: 2016_regular_losses_number
+  type: integer
+  description: 2016 regular losses number.
+- name: 2016_regular_points_penalty_points
+  type: integer
+  description: 2016 regular points penalty points.
+- name: 2016_regular_points_points_per_game
+  type: number
+  description: 2016 regular points points per game.
+- name: 2016_regular_points_points
+  type: integer
+  description: 2016 regular points points.
+- name: 2016_regular_ties_number
+  type: integer
+  description: 2016 regular ties number.
+- name: 2016_regular_games_played_games
+  type: integer
+  description: 2016 regular games played games.
+- name: 2016_regular_place_previous
+  type: integer
+  description: 2016 regular place previous.
+- name: 2016_regular_place_season_end_id
+  type: character
+  description: 2016 regular place season end ID.
+- name: 2016_regular_place_season_end
+  type: character
+  description: 2016 regular place season end.
+- name: 2016_regular_place_place
+  type: integer
+  description: 2016 regular place place.
+- name: 2016_regular_clinch_status_id
+  type: integer
+  description: 2016 regular clinch status ID.
+- name: 2016_regular_clinch_status_status
+  type: character
+  description: 2016 regular clinch status status.
+- name: 2016_regular_win_loss_record
+  type: character
+  description: 2016 regular win loss record.
+- name: 2016_regular_team_info_display_name
+  type: character
+  description: 2016 regular team info display name.
+- name: 2016_regular_team_info_name
+  type: character
+  description: 2016 regular team info name.
+- name: 2016_regular_team_info_alias
+  type: character
+  description: 2016 regular team info alias.
+- name: 2016_regular_team_info_location
+  type: character
+  description: 2016 regular team info location.
+- name: 2016_regular_team_info_id
+  type: integer
+  description: 2016 regular team info ID.
+- name: 2016_regular_team_info_global_id
+  type: integer
+  description: 2016 regular team info global ID.
+- name: 2016_regular_season_id
+  type: integer
+  description: 2016 regular season ID.
+- name: 2016_regular_season_season_id
+  type: integer
+  description: 2016 regular season season ID.
+- name: 2016_regular_season_sport_id
+  type: integer
+  description: 2016 regular season sport ID.
+- name: 2016_regular_season_league_id
+  type: integer
+  description: 2016 regular season league ID.
+- name: 2016_regular_season_league
+  type: character
+  description: 2016 regular season league.
+- name: 2016_regular_season_teams
+  type: character
+  description: 2016 regular season teams.
+- name: 2016_regular_season_season_year
+  type: integer
+  description: 2016 regular season season year.
+- name: 2016_regular_season_is_current
+  type: integer
+  description: 2016 regular season is current.
+- name: 2016_regular_season_season_type
+  type: character
+  description: 2016 regular season season type.
+- name: 2016_regular_season_season_type_desc
+  type: character
+  description: 2016 regular season season type desc.
+- name: 2016_regular_season_season_start_date
+  type: character
+  description: 2016 regular season season start date.
+- name: 2016_regular_season_season_end_date
+  type: character
+  description: 2016 regular season season end date.
+- name: 2017_regular_wins_number
+  type: integer
+  description: 2017 regular wins number.
+- name: 2017_regular_goals_for_goals
+  type: integer
+  description: 2017 regular goals for goals.
+- name: 2017_regular_last_results_r2
+  type: character
+  description: 2017 regular last results r2.
+- name: 2017_regular_last_results_r3
+  type: character
+  description: 2017 regular last results r3.
+- name: 2017_regular_last_results_r4
+  type: character
+  description: 2017 regular last results r4.
+- name: 2017_regular_last_results_r5
+  type: character
+  description: 2017 regular last results r5.
+- name: 2017_regular_last_results_r1
+  type: character
+  description: 2017 regular last results r1.
+- name: 2017_regular_winning_percentage_percentage
+  type: character
+  description: 2017 regular winning percentage percentage.
+- name: 2017_regular_goals_against_goals
+  type: integer
+  description: 2017 regular goals against goals.
+- name: 2017_regular_streak
+  type: character
+  description: 2017 regular streak.
+- name: 2017_regular_losses_number
+  type: integer
+  description: 2017 regular losses number.
+- name: 2017_regular_points_penalty_points
+  type: integer
+  description: 2017 regular points penalty points.
+- name: 2017_regular_points_points_per_game
+  type: number
+  description: 2017 regular points points per game.
+- name: 2017_regular_points_points
+  type: integer
+  description: 2017 regular points points.
+- name: 2017_regular_ties_number
+  type: integer
+  description: 2017 regular ties number.
+- name: 2017_regular_games_played_games
+  type: integer
+  description: 2017 regular games played games.
+- name: 2017_regular_place_previous
+  type: integer
+  description: 2017 regular place previous.
+- name: 2017_regular_place_season_end_id
+  type: character
+  description: 2017 regular place season end ID.
+- name: 2017_regular_place_place
+  type: integer
+  description: 2017 regular place place.
+- name: 2017_regular_place_season_end
+  type: character
+  description: 2017 regular place season end.
+- name: 2017_regular_win_loss_record
+  type: character
+  description: 2017 regular win loss record.
+- name: 2017_regular_team_info_display_name
+  type: character
+  description: 2017 regular team info display name.
+- name: 2017_regular_team_info_name
+  type: character
+  description: 2017 regular team info name.
+- name: 2017_regular_team_info_alias
+  type: character
+  description: 2017 regular team info alias.
+- name: 2017_regular_team_info_location
+  type: character
+  description: 2017 regular team info location.
+- name: 2017_regular_team_info_global_id
+  type: integer
+  description: 2017 regular team info global ID.
+- name: 2017_regular_team_info_id
+  type: integer
+  description: 2017 regular team info ID.
+- name: 2017_regular_season_id
+  type: integer
+  description: 2017 regular season ID.
+- name: 2017_regular_season_season_id
+  type: integer
+  description: 2017 regular season season ID.
+- name: 2017_regular_season_sport_id
+  type: integer
+  description: 2017 regular season sport ID.
+- name: 2017_regular_season_league_id
+  type: integer
+  description: 2017 regular season league ID.
+- name: 2017_regular_season_league
+  type: character
+  description: 2017 regular season league.
+- name: 2017_regular_season_teams
+  type: character
+  description: 2017 regular season teams.
+- name: 2017_regular_season_season_year
+  type: integer
+  description: 2017 regular season season year.
+- name: 2017_regular_season_is_current
+  type: integer
+  description: 2017 regular season is current.
+- name: 2017_regular_season_season_type
+  type: character
+  description: 2017 regular season season type.
+- name: 2017_regular_season_season_type_desc
+  type: character
+  description: 2017 regular season season type desc.
+- name: 2017_regular_season_season_start_date
+  type: character
+  description: 2017 regular season season start date.
+- name: 2017_regular_season_season_end_date
+  type: character
+  description: 2017 regular season season end date.
+- name: 2018_regular_wins_number
+  type: integer
+  description: 2018 regular wins number.
+- name: 2018_regular_goals_for_goals
+  type: integer
+  description: 2018 regular goals for goals.
+- name: 2018_regular_last_results_r2
+  type: character
+  description: 2018 regular last results r2.
+- name: 2018_regular_last_results_r3
+  type: character
+  description: 2018 regular last results r3.
+- name: 2018_regular_last_results_r4
+  type: character
+  description: 2018 regular last results r4.
+- name: 2018_regular_last_results_r5
+  type: character
+  description: 2018 regular last results r5.
+- name: 2018_regular_last_results_r1
+  type: character
+  description: 2018 regular last results r1.
+- name: 2018_regular_winning_percentage_percentage
+  type: character
+  description: 2018 regular winning percentage percentage.
+- name: 2018_regular_goals_against_goals
+  type: integer
+  description: 2018 regular goals against goals.
+- name: 2018_regular_streak
+  type: character
+  description: 2018 regular streak.
+- name: 2018_regular_losses_number
+  type: integer
+  description: 2018 regular losses number.
+- name: 2018_regular_points_penalty_points
+  type: integer
+  description: 2018 regular points penalty points.
+- name: 2018_regular_points_points_per_game
+  type: number
+  description: 2018 regular points points per game.
+- name: 2018_regular_points_points
+  type: integer
+  description: 2018 regular points points.
+- name: 2018_regular_ties_number
+  type: integer
+  description: 2018 regular ties number.
+- name: 2018_regular_games_played_games
+  type: integer
+  description: 2018 regular games played games.
+- name: 2018_regular_place_previous
+  type: integer
+  description: 2018 regular place previous.
+- name: 2018_regular_place_season_end_id
+  type: integer
+  description: 2018 regular place season end ID.
+- name: 2018_regular_place_place
+  type: integer
+  description: 2018 regular place place.
+- name: 2018_regular_place_season_end
+  type: character
+  description: 2018 regular place season end.
+- name: 2018_regular_clinch_status_id
+  type: integer
+  description: 2018 regular clinch status ID.
+- name: 2018_regular_clinch_status_status
+  type: character
+  description: 2018 regular clinch status status.
+- name: 2018_regular_win_loss_record
+  type: character
+  description: 2018 regular win loss record.
+- name: 2018_regular_team_info_display_name
+  type: character
+  description: 2018 regular team info display name.
+- name: 2018_regular_team_info_name
+  type: character
+  description: 2018 regular team info name.
+- name: 2018_regular_team_info_alias
+  type: character
+  description: 2018 regular team info alias.
+- name: 2018_regular_team_info_location
+  type: character
+  description: 2018 regular team info location.
+- name: 2018_regular_team_info_global_id
+  type: integer
+  description: 2018 regular team info global ID.
+- name: 2018_regular_team_info_id
+  type: integer
+  description: 2018 regular team info ID.
+- name: 2018_regular_season_id
+  type: integer
+  description: 2018 regular season ID.
+- name: 2018_regular_season_season_id
+  type: integer
+  description: 2018 regular season season ID.
+- name: 2018_regular_season_sport_id
+  type: integer
+  description: 2018 regular season sport ID.
+- name: 2018_regular_season_league_id
+  type: integer
+  description: 2018 regular season league ID.
+- name: 2018_regular_season_league
+  type: character
+  description: 2018 regular season league.
+- name: 2018_regular_season_teams
+  type: character
+  description: 2018 regular season teams.
+- name: 2018_regular_season_season_year
+  type: integer
+  description: 2018 regular season season year.
+- name: 2018_regular_season_is_current
+  type: integer
+  description: 2018 regular season is current.
+- name: 2018_regular_season_season_type
+  type: character
+  description: 2018 regular season season type.
+- name: 2018_regular_season_season_type_desc
+  type: character
+  description: 2018 regular season season type desc.
+- name: 2018_regular_season_season_start_date
+  type: character
+  description: 2018 regular season season start date.
+- name: 2018_regular_season_season_end_date
+  type: character
+  description: 2018 regular season season end date.
+- name: 2019_regular_wins_number
+  type: integer
+  description: 2019 regular wins number.
+- name: 2019_regular_goals_for_goals
+  type: integer
+  description: 2019 regular goals for goals.
+- name: 2019_regular_last_results_r2
+  type: character
+  description: 2019 regular last results r2.
+- name: 2019_regular_last_results_r3
+  type: character
+  description: 2019 regular last results r3.
+- name: 2019_regular_last_results_r4
+  type: character
+  description: 2019 regular last results r4.
+- name: 2019_regular_last_results_r5
+  type: character
+  description: 2019 regular last results r5.
+- name: 2019_regular_last_results_r1
+  type: character
+  description: 2019 regular last results r1.
+- name: 2019_regular_winning_percentage_percentage
+  type: character
+  description: 2019 regular winning percentage percentage.
+- name: 2019_regular_goals_against_goals
+  type: integer
+  description: 2019 regular goals against goals.
+- name: 2019_regular_streak
+  type: character
+  description: 2019 regular streak.
+- name: 2019_regular_losses_number
+  type: integer
+  description: 2019 regular losses number.
+- name: 2019_regular_points_penalty_points
+  type: integer
+  description: 2019 regular points penalty points.
+- name: 2019_regular_points_points_per_game
+  type: number
+  description: 2019 regular points points per game.
+- name: 2019_regular_points_points
+  type: integer
+  description: 2019 regular points points.
+- name: 2019_regular_ties_number
+  type: integer
+  description: 2019 regular ties number.
+- name: 2019_regular_games_played_games
+  type: integer
+  description: 2019 regular games played games.
+- name: 2019_regular_place_previous
+  type: integer
+  description: 2019 regular place previous.
+- name: 2019_regular_place_season_end_id
+  type: character
+  description: 2019 regular place season end ID.
+- name: 2019_regular_place_place
+  type: integer
+  description: 2019 regular place place.
+- name: 2019_regular_place_season_end
+  type: character
+  description: 2019 regular place season end.
+- name: 2019_regular_clinch_status_id
+  type: integer
+  description: 2019 regular clinch status ID.
+- name: 2019_regular_clinch_status_status
+  type: character
+  description: 2019 regular clinch status status.
+- name: 2019_regular_win_loss_record
+  type: character
+  description: 2019 regular win loss record.
+- name: 2019_regular_team_info_display_name
+  type: character
+  description: 2019 regular team info display name.
+- name: 2019_regular_team_info_name
+  type: character
+  description: 2019 regular team info name.
+- name: 2019_regular_team_info_alias
+  type: character
+  description: 2019 regular team info alias.
+- name: 2019_regular_team_info_location
+  type: character
+  description: 2019 regular team info location.
+- name: 2019_regular_team_info_global_id
+  type: integer
+  description: 2019 regular team info global ID.
+- name: 2019_regular_team_info_id
+  type: integer
+  description: 2019 regular team info ID.
+- name: 2019_regular_season_id
+  type: integer
+  description: 2019 regular season ID.
+- name: 2019_regular_season_season_id
+  type: integer
+  description: 2019 regular season season ID.
+- name: 2019_regular_season_sport_id
+  type: integer
+  description: 2019 regular season sport ID.
+- name: 2019_regular_season_league_id
+  type: integer
+  description: 2019 regular season league ID.
+- name: 2019_regular_season_league
+  type: character
+  description: 2019 regular season league.
+- name: 2019_regular_season_teams
+  type: character
+  description: 2019 regular season teams.
+- name: 2019_regular_season_season_year
+  type: integer
+  description: 2019 regular season season year.
+- name: 2019_regular_season_is_current
+  type: integer
+  description: 2019 regular season is current.
+- name: 2019_regular_season_season_type
+  type: character
+  description: 2019 regular season season type.
+- name: 2019_regular_season_season_type_desc
+  type: character
+  description: 2019 regular season season type desc.
+- name: 2019_regular_season_season_start_date
+  type: character
+  description: 2019 regular season season start date.
+- name: 2019_regular_season_season_end_date
+  type: character
+  description: 2019 regular season season end date.
+- name: 2020_regular_wins_number
+  type: integer
+  description: 2020 regular wins number.
+- name: 2020_regular_goals_for_goals
+  type: integer
+  description: 2020 regular goals for goals.
+- name: 2020_regular_last_results_r2
+  type: character
+  description: 2020 regular last results r2.
+- name: 2020_regular_last_results_r3
+  type: character
+  description: 2020 regular last results r3.
+- name: 2020_regular_last_results_r4
+  type: character
+  description: 2020 regular last results r4.
+- name: 2020_regular_last_results_r5
+  type: character
+  description: 2020 regular last results r5.
+- name: 2020_regular_last_results_r1
+  type: character
+  description: 2020 regular last results r1.
+- name: 2020_regular_winning_percentage_percentage
+  type: character
+  description: 2020 regular winning percentage percentage.
+- name: 2020_regular_goals_against_goals
+  type: integer
+  description: 2020 regular goals against goals.
+- name: 2020_regular_streak
+  type: character
+  description: 2020 regular streak.
+- name: 2020_regular_losses_number
+  type: integer
+  description: 2020 regular losses number.
+- name: 2020_regular_points_penalty_points
+  type: integer
+  description: 2020 regular points penalty points.
+- name: 2020_regular_points_points_per_game
+  type: number
+  description: 2020 regular points points per game.
+- name: 2020_regular_points_points
+  type: integer
+  description: 2020 regular points points.
+- name: 2020_regular_ties_number
+  type: integer
+  description: 2020 regular ties number.
+- name: 2020_regular_games_played_games
+  type: integer
+  description: 2020 regular games played games.
+- name: 2020_regular_place_previous
+  type: integer
+  description: 2020 regular place previous.
+- name: 2020_regular_place_season_end_id
+  type: character
+  description: 2020 regular place season end ID.
+- name: 2020_regular_place_place
+  type: integer
+  description: 2020 regular place place.
+- name: 2020_regular_place_season_end
+  type: character
+  description: 2020 regular place season end.
+- name: 2020_regular_goal_differential_differential
+  type: integer
+  description: 2020 regular goal differential differential.
+- name: 2020_regular_win_loss_record
+  type: character
+  description: 2020 regular win loss record.
+- name: 2020_regular_team_info_display_name
+  type: character
+  description: 2020 regular team info display name.
+- name: 2020_regular_team_info_name
+  type: character
+  description: 2020 regular team info name.
+- name: 2020_regular_team_info_alias
+  type: character
+  description: 2020 regular team info alias.
+- name: 2020_regular_team_info_location
+  type: character
+  description: 2020 regular team info location.
+- name: 2020_regular_team_info_global_id
+  type: integer
+  description: 2020 regular team info global ID.
+- name: 2020_regular_team_info_id
+  type: integer
+  description: 2020 regular team info ID.
+- name: 2020_regular_season_id
+  type: integer
+  description: 2020 regular season ID.
+- name: 2020_regular_season_season_id
+  type: integer
+  description: 2020 regular season season ID.
+- name: 2020_regular_season_sport_id
+  type: integer
+  description: 2020 regular season sport ID.
+- name: 2020_regular_season_league_id
+  type: integer
+  description: 2020 regular season league ID.
+- name: 2020_regular_season_league
+  type: character
+  description: 2020 regular season league.
+- name: 2020_regular_season_teams
+  type: character
+  description: 2020 regular season teams.
+- name: 2020_regular_season_season_year
+  type: integer
+  description: 2020 regular season season year.
+- name: 2020_regular_season_is_current
+  type: integer
+  description: 2020 regular season is current.
+- name: 2020_regular_season_season_type
+  type: character
+  description: 2020 regular season season type.
+- name: 2020_regular_season_season_type_desc
+  type: character
+  description: 2020 regular season season type desc.
+- name: 2020_regular_season_season_start_date
+  type: character
+  description: 2020 regular season season start date.
+- name: 2020_regular_season_season_end_date
+  type: character
+  description: 2020 regular season season end date.
+- name: 2021_regular_wins_number
+  type: integer
+  description: 2021 regular wins number.
+- name: 2021_regular_goals_for_goals
+  type: integer
+  description: 2021 regular goals for goals.
+- name: 2021_regular_last_results_r2
+  type: character
+  description: 2021 regular last results r2.
+- name: 2021_regular_last_results_r3
+  type: character
+  description: 2021 regular last results r3.
+- name: 2021_regular_last_results_r4
+  type: character
+  description: 2021 regular last results r4.
+- name: 2021_regular_last_results_r5
+  type: character
+  description: 2021 regular last results r5.
+- name: 2021_regular_last_results_r1
+  type: character
+  description: 2021 regular last results r1.
+- name: 2021_regular_winning_percentage_percentage
+  type: character
+  description: 2021 regular winning percentage percentage.
+- name: 2021_regular_goals_against_goals
+  type: integer
+  description: 2021 regular goals against goals.
+- name: 2021_regular_streak
+  type: character
+  description: 2021 regular streak.
+- name: 2021_regular_losses_number
+  type: integer
+  description: 2021 regular losses number.
+- name: 2021_regular_points_penalty_points
+  type: integer
+  description: 2021 regular points penalty points.
+- name: 2021_regular_points_points_per_game
+  type: number
+  description: 2021 regular points points per game.
+- name: 2021_regular_points_points
+  type: integer
+  description: 2021 regular points points.
+- name: 2021_regular_ties_number
+  type: integer
+  description: 2021 regular ties number.
+- name: 2021_regular_games_played_games
+  type: integer
+  description: 2021 regular games played games.
+- name: 2021_regular_place_previous
+  type: integer
+  description: 2021 regular place previous.
+- name: 2021_regular_place_season_end_id
+  type: integer
+  description: 2021 regular place season end ID.
+- name: 2021_regular_place_place
+  type: integer
+  description: 2021 regular place place.
+- name: 2021_regular_place_season_end
+  type: character
+  description: 2021 regular place season end.
+- name: 2021_regular_clinch_status_id
+  type: integer
+  description: 2021 regular clinch status ID.
+- name: 2021_regular_clinch_status_status
+  type: character
+  description: 2021 regular clinch status status.
+- name: 2021_regular_goal_differential_differential
+  type: integer
+  description: 2021 regular goal differential differential.
+- name: 2021_regular_win_loss_record
+  type: character
+  description: 2021 regular win loss record.
+- name: 2021_regular_team_info_display_name
+  type: character
+  description: 2021 regular team info display name.
+- name: 2021_regular_team_info_name
+  type: character
+  description: 2021 regular team info name.
+- name: 2021_regular_team_info_alias
+  type: character
+  description: 2021 regular team info alias.
+- name: 2021_regular_team_info_location
+  type: character
+  description: 2021 regular team info location.
+- name: 2021_regular_team_info_global_id
+  type: integer
+  description: 2021 regular team info global ID.
+- name: 2021_regular_team_info_id
+  type: integer
+  description: 2021 regular team info ID.
+- name: 2021_regular_season_id
+  type: integer
+  description: 2021 regular season ID.
+- name: 2021_regular_season_season_id
+  type: integer
+  description: 2021 regular season season ID.
+- name: 2021_regular_season_sport_id
+  type: integer
+  description: 2021 regular season sport ID.
+- name: 2021_regular_season_league_id
+  type: integer
+  description: 2021 regular season league ID.
+- name: 2021_regular_season_league
+  type: character
+  description: 2021 regular season league.
+- name: 2021_regular_season_teams
+  type: character
+  description: 2021 regular season teams.
+- name: 2021_regular_season_season_year
+  type: integer
+  description: 2021 regular season season year.
+- name: 2021_regular_season_is_current
+  type: integer
+  description: 2021 regular season is current.
+- name: 2021_regular_season_season_type
+  type: character
+  description: 2021 regular season season type.
+- name: 2021_regular_season_season_type_desc
+  type: character
+  description: 2021 regular season season type desc.
+- name: 2021_regular_season_season_start_date
+  type: character
+  description: 2021 regular season season start date.
+- name: 2021_regular_season_season_end_date
+  type: character
+  description: 2021 regular season season end date.
+- name: 2022_regular_wins_number
+  type: integer
+  description: 2022 regular wins number.
+- name: 2022_regular_goals_for_goals
+  type: integer
+  description: 2022 regular goals for goals.
+- name: 2022_regular_last_results_r2
+  type: character
+  description: 2022 regular last results r2.
+- name: 2022_regular_last_results_r3
+  type: character
+  description: 2022 regular last results r3.
+- name: 2022_regular_last_results_r4
+  type: character
+  description: 2022 regular last results r4.
+- name: 2022_regular_last_results_r5
+  type: character
+  description: 2022 regular last results r5.
+- name: 2022_regular_last_results_r1
+  type: character
+  description: 2022 regular last results r1.
+- name: 2022_regular_winning_percentage_percentage
+  type: character
+  description: 2022 regular winning percentage percentage.
+- name: 2022_regular_goals_against_goals
+  type: integer
+  description: 2022 regular goals against goals.
+- name: 2022_regular_streak
+  type: character
+  description: 2022 regular streak.
+- name: 2022_regular_losses_number
+  type: integer
+  description: 2022 regular losses number.
+- name: 2022_regular_points_penalty_points
+  type: integer
+  description: 2022 regular points penalty points.
+- name: 2022_regular_points_points_per_game
+  type: number
+  description: 2022 regular points points per game.
+- name: 2022_regular_points_points
+  type: integer
+  description: 2022 regular points points.
+- name: 2022_regular_ties_number
+  type: integer
+  description: 2022 regular ties number.
+- name: 2022_regular_games_played_games
+  type: integer
+  description: 2022 regular games played games.
+- name: 2022_regular_place_previous
+  type: integer
+  description: 2022 regular place previous.
+- name: 2022_regular_place_season_end_id
+  type: character
+  description: 2022 regular place season end ID.
+- name: 2022_regular_place_place
+  type: integer
+  description: 2022 regular place place.
+- name: 2022_regular_place_season_end
+  type: character
+  description: 2022 regular place season end.
+- name: 2022_regular_win_loss_record
+  type: character
+  description: 2022 regular win loss record.
+- name: 2022_regular_team_info_display_name
+  type: character
+  description: 2022 regular team info display name.
+- name: 2022_regular_team_info_name
+  type: character
+  description: 2022 regular team info name.
+- name: 2022_regular_team_info_alias
+  type: character
+  description: 2022 regular team info alias.
+- name: 2022_regular_team_info_location
+  type: character
+  description: 2022 regular team info location.
+- name: 2022_regular_team_info_global_id
+  type: integer
+  description: 2022 regular team info global ID.
+- name: 2022_regular_team_info_id
+  type: integer
+  description: 2022 regular team info ID.
+- name: 2022_regular_season_id
+  type: integer
+  description: 2022 regular season ID.
+- name: 2022_regular_season_season_id
+  type: integer
+  description: 2022 regular season season ID.
+- name: 2022_regular_season_sport_id
+  type: integer
+  description: 2022 regular season sport ID.
+- name: 2022_regular_season_league_id
+  type: integer
+  description: 2022 regular season league ID.
+- name: 2022_regular_season_league
+  type: character
+  description: 2022 regular season league.
+- name: 2022_regular_season_teams
+  type: character
+  description: 2022 regular season teams.
+- name: 2022_regular_season_season_year
+  type: integer
+  description: 2022 regular season season year.
+- name: 2022_regular_season_is_current
+  type: integer
+  description: 2022 regular season is current.
+- name: 2022_regular_season_season_type
+  type: character
+  description: 2022 regular season season type.
+- name: 2022_regular_season_season_type_desc
+  type: character
+  description: 2022 regular season season type desc.
+- name: 2022_regular_season_season_start_date
+  type: character
+  description: 2022 regular season season start date.
+- name: 2022_regular_season_season_end_date
+  type: character
+  description: 2022 regular season season end date.
+- name: 2023_regular_wins_number
+  type: integer
+  description: 2023 regular wins number.
+- name: 2023_regular_goals_for_goals
+  type: integer
+  description: 2023 regular goals for goals.
+- name: 2023_regular_last_results_r2
+  type: character
+  description: 2023 regular last results r2.
+- name: 2023_regular_last_results_r3
+  type: character
+  description: 2023 regular last results r3.
+- name: 2023_regular_last_results_r4
+  type: character
+  description: 2023 regular last results r4.
+- name: 2023_regular_last_results_r5
+  type: character
+  description: 2023 regular last results r5.
+- name: 2023_regular_last_results_r1
+  type: character
+  description: 2023 regular last results r1.
+- name: 2023_regular_winning_percentage_percentage
+  type: character
+  description: 2023 regular winning percentage percentage.
+- name: 2023_regular_goals_against_goals
+  type: integer
+  description: 2023 regular goals against goals.
+- name: 2023_regular_streak
+  type: character
+  description: 2023 regular streak.
+- name: 2023_regular_losses_number
+  type: integer
+  description: 2023 regular losses number.
+- name: 2023_regular_points_penalty_points
+  type: integer
+  description: 2023 regular points penalty points.
+- name: 2023_regular_points_points_per_game
+  type: number
+  description: 2023 regular points points per game.
+- name: 2023_regular_points_points
+  type: integer
+  description: 2023 regular points points.
+- name: 2023_regular_ties_number
+  type: integer
+  description: 2023 regular ties number.
+- name: 2023_regular_games_played_games
+  type: integer
+  description: 2023 regular games played games.
+- name: 2023_regular_place_previous
+  type: integer
+  description: 2023 regular place previous.
+- name: 2023_regular_place_season_end_id
+  type: character
+  description: 2023 regular place season end ID.
+- name: 2023_regular_place_place
+  type: integer
+  description: 2023 regular place place.
+- name: 2023_regular_place_season_end
+  type: character
+  description: 2023 regular place season end.
+- name: 2023_regular_goal_differential_differential
+  type: integer
+  description: 2023 regular goal differential differential.
+- name: 2023_regular_win_loss_record
+  type: character
+  description: 2023 regular win loss record.
+- name: 2023_regular_team_info_display_name
+  type: character
+  description: 2023 regular team info display name.
+- name: 2023_regular_team_info_name
+  type: character
+  description: 2023 regular team info name.
+- name: 2023_regular_team_info_alias
+  type: character
+  description: 2023 regular team info alias.
+- name: 2023_regular_team_info_location
+  type: character
+  description: 2023 regular team info location.
+- name: 2023_regular_team_info_global_id
+  type: integer
+  description: 2023 regular team info global ID.
+- name: 2023_regular_team_info_id
+  type: integer
+  description: 2023 regular team info ID.
+- name: 2023_regular_season_id
+  type: integer
+  description: 2023 regular season ID.
+- name: 2023_regular_season_season_id
+  type: integer
+  description: 2023 regular season season ID.
+- name: 2023_regular_season_sport_id
+  type: integer
+  description: 2023 regular season sport ID.
+- name: 2023_regular_season_league_id
+  type: integer
+  description: 2023 regular season league ID.
+- name: 2023_regular_season_league
+  type: character
+  description: 2023 regular season league.
+- name: 2023_regular_season_teams
+  type: character
+  description: 2023 regular season teams.
+- name: 2023_regular_season_season_year
+  type: integer
+  description: 2023 regular season season year.
+- name: 2023_regular_season_is_current
+  type: integer
+  description: 2023 regular season is current.
+- name: 2023_regular_season_season_type
+  type: character
+  description: 2023 regular season season type.
+- name: 2023_regular_season_season_type_desc
+  type: character
+  description: 2023 regular season season type desc.
+- name: 2023_regular_season_season_start_date
+  type: character
+  description: 2023 regular season season start date.
+- name: 2023_regular_season_season_end_date
+  type: character
+  description: 2023 regular season season end date.
+- name: 2024_regular_wins_number
+  type: integer
+  description: 2024 regular wins number.
+- name: 2024_regular_goals_for_goals
+  type: integer
+  description: 2024 regular goals for goals.
+- name: 2024_regular_last_results_r2
+  type: character
+  description: 2024 regular last results r2.
+- name: 2024_regular_last_results_r3
+  type: character
+  description: 2024 regular last results r3.
+- name: 2024_regular_last_results_r4
+  type: character
+  description: 2024 regular last results r4.
+- name: 2024_regular_last_results_r5
+  type: character
+  description: 2024 regular last results r5.
+- name: 2024_regular_last_results_r1
+  type: character
+  description: 2024 regular last results r1.
+- name: 2024_regular_winning_percentage_percentage
+  type: character
+  description: 2024 regular winning percentage percentage.
+- name: 2024_regular_goals_against_goals
+  type: integer
+  description: 2024 regular goals against goals.
+- name: 2024_regular_streak
+  type: character
+  description: 2024 regular streak.
+- name: 2024_regular_losses_number
+  type: integer
+  description: 2024 regular losses number.
+- name: 2024_regular_points_penalty_points
+  type: integer
+  description: 2024 regular points penalty points.
+- name: 2024_regular_points_points_per_game
+  type: number
+  description: 2024 regular points points per game.
+- name: 2024_regular_points_points
+  type: integer
+  description: 2024 regular points points.
+- name: 2024_regular_ties_number
+  type: integer
+  description: 2024 regular ties number.
+- name: 2024_regular_games_played_games
+  type: integer
+  description: 2024 regular games played games.
+- name: 2024_regular_place_previous
+  type: integer
+  description: 2024 regular place previous.
+- name: 2024_regular_place_season_end_id
+  type: integer
+  description: 2024 regular place season end ID.
+- name: 2024_regular_place_place
+  type: integer
+  description: 2024 regular place place.
+- name: 2024_regular_place_season_end
+  type: character
+  description: 2024 regular place season end.
+- name: 2024_regular_clinch_status_id
+  type: integer
+  description: 2024 regular clinch status ID.
+- name: 2024_regular_clinch_status_status
+  type: character
+  description: 2024 regular clinch status status.
+- name: 2024_regular_goal_differential_differential
+  type: integer
+  description: 2024 regular goal differential differential.
+- name: 2024_regular_win_loss_record
+  type: character
+  description: 2024 regular win loss record.
+- name: 2024_regular_team_info_display_name
+  type: character
+  description: 2024 regular team info display name.
+- name: 2024_regular_team_info_name
+  type: character
+  description: 2024 regular team info name.
+- name: 2024_regular_team_info_alias
+  type: character
+  description: 2024 regular team info alias.
+- name: 2024_regular_team_info_location
+  type: character
+  description: 2024 regular team info location.
+- name: 2024_regular_team_info_global_id
+  type: integer
+  description: 2024 regular team info global ID.
+- name: 2024_regular_team_info_id
+  type: integer
+  description: 2024 regular team info ID.
+- name: 2024_regular_season_id
+  type: integer
+  description: 2024 regular season ID.
+- name: 2024_regular_season_season_id
+  type: integer
+  description: 2024 regular season season ID.
+- name: 2024_regular_season_sport_id
+  type: integer
+  description: 2024 regular season sport ID.
+- name: 2024_regular_season_league_id
+  type: integer
+  description: 2024 regular season league ID.
+- name: 2024_regular_season_league
+  type: character
+  description: 2024 regular season league.
+- name: 2024_regular_season_teams
+  type: character
+  description: 2024 regular season teams.
+- name: 2024_regular_season_season_year
+  type: integer
+  description: 2024 regular season season year.
+- name: 2024_regular_season_is_current
+  type: integer
+  description: 2024 regular season is current.
+- name: 2024_regular_season_season_type
+  type: character
+  description: 2024 regular season season type.
+- name: 2024_regular_season_season_type_desc
+  type: character
+  description: 2024 regular season season type desc.
+- name: 2024_regular_season_season_start_date
+  type: character
+  description: 2024 regular season season start date.
+- name: 2024_regular_season_season_end_date
+  type: character
+  description: 2024 regular season season end date.
+- name: 2025_regular_wins_number
+  type: integer
+  description: 2025 regular wins number.
+- name: 2025_regular_goals_for_goals
+  type: integer
+  description: 2025 regular goals for goals.
+- name: 2025_regular_goals_against_goals
+  type: integer
+  description: 2025 regular goals against goals.
+- name: 2025_regular_goal_differential_differential
+  type: integer
+  description: 2025 regular goal differential differential.
+- name: 2025_regular_winning_percentage_percentage
+  type: character
+  description: 2025 regular winning percentage percentage.
+- name: 2025_regular_streak
+  type: character
+  description: 2025 regular streak.
+- name: 2025_regular_losses_number
+  type: integer
+  description: 2025 regular losses number.
+- name: 2025_regular_points_points
+  type: integer
+  description: 2025 regular points points.
+- name: 2025_regular_points_penalty_points
+  type: integer
+  description: 2025 regular points penalty points.
+- name: 2025_regular_points_points_per_game
+  type: character
+  description: 2025 regular points points per game.
+- name: 2025_regular_ties_number
+  type: integer
+  description: 2025 regular ties number.
+- name: 2025_regular_games_played_games
+  type: integer
+  description: 2025 regular games played games.
+- name: 2025_regular_place_place
+  type: integer
+  description: 2025 regular place place.
+- name: 2025_regular_win_loss_record
+  type: character
+  description: 2025 regular win loss record.
+- name: 2025_regular_team_info_display_name
+  type: character
+  description: 2025 regular team info display name.
+- name: 2025_regular_team_info_name
+  type: character
+  description: 2025 regular team info name.
+- name: 2025_regular_team_info_alias
+  type: character
+  description: 2025 regular team info alias.
+- name: 2025_regular_team_info_location
+  type: character
+  description: 2025 regular team info location.
+- name: 2025_regular_team_info_global_id
+  type: integer
+  description: 2025 regular team info global ID.
+- name: 2025_regular_team_info_id
+  type: integer
+  description: 2025 regular team info ID.
+- name: 2025_regular_clinch_status_id
+  type: integer
+  description: 2025 regular clinch status ID.
+- name: 2025_regular_clinch_status_status
+  type: character
+  description: 2025 regular clinch status status.
+- name: 2025_regular_season_id
+  type: integer
+  description: 2025 regular season ID.
+- name: 2025_regular_season_season_id
+  type: integer
+  description: 2025 regular season season ID.
+- name: 2025_regular_season_sport_id
+  type: integer
+  description: 2025 regular season sport ID.
+- name: 2025_regular_season_league_id
+  type: integer
+  description: 2025 regular season league ID.
+- name: 2025_regular_season_league
+  type: character
+  description: 2025 regular season league.
+- name: 2025_regular_season_teams
+  type: character
+  description: 2025 regular season teams.
+- name: 2025_regular_season_season_year
+  type: integer
+  description: 2025 regular season season year.
+- name: 2025_regular_season_is_current
+  type: integer
+  description: 2025 regular season is current.
+- name: 2025_regular_season_season_type
+  type: character
+  description: 2025 regular season season type.
+- name: 2025_regular_season_season_type_desc
+  type: character
+  description: 2025 regular season season type desc.
+- name: 2025_regular_season_season_start_date
+  type: character
+  description: 2025 regular season season start date.
+- name: 2025_regular_season_season_end_date
+  type: character
+  description: 2025 regular season season end date.

--- a/tools/codegen/schemas/native/fox_bifrost/event_odds.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/event_odds.yaml
@@ -1,7 +1,12 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: event_odds
 kind: dataframe
-columns: []
+columns:
+- name: modules
+  type: character
+  description: "Bifrost field `modules`: modules."

--- a/tools/codegen/schemas/native/fox_bifrost/event_recap.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/event_recap.yaml
@@ -1,7 +1,21 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: event_recap
 kind: dataframe
-columns: []
+columns:
+- name: id
+  type: character
+  description: "Bifrost field `id`: ID."
+- name: type
+  type: character
+  description: "Bifrost field `type`: type."
+- name: order
+  type: integer
+  description: "Bifrost field `order`: order."
+- name: last_update
+  type: character
+  description: "Bifrost field `last_update`: last update."

--- a/tools/codegen/schemas/native/fox_bifrost/event_standings.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/event_standings.yaml
@@ -1,7 +1,36 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: event_standings
 kind: dataframe
-columns: []
+columns:
+- name: section_id
+  type: character
+  description: "Bifrost field `section_id`: section ID."
+- name: section_title
+  type: character
+  description: "Bifrost field `section_title`: section title."
+- name: section_metadata_parameters_standings_type
+  type: character
+  description: "Bifrost field `section_metadata_parameters_standings_type`: section metadata parameters standings type."
+- name: section_metadata_parameters_league_name
+  type: character
+  description: "Bifrost field `section_metadata_parameters_league_name`: section metadata parameters league name."
+- name: section_metadata_parameters_group_name
+  type: character
+  description: "Bifrost field `section_metadata_parameters_group_name`: section metadata parameters group name."
+- name: section_metadata_parameters_season
+  type: character
+  description: "Bifrost field `section_metadata_parameters_season`: section metadata parameters season."
+- name: template
+  type: character
+  description: "Bifrost field `template`: template."
+- name: headers
+  type: character
+  description: "Bifrost field `headers`: headers."
+- name: rows
+  type: character
+  description: "Bifrost field `rows`: rows."

--- a/tools/codegen/schemas/native/fox_bifrost/explore_browse.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/explore_browse.yaml
@@ -1,7 +1,15 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: explore_browse
 kind: dataframe
-columns: []
+columns:
+- name: header_title
+  type: character
+  description: "Bifrost field `header_title`: header title."
+- name: items
+  type: character
+  description: "Bifrost field `items`: items."

--- a/tools/codegen/schemas/native/fox_bifrost/explore_odds.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/explore_odds.yaml
@@ -1,7 +1,12 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: explore_odds
 kind: dataframe
-columns: []
+columns:
+- name: modules
+  type: character
+  description: "Bifrost field `modules`: modules."

--- a/tools/codegen/schemas/native/fox_bifrost/league_conferences.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/league_conferences.yaml
@@ -1,7 +1,12 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: league_conferences
 kind: dataframe
-columns: []
+columns:
+- name: items
+  type: character
+  description: "Bifrost field `items`: items."

--- a/tools/codegen/schemas/native/fox_bifrost/league_header.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/league_header.yaml
@@ -1,7 +1,81 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: league_header
 kind: dataframe
-columns: []
+columns:
+- name: template
+  type: character
+  description: "Bifrost field `template`: template."
+- name: title
+  type: character
+  description: "Bifrost field `title`: title."
+- name: color
+  type: character
+  description: "Bifrost field `color`: color."
+- name: logo_url
+  type: character
+  description: "Bifrost field `logo_url`: logo URL."
+- name: image_type
+  type: character
+  description: "Bifrost field `image_type`: image type."
+- name: image_alt_text
+  type: character
+  description: "Bifrost field `image_alt_text`: image alt text."
+- name: content_uri
+  type: character
+  description: "Bifrost field `content_uri`: content URI."
+- name: content_type
+  type: character
+  description: "Bifrost field `content_type`: content type."
+- name: has_feature
+  type: character
+  description: "Bifrost field `has_feature`: has feature."
+- name: metadata_parameters_group
+  type: character
+  description: "Bifrost field `metadata_parameters_group`: metadata parameters group."
+- name: sponsorship_template
+  type: character
+  description: "Bifrost field `sponsorship_template`: sponsorship template."
+- name: sponsorship_secondary_template
+  type: character
+  description: "Bifrost field `sponsorship_secondary_template`: sponsorship secondary template."
+- name: sponsorship_sponsor_text
+  type: character
+  description: "Bifrost field `sponsorship_sponsor_text`: sponsorship sponsor text."
+- name: sponsorship_url
+  type: character
+  description: "Bifrost field `sponsorship_url`: sponsorship URL."
+- name: sponsorship_image_url
+  type: character
+  description: "Bifrost field `sponsorship_image_url`: sponsorship image URL."
+- name: sponsorship_image_alt_url
+  type: character
+  description: "Bifrost field `sponsorship_image_alt_url`: sponsorship image alt URL."
+- name: sponsorship_image_type
+  type: character
+  description: "Bifrost field `sponsorship_image_type`: sponsorship image type."
+- name: sponsorship_image_alt_text
+  type: character
+  description: "Bifrost field `sponsorship_image_alt_text`: sponsorship image alt text."
+- name: sponsorship_background_color
+  type: character
+  description: "Bifrost field `sponsorship_background_color`: sponsorship background color."
+- name: sponsorship_alt_background_color
+  type: character
+  description: "Bifrost field `sponsorship_alt_background_color`: sponsorship alt background color."
+- name: sponsorship_text_color
+  type: character
+  description: "Bifrost field `sponsorship_text_color`: sponsorship text color."
+- name: sponsorship_alt_text_color
+  type: character
+  description: "Bifrost field `sponsorship_alt_text_color`: sponsorship alt text color."
+- name: sponsorship_start_date
+  type: character
+  description: "Bifrost field `sponsorship_start_date`: sponsorship start date."
+- name: sponsorship_end_date
+  type: character
+  description: "Bifrost field `sponsorship_end_date`: sponsorship end date."

--- a/tools/codegen/schemas/native/fox_bifrost/league_playernews.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/league_playernews.yaml
@@ -1,7 +1,90 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: league_playernews
 kind: dataframe
-columns: []
+columns:
+- name: image_url
+  type: character
+  description: "Bifrost field `image_url`: image URL."
+- name: image_type
+  type: character
+  description: "Bifrost field `image_type`: image type."
+- name: image_alt_text
+  type: character
+  description: "Bifrost field `image_alt_text`: image alt text."
+- name: title
+  type: character
+  description: "Bifrost field `title`: title."
+- name: subtitle
+  type: character
+  description: "Bifrost field `subtitle`: subtitle."
+- name: headline
+  type: character
+  description: "Bifrost field `headline`: headline."
+- name: description
+  type: character
+  description: "Bifrost field `description`: description."
+- name: impact_title
+  type: character
+  description: "Bifrost field `impact_title`: impact title."
+- name: impact
+  type: character
+  description: "Bifrost field `impact`: impact."
+- name: entity_link_title
+  type: character
+  description: "Bifrost field `entity_link_title`: entity link title."
+- name: entity_link_web_url
+  type: character
+  description: "Bifrost field `entity_link_web_url`: entity link web URL."
+- name: entity_link_color
+  type: character
+  description: "Bifrost field `entity_link_color`: entity link color."
+- name: entity_link_image_url
+  type: character
+  description: "Bifrost field `entity_link_image_url`: entity link image URL."
+- name: entity_link_image_type
+  type: character
+  description: "Bifrost field `entity_link_image_type`: entity link image type."
+- name: entity_link_image_alt_text
+  type: character
+  description: "Bifrost field `entity_link_image_alt_text`: entity link image alt text."
+- name: entity_link_content_uri
+  type: character
+  description: "Bifrost field `entity_link_content_uri`: entity link content URI."
+- name: entity_link_content_type
+  type: character
+  description: "Bifrost field `entity_link_content_type`: entity link content type."
+- name: entity_link_layout_path
+  type: character
+  description: "Bifrost field `entity_link_layout_path`: entity link layout path."
+- name: entity_link_layout_tokens_id
+  type: character
+  description: "Bifrost field `entity_link_layout_tokens_id`: entity link layout tokens ID."
+- name: entity_link_layout_tokens_content_uri
+  type: character
+  description: "Bifrost field `entity_link_layout_tokens_content_uri`: entity link layout tokens content URI."
+- name: entity_link_analytics_name
+  type: character
+  description: "Bifrost field `entity_link_analytics_name`: entity link analytics name."
+- name: entity_link_analytics_sport
+  type: character
+  description: "Bifrost field `entity_link_analytics_sport`: entity link analytics sport."
+- name: entity_link_type
+  type: character
+  description: "Bifrost field `entity_link_type`: entity link type."
+- name: entity_link_alternate_image_url
+  type: character
+  description: "Bifrost field `entity_link_alternate_image_url`: entity link alternate image URL."
+- name: alternate_image_url
+  type: character
+  description: "Bifrost field `alternate_image_url`: alternate image URL."
+- name: date
+  type: character
+  description: "Bifrost field `date`: date."
+- name: source
+  type: character
+  description: "Bifrost field `source`: source."

--- a/tools/codegen/schemas/native/fox_bifrost/league_stats.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/league_stats.yaml
@@ -1,7 +1,15 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: league_stats
 kind: dataframe
-columns: []
+columns:
+- name: title
+  type: character
+  description: "Bifrost field `title`: title."
+- name: leaders
+  type: character
+  description: "Bifrost field `leaders`: leaders."

--- a/tools/codegen/schemas/native/fox_bifrost/league_stats_con.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/league_stats_con.yaml
@@ -1,7 +1,24 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: league_stats_con
 kind: dataframe
-columns: []
+columns:
+- name: id
+  type: character
+  description: "Bifrost field `id`: ID."
+- name: table_template
+  type: character
+  description: "Bifrost field `table_template`: table template."
+- name: table_headers
+  type: character
+  description: "Bifrost field `table_headers`: table headers."
+- name: table_rows
+  type: character
+  description: "Bifrost field `table_rows`: table rows."
+- name: legend_details
+  type: character
+  description: "Bifrost field `legend_details`: legend details."

--- a/tools/codegen/schemas/native/fox_bifrost/search_popular.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/search_popular.yaml
@@ -1,7 +1,12 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: search_popular
 kind: dataframe
-columns: []
+columns:
+- name: components
+  type: character
+  description: "Bifrost field `components`: components."

--- a/tools/codegen/schemas/native/fox_bifrost/team_header.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/team_header.yaml
@@ -1,7 +1,12 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: team_header
 kind: dataframe
-columns: []
+columns:
+- name: text
+  type: character
+  description: "Bifrost field `text`: text."

--- a/tools/codegen/schemas/native/fox_bifrost/team_standings.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/team_standings.yaml
@@ -1,7 +1,45 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: team_standings
 kind: dataframe
-columns: []
+columns:
+- name: section_id
+  type: character
+  description: "Bifrost field `section_id`: section ID."
+- name: section_title
+  type: character
+  description: "Bifrost field `section_title`: section title."
+- name: section_page_title
+  type: character
+  description: "Bifrost field `section_page_title`: section page title."
+- name: section_last_updated
+  type: character
+  description: "Bifrost field `section_last_updated`: section last updated."
+- name: section_legend_details
+  type: character
+  description: "Bifrost field `section_legend_details`: section legend details."
+- name: section_metadata_parameters_standings_type
+  type: character
+  description: "Bifrost field `section_metadata_parameters_standings_type`: section metadata parameters standings type."
+- name: section_metadata_parameters_league_name
+  type: character
+  description: "Bifrost field `section_metadata_parameters_league_name`: section metadata parameters league name."
+- name: section_metadata_parameters_team_name
+  type: character
+  description: "Bifrost field `section_metadata_parameters_team_name`: section metadata parameters team name."
+- name: section_metadata_parameters_season
+  type: character
+  description: "Bifrost field `section_metadata_parameters_season`: section metadata parameters season."
+- name: template
+  type: character
+  description: "Bifrost field `template`: template."
+- name: headers
+  type: character
+  description: "Bifrost field `headers`: headers."
+- name: rows
+  type: character
+  description: "Bifrost field `rows`: rows."

--- a/tools/codegen/schemas/native/fox_bifrost/team_stats.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/team_stats.yaml
@@ -1,7 +1,15 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: team_stats
 kind: dataframe
-columns: []
+columns:
+- name: title
+  type: character
+  description: "Bifrost field `title`: title."
+- name: leaders
+  type: character
+  description: "Bifrost field `leaders`: leaders."

--- a/tools/codegen/schemas/native/fox_bifrost/trending_articles.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/trending_articles.yaml
@@ -1,7 +1,39 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: trending_articles
 kind: dataframe
-columns: []
+columns:
+- name: data_existing_total
+  type: integer
+  description: "Bifrost field `data_existing_total`: data existing total."
+- name: data_results
+  type: character
+  description: "Bifrost field `data_results`: data results."
+- name: data_request_type
+  type: character
+  description: "Bifrost field `data_request_type`: data request type."
+- name: data_request_content_type
+  type: character
+  description: "Bifrost field `data_request_content_type`: data request content type."
+- name: data_request_internal
+  type: logical
+  description: "Bifrost field `data_request_internal`: data request internal."
+- name: data_request_platform
+  type: character
+  description: "Bifrost field `data_request_platform`: data request platform."
+- name: data_request_params
+  type: character
+  description: "Bifrost field `data_request_params`: data request params."
+- name: data_request_path_params_proxy
+  type: character
+  description: "Bifrost field `data_request_path_params_proxy`: data request path params proxy."
+- name: data_status_success
+  type: logical
+  description: "Bifrost field `data_status_success`: data status success."
+- name: data_status_code
+  type: integer
+  description: "Bifrost field `data_status_code`: data status code."

--- a/tools/codegen/schemas/native/fox_bifrost/trending_videos.yaml
+++ b/tools/codegen/schemas/native/fox_bifrost/trending_videos.yaml
@@ -1,7 +1,39 @@
-# Fox Sports Bifrost — generated returns schema. Columns are derived from the
-# spec's captured `components.schemas` (the item props of the list the parser
-# flattens), snake_cased to match the parser's output. Untyped (`object`)
-# responses carry `columns: []` (the parser flattens whatever the payload ships).
+# Fox Sports Bifrost returns schema — columns DERIVED from a captured live
+# response run through the registered parser (parse_fox_bifrost_*). The Fox spec
+# left this response untyped (`object`), so the columns are enumerated here from
+# a representative capture. `type` is inferred from the captured JS value;
+# `description` is best-effort from the snake_cased key. Endpoints with no
+# capture remain `columns: []`.
 schema: trending_videos
 kind: dataframe
-columns: []
+columns:
+- name: data_existing_total
+  type: integer
+  description: "Bifrost field `data_existing_total`: data existing total."
+- name: data_results
+  type: character
+  description: "Bifrost field `data_results`: data results."
+- name: data_request_type
+  type: character
+  description: "Bifrost field `data_request_type`: data request type."
+- name: data_request_content_type
+  type: character
+  description: "Bifrost field `data_request_content_type`: data request content type."
+- name: data_request_internal
+  type: logical
+  description: "Bifrost field `data_request_internal`: data request internal."
+- name: data_request_platform
+  type: character
+  description: "Bifrost field `data_request_platform`: data request platform."
+- name: data_request_params
+  type: character
+  description: "Bifrost field `data_request_params`: data request params."
+- name: data_request_path_params_proxy
+  type: character
+  description: "Bifrost field `data_request_path_params_proxy`: data request path params proxy."
+- name: data_status_success
+  type: logical
+  description: "Bifrost field `data_status_success`: data status success."
+- name: data_status_code
+  type: integer
+  description: "Bifrost field `data_status_code`: data status code."


### PR DESCRIPTION
## Summary

The **CBS NAPI** (`cbs_napi`) and **Fox Bifrost** (`fox_bifrost`) provider families were generated from OpenAPI specs that ship no typed 200-response schemas, so their returns tables were empty (`columns: []`). This PR fills the empty schemas by deriving **real columns from captured response payloads run through each endpoint's registered parser** — never fabricated. Schemas with no capture stay empty.

## Coverage

- **CBS NAPI: 5 / 82 typed** (77 left empty — no captures).
  The CBS capture corpus only covers 5 resource families: `league`, `season_teams`, `team_players`, `team_standings`, `endpoint_registry`. The other 77 endpoints have no captured payload, so they remain `columns: []` pending captures.
- **Fox Bifrost: 16 / 24 newly typed** (the 14 already-typed schemas untouched; 8 of the 24 left empty — no captures).
  Left empty for lack of a capture: `scorechip`, `league_scores_segment`, `explore_favorite`, `foxpolls`, `fs_feed`, `fs_images`, `fs_layouts`, `fs_videos`.

## Method (capture-driven, deterministic)

Two one-shot enrichment scripts under `tools/codegen/` (kept in-tree, mirroring the other one-shot gen scripts):

- `_enrich_cbs_napi_schemas.mjs` — the CBS manifest's `templates` column is empty, so endpoints are matched to captures by **filename pattern** (`league_<id>_meta`, `season_<id>_teams`, `team_<id>_players`, `team_<id>_standings`, `_discovery/resource_endpoint_registry`).
- `_enrich_fox_bifrost_schemas.mjs` — Fox capture filenames encode the endpoint as `<sport>_<path-suffix>` (path IDs inlined), so each empty short is matched by a **sport-agnostic filename matcher**; when several sports match the same template, the candidate whose parse yields the **most rows** is used (richest column union).

Both scripts run the endpoint's **registered parser** (`parse_cbs_napi_*` / `parse_fox_bifrost_*`) over the matched capture, take the union of emitted row keys (first 200 rows) as the column set, and **overwrite only the currently-empty schemas**. Column **names are exactly what the parser emits** (snake_cased); only `type` (inferred from the captured JS value) and a best-effort `description` are derived. The enriched columns flow into `docs/docs/reference/cbs.md` + `fox.md` via codegen.

The remainder stay `columns: []` pending captures — leaving a schema empty is correct when there is no capture; fabricating would not be.

## Gates

- `npm run codegen` + `npm run codegen:check` → drift green (up to date)
- `npm run build` → exit 0
- `npm test` → 1409 passing, 175 pending (gated live)
- `cd docs && npx docusaurus build` → `[SUCCESS]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fox Sports API reference documentation with comprehensive column definitions for multiple endpoints.

* **New Features**
  * Enriched CBS NAPI and Fox Bifrost endpoint schemas with detailed column metadata, including type definitions and descriptions for all data outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->