### PR TITLE
docs: v3.0.0 repo meta — LICENSE, CLAUDE, CONTRIBUTING, CoC, templates, README + CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a wrapper that errors, returns wrong data, or a broken endpoint
+title: "[bug] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what's wrong.
+
+**Which package surface?**
+- League / namespace + method (e.g. `sdv.cfb.espnCfbScoreboard`, `sdv.odds.oddsApiSports`):
+- Raw or `{ parsed: true }`:
+
+**Reproduction**
+
+```js
+import sdv from 'sportsdataverse';
+const data = await sdv.<league>.<method>({ /* params */ });
+```
+
+**Expected vs. actual**
+What you expected, and what happened (paste the error or a snippet of the wrong output).
+
+**Environment**
+- `sportsdataverse` version:
+- Node.js version (`node -v`, must be ≥ 20.18.1):
+- OS:
+
+**Additional context**
+Anything else (the endpoint may have changed upstream at ESPN / the provider, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://js.sportsdataverse.org/
+    about: Guides, the per-league reference, and the live playground.
+  - name: 💬 SportsDataverse community
+    url: https://sportsdataverse.org/
+    about: The wider SportsDataverse ecosystem (Node.js, Python, and R packages).
+  - name: 🐦 Twitter / X
+    url: https://twitter.com/SportsDataverse
+    about: Questions and updates.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request a new data source, sport, league, or endpoint
+title: "[feat] "
+labels: enhancement
+assignees: ''
+---
+
+**What would you like to see?**
+A clear description of the new data source / sport / league / endpoint.
+
+**Source**
+- Provider / API (ESPN, MLB Stats, NHL, NFL.com, The Odds API, CBS, Fox, Yahoo,
+  247Sports, or a new one):
+- Sport(s) / league(s):
+- A documentation link or an example request URL, if you have one:
+
+**Use case**
+What you'd build with it.
+
+**Additional context**
+Is there a sister implementation in the R / Python SportsDataverse packages we
+can mirror? Anything else helpful.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# GitHub Copilot instructions — `sportsdataverse` (Node.js)
+
+A TypeScript, ESM-only Node.js client (Node ≥ 20.18.1) for sports data: a
+cross-league ESPN surface plus native (non-ESPN) live-API families and five
+cross-sport provider families, all with a tidy parser layer.
+
+## Architecture (how the code is generated)
+
+- **Codegen-driven.** `tools/codegen/generate.mjs` reads the endpoint YAML in
+  `tools/codegen/endpoints/*.yaml` (the single source of truth) and generates the
+  runtime wrapper tables under `src/generated/`, the per-league reference docs
+  under `docs/docs/reference/`, and the playground metadata
+  `docs/src/playground/endpoints.json`.
+- **Do NOT hand-edit generated output** (`src/generated/**`,
+  `docs/docs/reference/**`, `docs/src/playground/endpoints.json`). Edit the YAML
+  (or the codegen templates) and run `npm run codegen`. `npm run codegen:check`
+  is the drift gate — it must stay green (CI fails otherwise).
+- New non-ESPN families come from a canonical OpenAPI spec via
+  `tools/codegen/from-openapi.mjs` (OpenAPI 3.x → endpoint-YAML skeleton).
+
+## Conventions
+
+- **ESM only** — `import sdv from 'sportsdataverse'`. There is no CommonJS
+  `require` export. In RunKit/notebooks use `await import('sportsdataverse')`.
+- **Dual-case naming** — every generated wrapper is exposed under BOTH snake_case
+  (`espn_nba_scoreboard`, `mlb_api_teams`) and camelCase (`espnNbaScoreboard`,
+  `mlbApiTeams`). Same function, either name.
+- **Parser contract** — parsers are `(raw: any) => Record<string, any>[]`: return
+  a tidy array of flat (snake_cased, nested-flattened) row objects; return `[]`
+  on empty/malformed input; never throw. `{ parsed: true }` is strictly additive
+  (omitting it returns the raw payload). When you change `src/parsers/**`, re-run
+  `npm run bundle:parsers` (the playground bundle) so its staleness test passes.
+- **New modules must be typed** and pass `npm run typecheck` (tsc) + `npm run build`.
+- **Tests** are Mocha, no network (inline payloads / committed fixtures);
+  live/integration tests are gated behind `SDV_LIVE=1`.
+
+## Commits / PRs
+
+- [Conventional Commits](https://www.conventionalcommits.org/) (`feat(odds): …`,
+  `fix(cfb): …`, `docs(readme): …`).
+- **Never add AI/assistant co-author trailers or "Generated with …" lines** to
+  commits or PRs. The human author is the sole attributable contributor.
+- If you touched any `tools/codegen/endpoints/*.yaml`, regenerate and commit the
+  generated output in the same change.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!-- Thanks for contributing to sportsdataverse-js! -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Type of change
+
+- [ ] `feat` — new endpoint / family / feature
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation / guides / playground
+- [ ] `refactor` / `chore` / `test` / `ci`
+- [ ] Breaking change
+
+## How was this tested?
+
+- [ ] `npm test` passes
+- [ ] `npm run codegen:check` is green (no drift)
+- [ ] `npm run build` / `npm run typecheck` pass
+- [ ] `cd docs && npx docusaurus build` passes (if docs/playground changed)
+
+## Checklist
+
+- [ ] Conventional Commit title (e.g. `feat(odds): …`, `fix(cfb): …`)
+- [ ] If I changed any `tools/codegen/endpoints/*.yaml`, I ran `npm run codegen`
+      and committed the regenerated output (I did **not** hand-edit
+      `src/generated/**` or `docs/docs/reference/**`)
+- [ ] If I changed `src/parsers/**`, I re-ran `npm run bundle:parsers`
+- [ ] New code is typed and passes lint/typecheck
+- [ ] No AI/assistant co-author trailers or "Generated with …" lines on my commits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,6 @@ All notable changes to `sportsdataverse` (Node.js) are documented here. The
 docs-site copy lives at [`docs/src/pages/CHANGELOG.md`](docs/src/pages/CHANGELOG.md)
 and renders at <https://js.sportsdataverse.org/CHANGELOG>.
 
-## Unreleased
-
-### The Odds API — first cross-sport provider family (`sdv.odds.*`)
-
-- **The Odds API** (`api.the-odds-api.com`) — a new flat-API family of **10
-  endpoints** under the standalone **`odds`** namespace (`sdv.odds.oddsApi*` /
-  `sdv.odds.odds_api_*`): `sports`, `sports_odds`, `sports_scores`,
-  `sports_events`, `sports_participants`, `event_odds`, `event_markets`,
-  `sports_odds_history`, `sports_events_history`, `event_odds_history`. Ported
-  from the [`oddsapiR`](https://oddsapiR.sportsdataverse.org) R package.
-- This is the **first cross-sport (non-league) provider family** — it
-  establishes standalone-namespace support: a flat family whose namespace is not
-  an ESPN league gets its own `sdv.<ns>.*` surface and its own generated
-  reference page (`/reference/odds`) instead of a "Native API" section on a
-  league page.
-- **Auth is a plain query param.** The Odds API uses `apiKey` (you supply it) —
-  every endpoint takes a required `api_key` param (query key `apiKey`); there is
-  no bearer-token machinery. `await sdv.odds.oddsApiSports({ api_key: '...' })`.
-- The odds / event-odds / history parsers **unroll** events → bookmakers →
-  markets → outcomes to **one row per outcome** (mirroring oddsapiR's
-  `tidyr::unnest` chain); pass `{ parsed: true }` for tidy rows.
-- First of a planned provider-expansion program (CBS / 247 / Yahoo / Fox to
-  follow).
-
 ## v3.0.0
 
 A major release that turns `sportsdataverse` into a **cross-league ESPN client**
@@ -56,6 +32,34 @@ the matching league namespace:
 - **NFL.com "Shield" API** (`api.nfl.com`) — `sdv.nfl.nflApi*`, with automatic
   anonymous `WEB_DESKTOP` bearer-token minting (cached + auto-renewed; no
   credentials required).
+
+### Provider families (5 cross-sport, standalone namespaces)
+
+Beyond ESPN + the league-native APIs, v3.0.0 adds **five independent provider
+families**, each generated from a canonical OpenAPI spec (the `sdv-swagger`
+collection) via a new reusable **OpenAPI 3.x → endpoint-YAML transform**
+(`tools/codegen/from-openapi.mjs`, with path / query / `$ref` param resolution +
+auth detection). Each cross-sport family gets its own standalone `sdv.<ns>.*`
+namespace and its own generated reference page; pass `{ parsed: true }` for tidy
+rows. The transform makes adding the next provider largely mechanical.
+
+- **The Odds API** (`sdv.odds.*`, 10 endpoints) — betting odds / scores / events
+  across sports. `apiKey` is a plain query param you supply. Ported from
+  [`oddsapiR`](https://oddsapiR.sportsdataverse.org); odds / event / history
+  parsers unroll events → bookmakers → markets → outcomes to one row per outcome.
+- **247Sports** (`sdv.recruiting.*`, 25 endpoints) — recruiting rankings /
+  commits / profiles (caller-supplied JWT via `headers`). Supersedes the legacy
+  `getPlayerRankings`-style service methods (kept for back-compat).
+- **CBS Sports** (`sdv.cbs.*`, 82 endpoints) — the public NAPI (scores /
+  standings / teams / odds across sports), keyless.
+- **Fox Sports** (`sdv.fox.*`, 38 endpoints) — the Bifrost API (`{sport}` path
+  param across 11 sports); a public `apikey` + `api-version` query pair, defaulted.
+- **Yahoo Sports** (`sdv.yahoo.*`, 107 endpoints) — the editorial scoreboard /
+  boxscore feed + the shangrila stats-graph API; keyless (needs browser-y
+  `Origin` / `Referer` headers).
+
+In total: **517 flat-API wrappers across 13 families** (the 7 native + 5 provider
++ Statcast).
 
 ### tidy.js parser layer
 
@@ -95,6 +99,15 @@ the matching league namespace:
   serverless proxy — host-allowlisted (derived from the generated metadata), with
   server-side token minting for NFL.com and content-type passthrough for Statcast
   CSV/HTML so credentials never reach the browser and non-JSON bodies display raw.
+  It now also has a **Raw/Parsed toggle** (tidy rows render as a sortable table —
+  with a section selector for the 21-sub-frame `summary` dispatcher),
+  **deep-linkable URLs** (every call is shareable), and an **Examples menu** of
+  curated presets across ESPN, the native APIs, and all 5 providers. The provider
+  families each appear under their standalone namespace.
+- **Getting-started guides** (`/docs/guides/`) — per-area recipe pages (quickstart,
+  NBA/WNBA/college-basketball/NFL/MLB/NHL/CFB/soccer, providers) with runnable
+  raw-vs-parsed snippets, "Open in playground" deep-links, and embedded **RunKit**
+  live notebooks.
 
 ### Tooling / housekeeping
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,328 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [CLAUDE.md — sportsdataverse (Node.js) Development Guide](#claudemd--sportsdataverse-nodejs-development-guide)
+  - [Package Overview](#package-overview)
+  - [Commit Convention](#commit-convention)
+  - [Branches](#branches)
+  - [Build & Development Commands](#build--development-commands)
+  - [Architecture](#architecture)
+    - [Codegen pipeline (the heart of the repo)](#codegen-pipeline-the-heart-of-the-repo)
+    - [ESPN cross-league surface](#espn-cross-league-surface)
+    - [Flat-API families (native + providers)](#flat-api-families-native--providers)
+    - [OpenAPI → endpoint-YAML transform](#openapi--endpoint-yaml-transform)
+    - [Parser layer](#parser-layer)
+    - [Namespace assembly (`src/index.ts`)](#namespace-assembly-srcindexts)
+  - [Project Structure](#project-structure)
+  - [Key Coding Conventions](#key-coding-conventions)
+  - [Common Pitfalls](#common-pitfalls)
+  - [Documentation Maintenance](#documentation-maintenance)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# CLAUDE.md — sportsdataverse (Node.js) Development Guide
+
+## Package Overview
+
+`sportsdataverse` (npm) is the SportsDataverse's **Node.js / TypeScript** client and
+the sister to the Python package [`sportsdataverse-py`](https://py.sportsdataverse.org/)
+and the SportsDataverse R packages (`hoopR`, `wehoop`, `cfbfastR`, `fastRhockey`,
+`baseballr`, …). It provides tidy access to play-by-play, box score, schedule,
+roster, standings, odds, and many other surfaces across the major leagues.
+
+As of **v3.0.0** the package is a **cross-league ESPN client _plus_ a native
+(non-ESPN) live-API client** with a tidy parser layer:
+
+- **116 ESPN endpoint short names** generated for **29 leagues** (31 namespaces),
+  exposed as `espn_<league>_<short>` (snake) + `espn<League><Short>` (camelCase).
+- **517 flat-API wrappers across 13 families** — 7 native league APIs + 5 cross-sport
+  providers (see [Flat-API families](#flat-api-families-native--providers)).
+- A **parser layer** (`src/parsers/`): every wrapper returns raw JSON by default;
+  `{ parsed: true }` returns a tidy array of flat, snake_cased row objects.
+
+When this guide differs from the current repo, treat `CONTRIBUTING.md`, the endpoint
+YAML under `tools/codegen/endpoints/`, and the test suite under `test/` as
+authoritative.
+
+- **License:** MIT
+- **Author:** Saiem Gilani
+- **Default / release branch:** `main`
+- **Runtime:** Node **≥ 20.18.1**, **ESM-only** (`"type": "module"`), TypeScript
+- **Packaging:** npm (`package-lock.json` committed); ships `dist/` only
+- **Docs:** Docusaurus 3 on Vercel (`js.sportsdataverse.org`) with a live playground
+
+## Commit Convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(nhl): add nhl_edge skater-tracking wrappers
+fix(parsers): handle empty boxscore in parse_summary
+docs(reference): regenerate after odds_api endpoint add
+refactor(codegen): split flat-API rendering out of generate.mjs
+chore(deps): bump esbuild + re-lock
+ci(actions): add Node 22 to the test matrix
+```
+
+Prefer scoped subjects (`feat(mlb): …`, `fix(cfb): …`). Use `type!:` or a
+`BREAKING CHANGE:` footer for breaking changes. Split unrelated work into separate
+commits.
+
+**Hard rule: never add AI/assistant co-author trailers or "Generated with …"
+lines.** Omit all `Co-Authored-By:` trailers referencing AI tools (Claude, Copilot,
+Cursor, GPT, Gemini, …) and never add a "🤖 Generated with" line to commits or PR
+bodies. The human author is the sole attributable contributor. This applies whether
+the change was generated, refactored, or reviewed with AI assistance.
+
+## Branches
+
+- **`main`** — default and release branch. The committed `src/generated/**`,
+  `docs/docs/reference/**`, and `docs/src/playground/endpoints.json` MUST be in sync
+  with `tools/codegen/endpoints/*.yaml` (the drift gate enforces this in CI).
+
+## Build & Development Commands
+
+```sh
+npm ci                  # install from the lockfile
+
+npm run build           # tsc -> dist/
+npm run typecheck       # tsc --noEmit
+npm test                # mocha suite (no network) — runs `npm run build` first via pretest
+
+npm run codegen         # regenerate src/generated + docs/docs/reference + playground JSON
+npm run codegen:check   # DRIFT GATE — fails if committed generated output is stale
+npm run bundle:parsers  # esbuild the browser parser bundle for the playground
+npm run docs            # typedoc -> the typed module reference
+```
+
+- `test` runs Mocha against `test/**/*.test.js` with no network access.
+- `prepare` / `prepublishOnly` build `dist/`; only `dist/` is published (`files:
+  ["dist"]`).
+
+## Architecture
+
+### Codegen pipeline (the heart of the repo)
+
+The library is **codegen-driven**. `tools/codegen/generate.mjs` reads the vendored
+endpoint YAML in `tools/codegen/endpoints/*.yaml` (plus return schemas under
+`tools/codegen/schemas/`) and, from that single source of truth, generates:
+
+| Output | Path | Purpose |
+|---|---|---|
+| Runtime wrapper / league tables | `src/generated/wrappers.ts`, `src/generated/leagues.ts` | the TS the package imports at runtime |
+| Per-league Markdown reference | `docs/docs/reference/*.md` (+ `_category_.json`) | the docs site reference subtree |
+| Playground metadata | `docs/src/playground/endpoints.json` | the in-browser playground endpoint list |
+
+- `npm run codegen` **writes** those outputs.
+- `npm run codegen:check` (`--check`) is the **drift gate**: it regenerates in-memory
+  and exits non-zero if any committed output differs. This runs in CI and as a
+  pre-commit hook.
+- **Never hand-edit generated files.** Every generated file carries an
+  `AUTO-GENERATED by tools/codegen/generate.mjs — do not edit by hand` header. Edit
+  the YAML (or the Jinja-style templates / renderers in `generate.mjs`) and rerun
+  `npm run codegen`; otherwise the drift gate goes red.
+
+The generator is a pure file-in / file-out renderer — it makes **no network calls**.
+
+### ESPN cross-league surface
+
+ESPN endpoints come from three family YAML files — `espn_site_v2.yaml`,
+`espn_core_v2.yaml`, `espn_web_v3.yaml` — and feed the `WRAPPERS` table in
+`src/generated/wrappers.ts`. The pattern is **one core, parameterized on
+`(sport, league)` slugs**, wrapped once per URL family.
+
+- **116 distinct short names** are exposed across **29 leagues** (`leagues.yaml`).
+- Each wrapper is registered under BOTH `espn_<prefix>_<short>` (snake, py/R parity)
+  and `espn<Prefix><Short>` (camelCase, idiomatic JS) by `makeLeagueModule`
+  (`src/leagues/_make.ts`) — both resolve to the same function.
+- Endpoints carry a **scope**: `universal` (every league), `ncaa` (college),
+  `football` (NFL / CFB / UFL), `mlb`. Each league gets exactly the endpoints in its
+  scope set, so the ESPN contract tests stay invariant.
+- The `summary` endpoint is a **dispatcher** returning 21 sub-frames; it honours a
+  `section` arg (omit → all sub-frames as a dict).
+- Multi-league sports take an extra `league` slug, e.g.
+  `sdv.soccer.espnSoccerScoreboard({ league: "eng.1" })`.
+
+### Flat-API families (native + providers)
+
+Non-ESPN, absolute-host live APIs are generated into a **separate** `FLAT_WRAPPERS`
+table (so the ESPN table stays untouched). **517 flat-API wrappers across 13
+families**:
+
+**7 native** — merged onto their league namespace:
+
+| Family (YAML stem) | Namespace | Host | Auth |
+|---|---|---|---|
+| `mlb_api` | `sdv.mlb.mlbApi*` | `statsapi.mlb.com` | keyless |
+| `mlb_statcast` | `sdv.mlb.mlbStatcast*` | `baseballsavant.mlb.com` | keyless (date-chunked search) |
+| `nhl_api_web` | `sdv.nhl.nhlApiWeb*` | `api-web.nhle.com` | keyless |
+| `nhl_edge` | `sdv.nhl.nhlEdge*` | `api-web.nhle.com/v1/edge` | keyless |
+| `nhl_stats_rest` | `sdv.nhl.nhlStatsRest*` | `api.nhle.com/stats/rest` | keyless |
+| `nhl_records` | `sdv.nhl.nhlRecords*` | `records.nhl.com` | keyless |
+| `nfl_api` | `sdv.nfl.nflApi*` | `api.nfl.com` | **bearer token minted automatically** (anonymous `WEB_DESKTOP`, cached + auto-renewed; `src/core/nfl_auth.ts`) |
+
+**5 cross-sport providers** — standalone `sdv.<ns>.*` namespaces (NOT leagues), each
+getting its own generated reference page:
+
+| Family | Namespace | Auth |
+|---|---|---|
+| The Odds API (`odds_api`) | `sdv.odds.*` | `apiKey` query param (caller-supplied) |
+| 247Sports (`sports247`) | `sdv.recruiting.*` | caller-supplied JWT via `headers` |
+| CBS Sports (`cbs_napi`) | `sdv.cbs.*` | keyless |
+| Fox Sports (`fox_bifrost`) | `sdv.fox.*` | public `apikey` + `api-version` query (defaulted) |
+| Yahoo Sports (`yahoo_editorial` + `yahoo_shangrila`) | `sdv.yahoo.*` | keyless (browser-y `Origin`/`Referer` headers) |
+
+`FLAT_API_NAMESPACES` in both `src/index.ts` and `generate.mjs` maps each stem to its
+namespace — **keep the two copies in sync**. `standaloneFlatNamespaces()` in
+`generate.mjs` decides which namespaces are providers (not leagues) and renders them
+their own standalone reference page.
+
+### OpenAPI → endpoint-YAML transform
+
+`tools/codegen/from-openapi.mjs` turns a canonical **OpenAPI 3.x** spec (the
+`sdv-swagger` collection; also handles Swagger-2 `host`+`basePath`) into a flat-API
+endpoint-YAML **skeleton** in the shape of `odds_api.yaml` / `nfl_api.yaml`. It:
+
+- emits only `GET` operations as wrappers;
+- derives a stable snake_case `short` from `operationId` (else from the path),
+  de-duplicating collisions;
+- resolves `$ref` params against `components.parameters`, merges path-item + operation
+  params, and rewrites path tokens to snake_case to match param names;
+- sets top-level `auth: true` only for bearer / header-token schemes.
+
+The output is a **skeleton**: `parser:` is a `parse_<api>_<short>` placeholder and
+`returns_schema:` a `native/<api>/<short>` placeholder. Real parsers
+(`src/parsers/<api>.ts`, registered in `_registry.ts`) and schemas
+(`tools/codegen/schemas/native/<api>/*.yaml`) are authored by hand on top. CLI:
+`node tools/codegen/from-openapi.mjs <spec.yaml> --api <stem> [--out <path>]`. This
+transform is what made the provider families largely mechanical to add.
+
+### Parser layer
+
+`src/parsers/` registers one parser per endpoint. **Contract:**
+
+- A parser is a function `(raw) => rows[]` — a tidy array of flat, snake_cased row
+  objects. Nested fields are flattened by the in-house `normalize` (the JS analog of
+  pandas `json_normalize`); keys are snake_cased via `snakeCase`.
+- Empty / malformed payloads return `[]` (or a zero-row frame), never throw — callers
+  can chain without null checks.
+- The dispatch is **strictly additive**: a wrapper returns the **raw** payload by
+  default; passing `{ parsed: true }` runs the registered parser. Omitting the kwarg
+  preserves the raw return for every existing caller. This mirrors
+  `sportsdataverse-py`'s `return_parsed=True`.
+- ESPN parsed dispatch is a port of py's `_common_espn_parsers` — **22 parsers**
+  (scoreboard / standings / rosters / leaders / athlete deep-dives / the 21-sub-frame
+  `summary` dispatcher + two generics for Core v2 list + single-resource). All 116
+  ESPN endpoints route through these; `summary` honours `section`.
+- The browser-safe public barrel is `src/parsers/index.ts`, exposed via the
+  `sportsdataverse/parsers` subpath export. It transitively imports only
+  `_normalize`, sibling parser modules, and `papaparse` (all browser-safe — no
+  node-only HTTP deps). `npm run bundle:parsers` esbuilds it into the playground so
+  parsing happens client-side. **Rebundle whenever a parser changes.**
+
+### Namespace assembly (`src/index.ts`)
+
+The default export `sdv` is assembled as:
+
+1. Start from the **legacy** hand-written services (`cfb, mbb, mlb, nba, ncaa, nfl,
+   nhl, tennis, wbb, wnba` from `src/services/`) — these preserve pre-3.0 convenience
+   methods like `sdv.nba.getPlayByPlay(...)`.
+2. Merge the generated ESPN wrappers onto each league via `makeLeagueModule(cfg)` for
+   every `cfg` in `LEAGUES`, adding new namespaces (soccer, cricket, ufl, …) where no
+   legacy service exists.
+3. Merge the flat-API wrappers via `makeFlatModule` AFTER the ESPN merge (additive,
+   never clobbering) using `FLAT_API_NAMESPACES`; provider stems land on standalone
+   namespaces.
+4. Merge `mlb_statcast_extra` (hand-written date-chunked search) onto `sdv.mlb`.
+
+Named, tree-shakeable re-exports include `LEAGUES`, `WRAPPERS`, `FLAT_WRAPPERS`,
+`makeLeagueModule`, `makeFlatModule`, `normalize`, `PARSERS` / `parserFor`, the
+NFL-auth helpers, and `export * as tidy from '@tidyjs/tidy'`.
+
+## Project Structure
+
+```
+src/
+  core/           # espn.ts (ESPN dispatch), client.ts (FLAT_HOSTS), flat.ts,
+                  # nfl_auth.ts (bearer mint), types.ts
+  generated/      # AUTO-GENERATED — wrappers.ts, leagues.ts (do NOT hand-edit)
+  leagues/        # _make.ts (ESPN league module), _make_flat.ts (flat module),
+                  # mlb_statcast_extra.ts
+  parsers/        # parser layer + index.ts barrel (sportsdataverse/parsers export)
+  services/       # legacy hand-written per-sport scrapers (preserved)
+  index.ts        # namespace assembly + default export
+tools/codegen/
+  generate.mjs    # the codegen entry point (writes generated + docs + playground)
+  from-openapi.mjs# OpenAPI 3.x spec -> endpoint-YAML skeleton
+  endpoints/*.yaml# SOURCE OF TRUTH (espn_* families + flat-API stems + leagues.yaml)
+  schemas/        # return schemas consumed by the docs renderer
+  templates/      # rendering templates
+docs/             # Docusaurus 3 site (reference subtree is generated; rest authored)
+test/             # Mocha no-network tests (test/**/*.test.js)
+examples/         # runnable example scripts
+package.json      # ESM, engines.node >= 20.18.1, scripts, exports (. and ./parsers)
+tsconfig.json, typedoc.json
+```
+
+## Key Coding Conventions
+
+- **ESM-only.** `"type": "module"`; use `import` / `export`, no `require`, and
+  include the `.js` extension in relative import specifiers (TS NodeNext). No CommonJS
+  entry point is published.
+- **Dual-case naming.** Generated wrappers are registered under snake_case (py/R
+  parity) AND camelCase (idiomatic JS canonical) — both resolve to the same function.
+  Params accept snake_case or camelCase.
+- **The drift gate must stay green.** After editing any `tools/codegen/endpoints/*.yaml`
+  (or a renderer), run `npm run codegen` and commit the regenerated
+  `src/generated/**`, `docs/docs/reference/**`, and playground JSON together.
+  `npm run codegen:check` must pass.
+- **`{ parsed: true }` is additive.** Never change a wrapper's default (raw) return.
+  Add or fix the registered parser; leave the raw path alone.
+- **Parser contract.** `(raw) => rows[]`, `[]` on empty, snake_cased flat rows via
+  `normalize`. New flat-API families: author `src/parsers/<api>.ts`, register in
+  `src/parsers/_registry.ts`, add returns schemas under
+  `tools/codegen/schemas/native/<api>/`.
+- **New flat-API family workflow.** Run `from-openapi.mjs` to get a YAML skeleton →
+  drop it in `tools/codegen/endpoints/` → add the stem to `FLAT_API_FILES` /
+  `FLAT_API_NAMESPACES` / `FLAT_API_META` in `generate.mjs` and the
+  `FLAT_API_NAMESPACES` copy in `src/index.ts` → author parsers + schemas →
+  `npm run codegen` → `npm run bundle:parsers` (if parsers are browser-relevant).
+- **Tests are no-network.** Mocha + `should`. Use captured fixtures; don't hit live
+  APIs in the default suite.
+- **Fully typed.** New modules ship param + return types; `npm run typecheck` must be
+  clean.
+
+## Common Pitfalls
+
+- **Don't hand-edit `src/generated/**` or `docs/docs/reference/**`.** They're
+  codegen-owned; the drift gate will fail and your edit will be clobbered on the next
+  `npm run codegen`. Edit the YAML / renderer instead.
+- **Rebundle parsers when they change.** The playground runs the esbuild bundle, not
+  `src/parsers` directly — `npm run bundle:parsers` after any parser edit, or the
+  browser playground serves stale parsing logic.
+- **Keep `FLAT_API_NAMESPACES` in sync** between `generate.mjs` and `src/index.ts`. A
+  mismatch routes a family's wrappers to the wrong namespace (or a missing one).
+- **Legal comments in the bundle.** `bundle:parsers` uses
+  `--legal-comments=eof`; don't strip the license footer from
+  `docs/src/playground/parsers.bundle.mjs`.
+- **Rate-limit live captures, not codegen.** `generate.mjs` makes no network calls.
+  When capturing fixtures from ESPN Core v2 / providers, keep parallelism low —
+  ESPN Core v2 in particular 403s under load.
+- **NFL.com token is auto-minted.** `sdv.nfl.nflApi*` mints an anonymous
+  `WEB_DESKTOP` bearer token (cached + auto-renewed in `src/core/nfl_auth.ts`); don't
+  add a credential requirement or re-implement the mint.
+- **The `{ parsed: true }` kwarg must never change the raw default.** Adding a parser
+  is additive; verify a raw call still returns the untouched payload.
+
+## Documentation Maintenance
+
+- The Docusaurus site lives under `docs/`. The per-league/provider reference subtree
+  (`docs/docs/reference/*.md`, `_category_.json`) and the playground metadata are
+  **generated** — never hand-edit them. Conceptual pages outside that subtree
+  (`docs/docs/intro.md`, tutorials, architecture) are hand-authored and survive
+  regeneration.
+- `CONTRIBUTING.md` is the canonical contributor onboarding file.
+- `README.md` carries Install / Quick start / Architecture and the companion-package
+  cross-links.
+- Verify the docs build with `cd docs && npx docusaurus build` before shipping
+  doc-affecting changes.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our pledge
+
+The `sportsdataverse` project and the wider [SportsDataverse](https://sportsdataverse.org)
+community are committed to providing a friendly, safe, and welcoming environment
+for everyone, regardless of experience level or background. We want contributing
+to — and using — these packages to be a positive experience for all.
+
+## Our standard
+
+This project adopts the **[Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1**, as its Code of Conduct. The full text is available at:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+In short: be respectful and considerate, assume good intent, give and accept
+constructive feedback gracefully, and help keep the community welcoming. Behavior
+that makes others feel unwelcome or unsafe is not acceptable.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the repository, issues,
+pull requests, discussions — and when an individual is representing the project
+in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it to the
+project maintainer at **sportsdataverse@gmail.com**. All reports will be reviewed
+and investigated promptly and fairly, and the reporter's privacy will be
+respected.
+
+Project maintainers are responsible for clarifying and enforcing this Code of
+Conduct and may take any action they deem appropriate, up to and including a
+temporary or permanent ban from the project's spaces.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1. Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,222 @@
+# Contributing to sportsdataverse (Node.js)
+
+Thanks for helping improve `sportsdataverse`! This guide covers local setup, the
+codegen workflow, how to add endpoints and parsers, testing, and the commit/docs
+conventions. By participating you agree to the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Getting started](#getting-started)
+- [Architecture overview](#architecture-overview)
+- [Codegen workflow](#codegen-workflow)
+- [Adding an ESPN endpoint](#adding-an-espn-endpoint)
+- [Adding a new flat-API family](#adding-a-new-flat-api-family)
+- [The parser contract](#the-parser-contract)
+- [Testing](#testing)
+- [Docs & playground](#docs--playground)
+- [Commit conventions](#commit-conventions)
+- [Opening a pull request](#opening-a-pull-request)
+
+## Prerequisites
+
+- **Node ≥ 20.18.1** (see `engines` in `package.json`).
+- npm (the repo commits `package-lock.json`).
+- The package is **ESM-only** and written in **TypeScript**.
+
+## Getting started
+
+```sh
+git clone https://github.com/sportsdataverse/sportsdataverse-js.git
+cd sportsdataverse-js
+
+npm ci             # install exactly from the lockfile
+npm run build      # tsc -> dist/
+npm test           # mocha suite (no network; runs the build first via pretest)
+npm run typecheck  # tsc --noEmit
+```
+
+Useful scripts:
+
+| Script | What it does |
+|---|---|
+| `npm run codegen` | regenerate `src/generated/**`, `docs/docs/reference/**`, playground JSON |
+| `npm run codegen:check` | **drift gate** — fails if committed generated output is stale |
+| `npm run bundle:parsers` | esbuild the browser parser bundle for the playground |
+| `npm run docs` | TypeDoc (the typed module reference) |
+| `npm run build` | compile TypeScript to `dist/` |
+| `npm test` | Mocha suite over `test/**/*.test.js` (no network) |
+
+## Architecture overview
+
+The library is **codegen-driven**. `tools/codegen/generate.mjs` reads the vendored
+endpoint YAML in `tools/codegen/endpoints/*.yaml` — the single source of truth — and
+generates:
+
+- the runtime TypeScript wrapper / league tables under `src/generated/`
+  (`wrappers.ts`, `leagues.ts`),
+- the per-league/provider Markdown reference under `docs/docs/reference/`, and
+- the playground metadata `docs/src/playground/endpoints.json`.
+
+Two kinds of endpoints:
+
+- **ESPN** (`espn_site_v2.yaml`, `espn_core_v2.yaml`, `espn_web_v3.yaml`) — one core,
+  parameterized on `(sport, league)` slugs, exposed across **29 leagues** as
+  `espn_<league>_<short>` + `espn<League><Short>`.
+- **Flat APIs** (non-ESPN absolute hosts) — **7 native** league APIs (MLB Stats,
+  Statcast, NHL ×4, NFL.com) merged onto their league namespace, and **5 cross-sport
+  providers** (Odds / 247 / CBS / Fox / Yahoo) on standalone `sdv.<provider>.*`
+  namespaces.
+
+Every wrapper returns raw JSON by default; `{ parsed: true }` runs it through a
+registered **parser** → a tidy array of flat, snake_cased row objects. See
+[`CLAUDE.md`](CLAUDE.md) for the full deep-dive.
+
+## Codegen workflow
+
+> **Generated files are never hand-edited.** Every file under `src/generated/` and
+> `docs/docs/reference/` starts with an `AUTO-GENERATED … do not edit by hand`
+> header. Edit the **YAML** (or the renderer/templates) and regenerate.
+
+The loop is:
+
+```sh
+# 1. edit tools/codegen/endpoints/<file>.yaml  (or generate.mjs / templates)
+npm run codegen          # 2. regenerate the runtime + docs + playground outputs
+npm run codegen:check    # 3. confirm there is no drift
+git add src/generated docs/docs/reference docs/src/playground tools/codegen
+```
+
+`codegen:check` runs in CI and as a pre-commit hook. **A PR that changes endpoint
+YAML without committing the regenerated output will fail the drift gate.**
+
+## Adding an ESPN endpoint
+
+1. Add the endpoint to the right family file (`espn_site_v2.yaml` / `espn_core_v2.yaml`
+   / `espn_web_v3.yaml`) with its `short`, `family`, `scope`
+   (`universal` / `ncaa` / `football` / `mlb`), `path`, and params.
+2. (Optional) Register a parser in `src/parsers/espn.ts` / `_registry.ts` and a
+   returns schema under `tools/codegen/schemas/`.
+3. `npm run codegen` and commit the regenerated output.
+4. Add or extend a Mocha test under `test/`.
+
+The endpoint automatically appears on **every** league in its scope under both naming
+conventions — no per-league edits required.
+
+## Adding a new flat-API family
+
+1. **Generate a YAML skeleton from the OpenAPI spec.** If the provider has an
+   OpenAPI 3.x spec (e.g. from the `sdv-swagger` collection):
+
+   ```sh
+   node tools/codegen/from-openapi.mjs <spec.yaml> --api <stem> --out tools/codegen/endpoints/<stem>.yaml
+   ```
+
+   This emits a skeleton (`api:`, `host:`, optional `auth: true`, `endpoints:` with
+   `short`/`path`/`parser`/`returns_schema`/params). Only `GET` operations become
+   wrappers. The `parser:` / `returns_schema:` values are placeholders.
+2. **Register the stem** in `tools/codegen/generate.mjs`: add it to `FLAT_API_FILES`,
+   map it in `FLAT_API_NAMESPACES`, and add a `FLAT_API_META` `{ label, source }`
+   entry. **Add the same `FLAT_API_NAMESPACES` mapping to `src/index.ts`** (the two
+   copies must stay in sync). A standalone provider namespace (not a league) gets its
+   own reference page automatically.
+3. **Author the parsers** in `src/parsers/<stem>.ts` and register them in
+   `src/parsers/_registry.ts`. Add returns schemas under
+   `tools/codegen/schemas/native/<stem>/`.
+4. **Handle auth** if needed in `src/core/` (e.g. `client.ts` hosts, an auth helper
+   like `nfl_auth.ts`). Document the auth style (keyless / apiKey query / bearer mint
+   / caller-supplied headers/JWT).
+5. `npm run codegen`, then `npm run bundle:parsers` if the parsers are browser-relevant.
+6. Add Mocha tests with captured fixtures.
+
+## The parser contract
+
+A parser is a function `(raw) => rows[]`:
+
+- Returns a **tidy array of flat row objects** — nested fields flattened via the
+  in-house `normalize` (the JS analog of pandas `json_normalize`), keys snake_cased
+  via `snakeCase`.
+- Returns `[]` (a zero-row result) for empty / malformed payloads — **never throws**,
+  so callers can chain without null checks.
+- Is reached only when the caller passes `{ parsed: true }`; the default return is
+  always the **raw** payload. Dispatch is strictly additive — do not change a
+  wrapper's default return.
+- The ESPN `summary` parser is a dispatcher: it returns 21 sub-frames, or one when
+  given a `section` arg.
+
+The browser-safe barrel is `src/parsers/index.ts` (the `sportsdataverse/parsers`
+subpath export). It must import only browser-safe code (`_normalize`, sibling
+parsers, `papaparse`) — never node-only HTTP deps. Run `npm run bundle:parsers` after
+editing any parser so the playground bundle stays current.
+
+## Testing
+
+- Tests live under `test/**/*.test.js` and run with **Mocha** + `should`.
+- **No network in the default suite** — use captured fixtures.
+- `npm test` runs `npm run build` first (via `pretest`), then Mocha.
+- Add a test for any new endpoint, parser, or bug fix. Parser tests should be
+  payload-agnostic where possible so re-captured fixtures keep working.
+
+## Docs & playground
+
+- The Docusaurus site is under `docs/`. The reference subtree
+  (`docs/docs/reference/**`) and playground metadata are **generated** — edit the YAML,
+  not the Markdown. Conceptual pages (`docs/docs/intro.md`, tutorials, architecture)
+  are hand-authored and survive regeneration.
+- Build the site to confirm nothing broke:
+
+  ```sh
+  cd docs && npx docusaurus build
+  ```
+
+- The playground runs the **bundled** parser layer
+  (`docs/src/playground/parsers.bundle.mjs`) plus a serverless proxy
+  (`docs/api/run.mjs`). Rebundle with `npm run bundle:parsers` after parser changes.
+
+## Commit conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(odds): add player-prop event-odds wrappers
+fix(parsers): return [] for empty NHL boxscore
+docs(reference): regenerate after mlb_api endpoint add
+refactor(codegen): extract standalone-provider page renderer
+chore(deps): bump typescript + re-lock
+```
+
+**Do not add AI/assistant co-author trailers or "Generated with …" lines.** Omit all
+`Co-Authored-By:` trailers referencing AI tools (Claude, Copilot, Cursor, GPT,
+Gemini, …) and never add a "🤖 Generated with" line to commits or PR bodies — whether
+the change was generated, refactored, or reviewed with AI assistance.
+
+## Opening a pull request
+
+Before opening a PR, confirm:
+
+- [ ] `npm test` passes.
+- [ ] `npm run codegen:check` passes (regenerated output committed if you touched
+      endpoint YAML / renderers).
+- [ ] `npm run typecheck` is clean.
+- [ ] `cd docs && npx docusaurus build` succeeds (for doc-affecting changes).
+- [ ] No hand-edited generated files (`src/generated/**`, `docs/docs/reference/**`).
+- [ ] Parsers rebundled (`npm run bundle:parsers`) if you changed `src/parsers/`.
+- [ ] Conventional Commit messages, no AI attribution.
+
+Fill out the [pull request template](.github/pull_request_template.md) and link any
+related issue. Thank you for contributing!
+
+## The SportsDataverse ecosystem
+
+`sportsdataverse-js` is one of a family of open-source sports-data packages. If
+you're adding a data source, check whether a sister package already implements it
+— mirroring the R/Python surface keeps the ecosystem consistent:
+
+- **Python** ([py.sportsdataverse.org](https://py.sportsdataverse.org)): `sportsdataverse-py`,
+  `collegebaseball`, `sportypy`, `nwslpy`.
+- **R** ([r.sportsdataverse.org](https://r.sportsdataverse.org)): `hoopR`, `wehoop`,
+  `cfbfastR`, `fastRhockey`, `baseballr`, `recruitR`, `oddsapiR`, `softballR`,
+  `cfb4th`, `cfbplotR`, `sportyR`, plus the `nflverse` family.
+
+See the [README ecosystem table](README.md#the-sportsdataverse-ecosystem) for links.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Saiem Gilani
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,21 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=twitter&style=for-the-badge)](https://twitter.com/SportsDataverse)
 
 `sportsdataverse` is the SportsDataverse's **Node.js** client for sports data. As of
-**v3.0.0** it is a **cross-league ESPN client**: a single, uniform surface of **116
-endpoint wrappers** generated for **29 leagues** — play-by-play, box scores,
-schedules, rosters, standings, rankings, odds, and more — plus the original
-hand-written scrapers it has always shipped.
+**v3.0.0** it is a **cross-league ESPN client _plus_ a native (non-ESPN) live-API
+client** with a tidy parser layer:
+
+- **116 ESPN endpoint wrappers** generated for **29 leagues** (31 namespaces) from a
+  single YAML source of truth — play-by-play, box scores, schedules, rosters,
+  standings, rankings, and more, identical on every league.
+- **517 flat-API wrappers across 13 families** — the **7 native** league APIs (MLB
+  Stats, Baseball Savant / Statcast, NHL api-web/edge/stats-rest/records, NFL.com
+  Shield) merged onto their league namespace, and **5 cross-sport providers** (The
+  Odds API, 247Sports, CBS Sports, Fox Sports, Yahoo Sports) on their own
+  `sdv.<provider>.*` namespaces.
+- **A tidy parser layer** — every wrapper returns raw JSON by default; pass
+  `{ parsed: true }` to get a tidy array of flat, snake_cased row objects.
+- Plus the original hand-written scrapers the package has always shipped
+  (`sdv.nba.getPlayByPlay(...)` etc.), preserved unchanged.
 
 It is the Node.js sister to the [`sportsdataverse-py`](https://py.sportsdataverse.org/)
 Python package and the [SportsDataverse R packages](https://r.sportsdataverse.org/)
@@ -74,13 +85,55 @@ await sdv.nfl.espnNflTeamSchedule({ teamId: 12, season: 2024 });  // identical
 const pbp = await sdv.nba.getPlayByPlay(401584793);  // legacy method, still works
 ```
 
+### Tidy rows with `{ parsed: true }`
+
+Every wrapper returns the **raw** payload by default. Pass `{ parsed: true }` to run
+it through a registered parser and get a tidy array of flat, snake_cased row objects
+(nested fields flattened) — the JS analog of `sportsdataverse-py`'s `return_parsed=True`:
+
+```js
+const raw  = await sdv.nba.espnNbaScoreboard({});                  // raw ESPN JSON
+const rows = await sdv.nba.espnNbaScoreboard({ parsed: true });    // tidy row objects
+
+// The summary endpoint is a dispatcher — omit `section` for all 21 sub-frames,
+// or request one:
+const box  = await sdv.nba.espnNbaSummary({ event_id: 401584793, parsed: true, section: "boxscore_player" });
+```
+
+### Native APIs and cross-sport providers
+
+The **native** league APIs are merged onto their league namespace, so they sit next
+to the ESPN methods. The **provider** families live on their own namespaces:
+
+```js
+// Native — MLB Stats API + Baseball Savant / Statcast (on sdv.mlb)
+await sdv.mlb.mlbApiSchedule({ sport_id: 1, date: "2024-07-04", parsed: true });
+await sdv.mlb.mlbStatcastSearch({ season: 2024, player_type: "batter" });
+
+// Native — NHL api-web + NFL.com Shield (token minted automatically, no creds)
+await sdv.nhl.nhlApiWebPbp({ game_id: 2023030417, parsed: true });
+await sdv.nfl.nflApiWeeklyGameDetails({ season: 2024, week: 1, parsed: true });
+
+// Providers — standalone namespaces (auth varies per provider)
+await sdv.odds.oddsApiSports({ api_key: process.env.ODDS_API_KEY, parsed: true });
+await sdv.fox.fox_bifrost_scoreboard({ parsed: true });            // public apikey defaulted
+```
+
+Browser callers can import **just** the parser layer (no node-only HTTP deps) from the
+`sportsdataverse/parsers` subpath export:
+
+```js
+import { parseEndpoint } from "sportsdataverse/parsers";
+const rows = parseEndpoint("espn", "scoreboard", rawPayload);
+```
+
 ### Introspect the surface
 
 ```js
 import sdv, { LEAGUES, WRAPPERS } from "sportsdataverse";
 
-LEAGUES.map((l) => l.prefix);           // ['nba','nfl',...,'soccer','cricket','ufl',...]
-WRAPPERS.length;                         // 116 endpoint definitions
+LEAGUES.map((l) => l.prefix);           // ['nba','wnba',...,'soccer','cricket','ufl',...] (29)
+WRAPPERS.length;                         // generated ESPN wrapper definitions
 Object.keys(sdv.nba).filter((k) => k.startsWith("espnNba"));  // every NBA wrapper
 ```
 
@@ -90,19 +143,55 @@ apply to it. See the [per-league reference](https://js.sportsdataverse.org/docs/
 for the full list, or try any call live in the
 [playground](https://js.sportsdataverse.org/playground).
 
-## How it's built
+## Architecture
 
-The ESPN client is **generated from a single YAML source of truth**
-(`tools/codegen/endpoints/*.yaml`). One generator emits the runtime wrapper tables,
-the per-league docs reference, and the playground metadata — so they can never drift
-apart.
+The library is **codegen-driven**. `tools/codegen/generate.mjs` reads the vendored
+endpoint YAML in `tools/codegen/endpoints/*.yaml` and, from that single source of
+truth, generates:
+
+- the runtime TypeScript wrapper / league tables under `src/generated/`
+  (`wrappers.ts`, `leagues.ts`),
+- the per-league Markdown reference under `docs/docs/reference/`, and
+- the playground metadata `docs/src/playground/endpoints.json`.
+
+`npm run codegen` writes those outputs; `npm run codegen:check` is the **drift gate**
+that fails CI if the committed output is stale. **Generated files are never
+hand-edited** — you edit the YAML (or the templates) and regenerate.
+
+- **ESPN surface** — one core, parameterized on `(sport, league)` slugs, is wrapped
+  once per URL family (Site v2 / Core v2 / Web v3) and exposed across **29 leagues**
+  as `espn_<league>_<short>` (snake) **and** `espn<League><Short>` (camelCase). The
+  per-league extension modules are thin; endpoints carry a **scope** (`universal`,
+  `ncaa`, `football`, `mlb`) so each league gets exactly the endpoints that apply.
+- **Flat-API families** — non-ESPN, absolute-host live APIs. The **7 native** APIs
+  (MLB Stats, Statcast, NHL ×4, NFL.com) are merged onto their league namespace; the
+  **5 cross-sport providers** (Odds / 247 / CBS / Fox / Yahoo) get standalone
+  `sdv.<provider>.*` namespaces and their own generated reference page. Auth varies
+  per family — bearer-token mint (NFL.com, automatic), `apiKey` query (Odds), public
+  `apikey`+`api-version` (Fox), caller-supplied `headers`/JWT (247, Yahoo), keyless
+  (CBS).
+- **OpenAPI → YAML transform** — `tools/codegen/from-openapi.mjs` turns a canonical
+  OpenAPI 3.x spec (the `sdv-swagger` collection) into an endpoint-YAML *skeleton*,
+  which made the provider families largely mechanical to add.
+- **Parser layer** — `src/parsers/` registers one parser per endpoint. `{ parsed:
+  true }` runs the raw payload through it → a tidy array of flat, snake_cased row
+  objects (nested fields flattened by the in-house `normalize`). The browser-safe
+  `sportsdataverse/parsers` barrel is esbuild-bundled into the playground so it parses
+  client-side.
+
+**TypeScript + ESM-only**, dual-case naming, Mocha no-network tests, and a Docusaurus
+3 docs site on Vercel with a live playground.
 
 ```bash
 npm run codegen         # regenerate from the endpoint YAML
 npm run codegen:check   # drift gate (fails if the committed output is stale)
+npm run bundle:parsers  # rebuild the browser parser bundle for the playground
 npm run build           # compile TypeScript -> dist/
-npm test                # mocha suite (SDV_LIVE=1 adds a live per-league smoke test)
+npm test                # mocha suite (no network)
 ```
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full workflow and
+[`CLAUDE.md`](CLAUDE.md) for the architecture deep-dive.
 
 ## Documentation
 
@@ -113,6 +202,42 @@ The full reference is on the docs site: **<https://js.sportsdataverse.org/>**.
 - **[Playground](https://js.sportsdataverse.org/playground)** — run live ESPN calls in the browser.
 - **[API](https://js.sportsdataverse.org/docs/api/)** — the full typed module surface (TypeDoc).
 - **[Changelog](https://js.sportsdataverse.org/CHANGELOG)** — release notes.
+
+### The SportsDataverse ecosystem
+
+`sportsdataverse-js` is part of a family of open-source sports-data packages across
+**Node.js, Python, and R**, all under the [SportsDataverse](https://sportsdataverse.org)
+umbrella.
+
+**Node.js** — [js.sportsdataverse.org](https://js.sportsdataverse.org)
+
+- [`sportsdataverse`](https://js.sportsdataverse.org) — this package.
+
+**Python** — [py.sportsdataverse.org](https://py.sportsdataverse.org)
+
+| Package | Domain |
+|---|---|
+| [`sportsdataverse-py`](https://py.sportsdataverse.org/) | Cross-sport sister package (NBA/WNBA/NFL/MLB/NHL/MBB/WBB/CFB + odds) |
+| [`collegebaseball`](https://collegebaseball.readthedocs.io/) | College baseball |
+| [`sportypy`](https://sportypy.sportsdataverse.org/) | Matplotlib sport field/court/rink plotting |
+| [`nwslpy`](https://github.com/nwslR/nwslpy) | NWSL women's soccer |
+
+**R** — [r.sportsdataverse.org](https://r.sportsdataverse.org)
+
+| Package | Domain |
+|---|---|
+| [`hoopR`](https://hoopR.sportsdataverse.org) | Men's basketball (NBA / MBB) |
+| [`wehoop`](https://wehoop.sportsdataverse.org) | Women's basketball (WNBA / WBB) |
+| [`cfbfastR`](https://cfbfastR.sportsdataverse.org) | College football |
+| [`fastRhockey`](https://fastRhockey.sportsdataverse.org) | Hockey (NHL / PWHL) |
+| [`baseballr`](https://billpetti.github.io/baseballr/) | Baseball (MLB / MiLB / college) |
+| [`recruitR`](https://recruitR.sportsdataverse.org) | Recruiting |
+| [`oddsapiR`](https://oddsapiR.sportsdataverse.org) | Betting odds (The Odds API) |
+| [`softballR`](https://github.com/sportsdataverse/softballR) | Softball |
+| [`cfb4th`](https://cfb4th.sportsdataverse.org) | College football 4th-down models |
+| [`cfbplotR`](https://cfbplotR.sportsdataverse.org) | College football ggplot2 helpers |
+| [`sportyR`](https://sportyR.sportsdataverse.org) | ggplot2 sport field/court/rink plotting |
+| [`nflfastR`](https://www.nflfastr.com) / [`nflverse`](https://nflverse.nflverse.com) | NFL ecosystem |
 
 ## Our Authors
 

--- a/docs/src/pages/CHANGELOG.md
+++ b/docs/src/pages/CHANGELOG.md
@@ -34,6 +34,18 @@ A major release that turns `sportsdataverse` into a **cross-league ESPN client**
   wrappers** now accept the same `{ parsed: true }` flag — a faithful port of
   `sdv-py`'s `_common_espn_parsers` (22 parsers covering all 116 ESPN endpoints,
   incl. the 21-sub-frame `summary` dispatcher with a `section` arg).
+- **Five cross-sport provider families.** Beyond ESPN + the native league APIs,
+  five independent providers each get a standalone `sdv.<ns>.*` namespace +
+  reference page, generated from a canonical OpenAPI spec via a reusable
+  **OpenAPI→endpoint-YAML transform**:
+  - **The Odds API** (`sdv.odds.*`, 10) — odds/scores; `apiKey` query param.
+  - **247Sports** (`sdv.recruiting.*`, 25) — recruiting rankings (caller JWT).
+  - **CBS Sports** (`sdv.cbs.*`, 82) — public NAPI, keyless.
+  - **Fox Sports** (`sdv.fox.*`, 38) — Bifrost API (`{sport}`); public apikey.
+  - **Yahoo Sports** (`sdv.yahoo.*`, 107) — editorial + shangrila stats-graph.
+
+  **517 flat-API wrappers across 13 families** in total; `{ parsed: true }` works
+  for every one.
 - **Dual-case naming.** Every generated wrapper (ESPN and native) is exposed
   under BOTH its snake_case name (`mlb_api_teams`, py/R parity) and its camelCase
   canonical name (`mlbApiTeams`, idiomatic JS) — same function, either name.
@@ -44,7 +56,14 @@ A major release that turns `sportsdataverse` into a **cross-league ESPN client**
   with server-side token minting for NFL.com and content-type passthrough for
   Statcast CSV/HTML). A shared **ESPN parsed returns** page documents the columns
   each of the 22 ESPN parsers yields (documented once by parser, since the 116
-  endpoints share them), linked from every league page.
+  endpoints share them), linked from every league page. The playground now also
+  has a **Raw/Parsed toggle** (tidy rows render as a sortable table), **shareable
+  deep-link URLs**, and an **Examples menu** spanning ESPN, the native APIs, and
+  all five providers.
+- **Getting-started guides + RunKit notebooks.** Per-area recipe pages under
+  `/docs/guides/` (quickstart, NBA/WNBA/college-basketball/NFL/MLB/NHL/CFB/soccer,
+  providers) with runnable raw-vs-parsed snippets, "Open in playground" deep-links,
+  and embedded RunKit live notebooks.
 - **Migrated to TypeScript.** The package is authored in TypeScript and ships
   type declarations (`.d.ts`) alongside the ESM build. The compiler caught
   several latent bugs during the port.


### PR DESCRIPTION
Repo documentation + meta files for the v3.0.0 release.

## What's here
- **LICENSE** (MIT, Saiem Gilani) — the repo had none despite `package.json` declaring MIT.
- **CLAUDE.md** — agent/contributor guide centered on the **codegen architecture**: `tools/codegen/endpoints/*.yaml` → `generate.mjs` → the runtime wrapper tables (`src/generated/`), per-league reference docs, and playground metadata; the flat-API families (7 native + 5 standalone-namespace providers); the `from-openapi.mjs` OpenAPI→YAML transform; the parser layer + `{ parsed: true }`; dual-case naming; the drift gate; and conventions (incl. the no-AI-attribution rule).
- **CONTRIBUTING.md** — setup, the edit-YAML→`codegen`→commit-generated workflow, adding an endpoint / a new family via the transform, the parser contract + `bundle:parsers`, testing (Mocha, no-network), commit conventions, and an ecosystem cross-link section.
- **CODE_OF_CONDUCT.md** — adopts Contributor Covenant v2.1.
- **.github/** — `copilot-instructions.md`, `pull_request_template.md`, `ISSUE_TEMPLATE/` (bug report, feature request, config).
- **README** — refreshed for the full v3.0.0 surface (ESPN + 7 native + 5 provider families + parser layer + playground), added an **Architecture** section, fixed two stale method names, and expanded the **SportsDataverse ecosystem** table to cover all the Python and R sister packages.
- **CHANGELOG** (root + docs mirror) — completed the v3.0.0 notes (all 5 providers + the transform + the playground upgrade), folding the previously "Unreleased" Odds section in.

Docs-only / metadata; no runtime or generated-output changes. Precedes the v3.0.0 tag + npm publish.