### PR TITLE
proto: embeddable RunCell + build-time output injector (docs prototypes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
             docs/package-lock.json
       # Root deps so docusaurus-plugin-typedoc can resolve the package's src imports.
       - run: npm ci
+      # Drift gate: the guides carry build-time "frozen" parser-output tables
+      # (tools/docs/inject-outputs.mjs, manifest in tools/docs/examples.mjs).
+      # `--check` re-runs every example through the committed parser bundle and
+      # fails if any guide's injected block is stale vs a fresh run, so the
+      # frozen outputs can never silently drift from the parsers. Regenerate
+      # locally with `npm run docs:examples` and commit the result.
+      - name: Docs example-output drift check
+        run: npm run docs:examples:check
       - run: npm ci
         working-directory: docs
       # Builds the Docusaurus site (generates the TypeDoc API reference) and fails

--- a/docs/docs/guides/01-quickstart.mdx
+++ b/docs/docs/guides/01-quickstart.mdx
@@ -108,6 +108,73 @@ up once **v3 is published**. Until then the embed may resolve v2, whose surface
 differs. Copy any snippet into Node to run it against your installed version.
 :::
 
+## Real parsed output (frozen at build)
+
+The tables below are **real parser output**, rendered at build time from
+committed ESPN fixtures and frozen into this page. They are deterministic
+(fixture-driven, no network) so CI reproduces them exactly — the same injector
+could instead run live and refresh against today's data. Regenerate with
+`npm run docs:examples`.
+
+{/* The blocks between the markers below are written by tools/docs/inject-outputs.mjs. */}
+
+<!-- inject:example:scoreboard -->
+
+`sdv.nba.espnNbaScoreboard({ parsed: true })` — one row per game.
+
+| game_id | uid | date | name | short_name | season_year |
+| --- | --- | --- | --- | --- | --- |
+| 401704871 | s:40~l:46~e:401704871 | 2024-12-01T20:30Z | Orlando Magic at Brooklyn Nets | ORL @ BKN | 2025 |
+| 401704872 | s:40~l:46~e:401704872 | 2024-12-01T20:30Z | Indiana Pacers at Memphis Grizzlies | IND @ MEM | 2025 |
+| 401704873 | s:40~l:46~e:401704873 | 2024-12-01T23:00Z | Boston Celtics at Cleveland Cavaliers | BOS @ CLE | 2025 |
+| 401704874 | s:40~l:46~e:401704874 | 2024-12-01T23:00Z | New Orleans Pelicans at New York Knicks | NO @ NY | 2025 |
+| 401704875 | s:40~l:46~e:401704875 | 2024-12-01T23:00Z | Miami Heat at Toronto Raptors | MIA @ TOR | 2025 |
+| 401704876 | s:40~l:46~e:401704876 | 2024-12-02T00:00Z | Oklahoma City Thunder at Houston Rockets | OKC @ HOU | 2025 |
+| 401704877 | s:40~l:46~e:401704877 | 2024-12-02T01:00Z | Los Angeles Lakers at Utah Jazz | LAL @ UTAH | 2025 |
+| 401704878 | s:40~l:46~e:401704878 | 2024-12-02T02:00Z | Dallas Mavericks at Portland Trail Bl… | DAL @ POR | 2025 |
+
+_10 rows total — first 8 shown, 50 cols total — first 6 shown._
+
+<!-- /inject -->
+
+<!-- inject:example:standings -->
+
+`sdv.nba.espnNbaStandings({ parsed: true })` — one row per team.
+
+| group_name | group_abbreviation | team_id | team_name | team_abbreviation | team_display_name |
+| --- | --- | --- | --- | --- | --- |
+| Eastern Conference | East | 19 | Magic | ORL | Orlando Magic |
+| Eastern Conference | East | 15 | Bucks | MIL | Milwaukee Bucks |
+| Eastern Conference | East | 14 | Heat | MIA | Miami Heat |
+| Eastern Conference | East | 20 | 76ers | PHI | Philadelphia 76ers |
+| Eastern Conference | East | 11 | Pacers | IND | Indiana Pacers |
+| Eastern Conference | East | 5 | Cavaliers | CLE | Cleveland Cavaliers |
+| Eastern Conference | East | 18 | Knicks | NY | New York Knicks |
+| Eastern Conference | East | 1 | Hawks | ATL | Atlanta Hawks |
+
+_30 rows total — first 8 shown, 31 cols total — first 6 shown._
+
+<!-- /inject -->
+
+<!-- inject:example:team_roster -->
+
+`sdv.nba.espnNbaTeamRoster({ team_id: 13, parsed: true })` — one row per player.
+
+| id | uid | guid | alternate_ids_sdr | first_name | last_name |
+| --- | --- | --- | --- | --- | --- |
+| 4278129 | s:40~l:46~a:4278129 | 9af41ea8-a24c-025f-a63f-8263fbf0ca66 | 4278129 | Deandre | Ayton |
+| 3945274 | s:40~l:46~a:3945274 | 583794eb-0f38-9bbd-3e25-9dd33b7f83b8 | 3945274 | Luka | Doncic |
+| 4066648 | s:40~l:46~a:4066648 | 40c1bcf6-675b-f217-f97c-1d628073f927 | 4066648 | Rui | Hachimura |
+| 4397077 | s:40~l:46~a:4397077 | 4cd92ac1-73ce-653d-c3b1-9c68e9c7a4d0 | 4397077 | Jaxson | Hayes |
+| 4683774 | s:40~l:46~a:4683774 | 456f71fd-2ce5-3f50-8d0d-f30c0159789d | 4683774 | Bronny | James |
+| 1966 | s:40~l:46~a:1966 | 1f6592b3-ff53-d321-8dc5-6038d48c1786 | 2126588 | LeBron | James |
+| 3913174 | s:40~l:46~a:3913174 | 668a6a14-4003-d79c-c252-0ece0a960d36 | 3913174 | Luke | Kennard |
+| 2960236 | s:40~l:46~a:2960236 | d06ad722-26ff-5865-1433-061e2e6fbb32 | 2960236 | Maxi | Kleber |
+
+_17 rows total — first 8 shown, 68 cols total — first 6 shown._
+
+<!-- /inject -->
+
 ## Where next
 
 - **[NBA](./nba)**, **[NFL](./nfl)**, **[MLB](./mlb)**, **[NHL](./nhl)**,

--- a/docs/docs/guides/cfb.mdx
+++ b/docs/docs/guides/cfb.mdx
@@ -4,6 +4,8 @@ sidebar_label: CFB
 sidebar_position: 8
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # CFB recipes
 
 College football lives under `sdv.cfb`. It carries the universal ESPN surface
@@ -19,6 +21,10 @@ const games = await sdv.cfb.espnCfbScoreboard({ parsed: true });
 console.table(games);
 ```
 
+Live and inline — `week` + `groups` (80 = FBS) narrow it down:
+
+<RunCell league="cfb" endpoint="espn:scoreboard" parsed title="CFB scoreboard — live" />
+
 [Open in playground ▶](/playground?l=cfb&e=espn%3Ascoreboard&parsed=1)
 
 ## Rankings (AP poll & friends)
@@ -29,6 +35,8 @@ import sdv from 'sportsdataverse';
 const rankings = await sdv.cfb.espnCfbRankings({ parsed: true });
 console.table(rankings);
 ```
+
+<RunCell league="cfb" endpoint="espn:rankings" parsed title="CFB rankings — live" />
 
 [Open in playground ▶](/playground?l=cfb&e=espn%3Arankings&parsed=1)
 

--- a/docs/docs/guides/college-basketball.mdx
+++ b/docs/docs/guides/college-basketball.mdx
@@ -4,6 +4,8 @@ sidebar_label: College Basketball
 sidebar_position: 4
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # College basketball recipes (MBB & WBB)
 
 College basketball spans two namespaces that share an identical ESPN surface:
@@ -28,6 +30,10 @@ const games = await sdv.mbb.espnMbbScoreboard({ parsed: true });
 console.table(games);
 ```
 
+Live and inline (men's). Swap `league="wbb"` for the women's board:
+
+<RunCell league="mbb" endpoint="espn:scoreboard" parsed title="Men's CBB scoreboard — live" />
+
 [Open in playground ▶](/playground?l=mbb&e=espn%3Ascoreboard&parsed=1)
 
 ## Rankings (AP Top 25 & Coaches)
@@ -42,6 +48,10 @@ const women = await sdv.wbb.espnWbbRankings({ parsed: true });
 console.table(men);
 console.table(women);
 ```
+
+The men's AP Top 25, live and inline (swap `league="wbb"` for the women's poll):
+
+<RunCell league="mbb" endpoint="espn:rankings" parsed title="Men's CBB rankings — live" />
 
 [Open men's in playground ▶](/playground?l=mbb&e=espn%3Arankings&parsed=1) ·
 [Open women's in playground ▶](/playground?l=wbb&e=espn%3Arankings&parsed=1)

--- a/docs/docs/guides/mlb.mdx
+++ b/docs/docs/guides/mlb.mdx
@@ -4,6 +4,8 @@ sidebar_label: MLB
 sidebar_position: 6
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # MLB recipes
 
 Baseball lives under `sdv.mlb`, which spans **three** surfaces: the ESPN
@@ -33,6 +35,17 @@ import sdv from 'sportsdataverse';
 const schedule = await sdv.mlb.mlbApiSchedule({ parsed: true });
 console.table(schedule);
 ```
+
+Live and inline — `statsapi.mlb.com`'s schedule, parsed to one row per game.
+Add a `date` (YYYY-MM-DD) to scope it:
+
+<RunCell
+  league="mlb"
+  endpoint="flat:mlb_api:schedule"
+  params={{ date: '2024-03-28' }}
+  parsed
+  title="MLB Stats API schedule — native, live"
+/>
 
 [Open in playground ▶](/playground?l=mlb&e=flat%3Amlb_api%3Aschedule&parsed=1)
 
@@ -74,6 +87,17 @@ const batTracking = await sdv.mlb.mlbStatcastLeaderboardBatTracking({
 });
 console.table(batTracking.slice(0, 10));
 ```
+
+Statcast leaderboards stream **CSV** (not JSON), so the inline cell below shows
+the raw response body — the package's `mlbStatcast*` parsers turn that CSV into
+tidy rows in Node (the browser cell just surfaces it). Scope with a `year`:
+
+<RunCell
+  league="mlb"
+  endpoint="flat:mlb_statcast:leaderboard_bat_tracking"
+  params={{ year: 2024 }}
+  title="Statcast bat-tracking leaderboard — raw CSV"
+/>
 
 [Open in playground ▶](/playground?l=mlb&e=flat%3Amlb_statcast%3Aleaderboard_bat_tracking&parsed=1&year=2024)
 

--- a/docs/docs/guides/nba.mdx
+++ b/docs/docs/guides/nba.mdx
@@ -1,8 +1,4 @@
----
-title: NBA & WNBA recipes
-sidebar_label: NBA / WNBA
-sidebar_position: 2
----
+import RunCell from '@site/src/components/RunCell';
 
 # NBA & WNBA recipes
 
@@ -20,6 +16,12 @@ const games = await sdv.nba.espnNbaScoreboard({ parsed: true });
 console.table(games);
 ```
 
+The cell below is the same call, live and inline — edit a param, hit **Run ▶**,
+and the response is parsed into tidy rows right here (no copy-paste, no leaving
+the page). It runs against the deployed site's proxy.
+
+<RunCell league="nba" endpoint="espn:scoreboard" parsed title="NBA scoreboard — live" />
+
 [Open in playground ▶](/playground?l=nba&e=espn%3Ascoreboard&parsed=1)
 
 ## A full team roster
@@ -32,6 +34,14 @@ import sdv from 'sportsdataverse';
 const roster = await sdv.nba.espnNbaTeamRoster({ team_id: 13, parsed: true });
 console.table(roster);
 ```
+
+<RunCell
+  league="nba"
+  endpoint="espn:team_roster"
+  params={{ team_id: 13 }}
+  parsed
+  title="Lakers roster — change team_id and re-run"
+/>
 
 [Open in playground ▶](/playground?l=nba&e=espn%3Ateam_roster&parsed=1&team_id=13)
 

--- a/docs/docs/guides/nba.mdx
+++ b/docs/docs/guides/nba.mdx
@@ -65,6 +65,31 @@ console.table(boxscore);
 
 [Open in playground ▶](/playground?l=nba&e=espn%3Asummary&parsed=1&section=boxscore_team)
 
+### Frozen output (real summary sub-frame, no network)
+
+The table below is **real summary-dispatcher output** — the `leaders` sub-frame,
+rendered at build time from a committed ESPN fixture and frozen into this page
+(deterministic; CI reproduces it exactly). Regenerate with `npm run docs:examples`.
+
+{/* Written by tools/docs/inject-outputs.mjs — do not hand-edit. */}
+
+<!-- inject:example:summary_leaders -->
+
+`sdv.nba.espnNbaSummary({ event_id, parsed: true, section: 'leaders' })` — the `leaders` sub-frame of the 21-section summary dispatcher.
+
+| team_id | team_abbreviation | category_name | category_display_name | athlete_id | athlete_display_name |
+| --- | --- | --- | --- | --- | --- |
+| 19 | ORL | points | Points | 4432573 | Paolo Banchero |
+| 19 | ORL | assists | Assists | 4432573 | Paolo Banchero |
+| 19 | ORL | rebounds | Rebounds | 4566434 | Franz Wagner |
+| 28 | TOR | points | Points | 4277883 | Jordan Nwora |
+| 28 | TOR | assists | Assists | 4395724 | Immanuel Quickley |
+| 28 | TOR | rebounds | Rebounds | 4277883 | Jordan Nwora |
+
+_6 rows, 12 cols total — first 6 shown._
+
+<!-- /inject -->
+
 ## WNBA — same surface, different namespace
 
 ```js

--- a/docs/docs/guides/nfl.mdx
+++ b/docs/docs/guides/nfl.mdx
@@ -4,6 +4,8 @@ sidebar_label: NFL
 sidebar_position: 5
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # NFL recipes
 
 Pro football lives under `sdv.nfl`, which spans **two** surfaces: the ESPN
@@ -21,6 +23,10 @@ import sdv from 'sportsdataverse';
 const games = await sdv.nfl.espnNflScoreboard({ parsed: true });
 console.table(games);
 ```
+
+Run it inline — edit a param and hit **Run ▶** for live, parsed rows:
+
+<RunCell league="nfl" endpoint="espn:scoreboard" parsed title="NFL scoreboard — live" />
 
 [Open in playground ▶](/playground?l=nfl&e=espn%3Ascoreboard&parsed=1)
 
@@ -73,7 +79,41 @@ const standings = await sdv.nfl.nflApiStandings({
 console.table(standings);
 ```
 
+The same call, live and inline — a native `api.nfl.com` request, parsed to one
+row per team. `season_type` is a dropdown (`REG` / `POST` / `PRE`):
+
+<RunCell
+  league="nfl"
+  endpoint="flat:nfl_api:standings"
+  params={{ season: 2024, season_type: 'REG', week: 1 }}
+  parsed
+  title="NFL.com Shield standings — native, live"
+/>
+
 [Open in playground ▶](/playground?l=nfl&e=flat%3Anfl_api%3Astandings&parsed=1&season=2024&season_type=REG&week=1)
+
+### Frozen output (real parser rows, no network)
+
+The table below is **real `parse_nfl_standings` output**, rendered at build time
+from a committed sample fixture and frozen into this page (deterministic — CI
+reproduces it exactly). Regenerate with `npm run docs:examples`.
+
+{/* Written by tools/docs/inject-outputs.mjs — do not hand-edit. */}
+
+<!-- inject:example:nfl_standings -->
+
+`sdv.nfl.nflApiStandings({ season: 2024, parsed: true })` — the native NFL.com Shield standings, one row per team (sample fixture).
+
+| team_abbreviation | team_full_name | conference | division | wins | losses |
+| --- | --- | --- | --- | --- | --- |
+| KC | Kansas City Chiefs | AFC | AFC West | 15 | 2 |
+| BUF | Buffalo Bills | AFC | AFC East | 13 | 4 |
+| DET | Detroit Lions | NFC | NFC North | 15 | 2 |
+| PHI | Philadelphia Eagles | NFC | NFC East | 14 | 3 |
+
+_4 rows, 12 cols total — first 6 shown._
+
+<!-- /inject -->
 
 ## Rosters & weekly game details (native)
 

--- a/docs/docs/guides/nhl.mdx
+++ b/docs/docs/guides/nhl.mdx
@@ -5,6 +5,7 @@ sidebar_position: 7
 ---
 
 import RunKit from '@site/src/components/RunKit';
+import RunCell from '@site/src/components/RunCell';
 
 # NHL recipes
 
@@ -43,6 +44,15 @@ const standings = await sdv.nhl.nhlApiWebStandingsSeason({ parsed: true });
 console.table(standings);
 ```
 
+Live and inline — a native `api-web.nhle.com` request, no params:
+
+<RunCell
+  league="nhl"
+  endpoint="flat:nhl_api_web:standings_season"
+  parsed
+  title="NHL api-web full-season standings — live"
+/>
+
 [Open in playground ▶](/playground?l=nhl&e=flat%3Anhl_api_web%3Astandings_season&parsed=1)
 
 ## Play-by-play for one game (api-web)
@@ -54,6 +64,16 @@ import sdv from 'sportsdataverse';
 const plays = await sdv.nhl.nhlApiWebPbp({ game_id: '2023030417', parsed: true });
 console.table(plays.slice(0, 10));
 ```
+
+The game feed, parsed to plays — change `game_id` and re-run:
+
+<RunCell
+  league="nhl"
+  endpoint="flat:nhl_api_web:pbp"
+  params={{ game_id: '2023030417' }}
+  parsed
+  title="NHL api-web game feed → parsed plays"
+/>
 
 [Open in playground ▶](/playground?l=nhl&e=flat%3Anhl_api_web%3Apbp&parsed=1&game_id=2023030417)
 

--- a/docs/docs/guides/providers.mdx
+++ b/docs/docs/guides/providers.mdx
@@ -5,6 +5,7 @@ sidebar_position: 10
 ---
 
 import RunKit from '@site/src/components/RunKit';
+import RunCell from '@site/src/components/RunCell';
 
 # Provider recipes
 
@@ -37,9 +38,19 @@ console.table(sports);
 
 [Open in playground ▶](/playground?l=odds&e=flat%3Aodds_api%3Asports&parsed=1&api_key=YOUR_ODDS_API_KEY)
 
+Live and inline — paste a real key into the `api_key` field first (calls without
+one return 401):
+
+<RunCell
+  league="odds"
+  endpoint="flat:odds_api:sports"
+  parsed
+  title="The Odds API — covered leagues (needs your api_key)"
+/>
+
 :::note
-In the playground, replace `YOUR_ODDS_API_KEY` in the `api_key` field with a real
-key — calls without one return a 401.
+In the playground and the cell above, replace the empty `api_key` field with a
+real key — calls without one return a 401.
 :::
 
 ## CBS — league metadata
@@ -52,6 +63,17 @@ import sdv from 'sportsdataverse';
 const league = await sdv.cbs.cbsNapiLeague({ league_id: 'football-nfl', parsed: true });
 console.table(league);
 ```
+
+Live and inline — the `league_id` is a CBS slug (`football-nfl`,
+`basketball-nba`, `baseball-mlb`):
+
+<RunCell
+  league="cbs"
+  endpoint="flat:cbs_napi:league"
+  params={{ league_id: 'football-nfl' }}
+  parsed
+  title="CBS NAPI league metadata — live"
+/>
 
 [Open in playground ▶](/playground?l=cbs&e=flat%3Acbs_napi%3Aleague&parsed=1&league_id=football-nfl)
 
@@ -66,6 +88,17 @@ import sdv from 'sportsdataverse';
 const board = await sdv.fox.foxBifrostScoreboard({ sport: 'cfb', parsed: true });
 console.table(board);
 ```
+
+Live and inline — the public `apikey` defaults out of the box; just pick a
+`sport` (`cfb`, `nfl`, `mlb`, `nba`, …):
+
+<RunCell
+  league="fox"
+  endpoint="flat:fox_bifrost:scoreboard"
+  params={{ sport: 'cfb' }}
+  parsed
+  title="Fox Bifrost scoreboard — public apikey, live"
+/>
 
 [Open in playground ▶](/playground?l=fox&e=flat%3Afox_bifrost%3Ascoreboard&parsed=1&sport=cfb)
 
@@ -85,6 +118,17 @@ const standings = await sdv.yahoo.yahooShangrilaLeagueStandings({
 console.table(standings);
 ```
 
+Live and inline — `lang`/`region`/`tz` default automatically; pass a `league`
+slug. If a Yahoo host rejects the call, add an `Origin`/`Referer` via `headers`:
+
+<RunCell
+  league="yahoo"
+  endpoint="flat:yahoo_shangrila:league_standings"
+  params={{ league: 'ncaaf' }}
+  parsed
+  title="Yahoo shangrila league standings — live"
+/>
+
 [Open in playground ▶](/playground?l=yahoo&e=flat%3Ayahoo_shangrila%3Aleague_standings&parsed=1&league=ncaaf)
 
 ## 247Sports — recruiting rankings
@@ -101,6 +145,14 @@ const rankings = await sdv.recruiting.sports247Rankings({
 });
 console.table(rankings);
 ```
+
+<RunCell
+  league="recruiting"
+  endpoint="flat:sports247:rankings"
+  params={{ year: 2025, sport_key: 'football' }}
+  parsed
+  title="247Sports recruiting rankings — live"
+/>
 
 [Open in playground ▶](/playground?l=recruiting&e=flat%3Asports247%3Arankings&parsed=1&year=2025&sport_key=football)
 

--- a/docs/docs/guides/soccer.mdx
+++ b/docs/docs/guides/soccer.mdx
@@ -4,6 +4,8 @@ sidebar_label: Soccer
 sidebar_position: 9
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # Soccer recipes
 
 Soccer lives under `sdv.soccer` and exposes the ESPN cross-league surface under
@@ -37,6 +39,17 @@ const fixtures = await sdv.soccer.espnSoccerScoreboard({ league: 'eng.1', parsed
 console.table(fixtures);
 ```
 
+Live and inline — the `league` field is the competition slug; change it to
+`esp.1`, `ger.1`, `uefa.champions`, … and re-run:
+
+<RunCell
+  league="soccer"
+  endpoint="espn:scoreboard"
+  params={{ league: 'eng.1' }}
+  parsed
+  title="Soccer scoreboard — pick a competition, live"
+/>
+
 [Open in playground ▶](/playground?l=soccer&e=espn%3Ascoreboard&parsed=1&league=eng.1)
 
 ## League table (standings)
@@ -49,6 +62,14 @@ import sdv from 'sportsdataverse';
 const table = await sdv.soccer.espnSoccerStandings({ league: 'esp.1', parsed: true });
 console.table(table);
 ```
+
+<RunCell
+  league="soccer"
+  endpoint="espn:standings"
+  params={{ league: 'esp.1' }}
+  parsed
+  title="Soccer league table — change the league slug, live"
+/>
 
 [Open in playground ▶](/playground?l=soccer&e=espn%3Astandings&parsed=1&league=esp.1)
 

--- a/docs/docs/guides/wnba.mdx
+++ b/docs/docs/guides/wnba.mdx
@@ -4,6 +4,8 @@ sidebar_label: WNBA
 sidebar_position: 3
 ---
 
+import RunCell from '@site/src/components/RunCell';
+
 # WNBA recipes
 
 The WNBA lives under `sdv.wnba` and exposes the full ESPN cross-league surface
@@ -23,6 +25,10 @@ const games = await sdv.wnba.espnWnbaScoreboard({ parsed: true });
 console.table(games);
 ```
 
+Live and inline — edit `dates` (YYYYMMDD) and hit **Run ▶**:
+
+<RunCell league="wnba" endpoint="espn:scoreboard" parsed title="WNBA scoreboard — live" />
+
 [Open in playground ▶](/playground?l=wnba&e=espn%3Ascoreboard&parsed=1)
 
 ## League standings
@@ -35,6 +41,8 @@ import sdv from 'sportsdataverse';
 const standings = await sdv.wnba.espnWnbaStandings({ parsed: true });
 console.table(standings);
 ```
+
+<RunCell league="wnba" endpoint="espn:standings" parsed title="WNBA standings — live" />
 
 [Open in playground ▶](/playground?l=wnba&e=espn%3Astandings&parsed=1)
 

--- a/docs/src/components/RunCell/index.jsx
+++ b/docs/src/components/RunCell/index.jsx
@@ -1,0 +1,311 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import endpoints from '@site/src/playground/endpoints.json';
+import { resolveUrl, resolveFlatUrl } from '@site/src/playground/resolve.mjs';
+import { parseEndpoint } from '@site/src/playground/parsers.bundle.mjs';
+import styles from './styles.module.css';
+
+// ---------------------------------------------------------------------------
+// <RunCell> — a compact, single-endpoint live runner, droppable inline in an
+// MDX guide. It is a focused slice of the full <Playground>: one endpoint, a
+// small row of editable param inputs, the resolved GET URL, a Run button, and
+// the result (a tidy table when `parsed`, pretty JSON otherwise).
+//
+// It reuses the playground's own infrastructure verbatim:
+//   - resolve.mjs        — builds the request URL (no network)
+//   - parsers.bundle.mjs — client-side parseEndpoint(kind, key, raw, section)
+//   - /api/run           — the Vercel serverless proxy (ESPN/flat send no CORS)
+//
+// Props:
+//   league   (string)  league prefix, e.g. "nba"
+//   endpoint (string)  "espn:<short>" or "flat:<api>:<short>"
+//   params   (object)  default param values, e.g. { team_id: 13 }
+//   parsed   (bool)    run the response through parseEndpoint and show a table
+//   section  (string)  for the ESPN summary dispatcher, pick one sub-frame
+//   title    (string)  optional heading above the cell
+// ---------------------------------------------------------------------------
+
+const FLAT_APIS = endpoints.flatApis || [];
+const FLAT_HOSTS = endpoints.flatHosts || {};
+
+const MAX_TABLE_ROWS = 25;
+const MAX_TABLE_COLS = 12;
+
+/** snake_case -> camelCase (espn_nba_scoreboard -> espnNbaScoreboard). */
+const toCamel = (s) => s.replace(/_([a-z0-9])/g, (_m, c) => c.toUpperCase());
+const espnMethodName = (prefix, short) => toCamel(`espn_${prefix}_${short}`);
+const flatMethodName = (api, short) => toCamel(`${api}_${short}`);
+
+/** Resolve the `endpoint` prop string to a def + dispatch metadata. */
+function resolveSelection(league, endpoint) {
+  if (!endpoint) return { error: 'RunCell: missing `endpoint` prop.' };
+  if (endpoint.startsWith('flat:')) {
+    const [, api, short] = endpoint.split(':');
+    const def = FLAT_APIS.find((e) => e.api === api && e.short === short);
+    if (!def) return { error: `RunCell: unknown flat endpoint "${endpoint}".` };
+    return { kind: 'flat', def, api, short };
+  }
+  const short = endpoint.startsWith('espn:') ? endpoint.slice('espn:'.length) : endpoint;
+  const lg = endpoints.leagues.find((l) => l.prefix === league);
+  if (!lg) return { error: `RunCell: unknown league "${league}".` };
+  const def = endpoints.endpoints.find((e) => e.short === short);
+  if (!def) return { error: `RunCell: unknown ESPN endpoint "${short}".` };
+  return { kind: 'espn', def, short, lg };
+}
+
+/** Editable fields for a selection (path + query params), with seeded defaults. */
+function fieldsFor(sel) {
+  const fields = [];
+  for (const p of sel.def.pathParams || []) {
+    fields.push({ name: p.name, required: p.required !== false, def: p.default });
+  }
+  for (const p of sel.def.queryParams || []) {
+    fields.push({ name: p.name, required: false, def: p.default });
+  }
+  return fields;
+}
+
+function fmtCell(v) {
+  if (v == null) return '';
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function CompactTable({ rows }) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return <div className={styles.empty}>0 rows (empty frame).</div>;
+  }
+  const allCols = [...new Set(rows.flatMap((r) => Object.keys(r)))];
+  const cols = allCols.slice(0, MAX_TABLE_COLS);
+  const shown = rows.slice(0, MAX_TABLE_ROWS);
+  return (
+    <>
+      <div className={styles.tableWrap}>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th className={styles.rowNum}>#</th>
+              {cols.map((c) => (
+                <th key={c}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((r, i) => (
+              <tr key={i}>
+                <td className={styles.rowNum}>{i}</td>
+                {cols.map((c) => (
+                  <td key={c} title={fmtCell(r[c])}>
+                    {fmtCell(r[c])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className={styles.meta}>
+        {rows.length} rows × {allCols.length} cols
+        {rows.length > MAX_TABLE_ROWS && ` — showing first ${MAX_TABLE_ROWS}`}
+        {allCols.length > MAX_TABLE_COLS && `, first ${MAX_TABLE_COLS} cols`}
+      </div>
+    </>
+  );
+}
+
+function RunCellInner({ league, endpoint, params: seedParams, parsed, section, title }) {
+  const { useMemo, useState } = React;
+
+  const sel = useMemo(() => resolveSelection(league, endpoint), [league, endpoint]);
+  const fields = useMemo(() => (sel.error ? [] : fieldsFor(sel)), [sel]);
+
+  // Seed params: explicit `params` prop wins, then the endpoint's declared
+  // defaults. Everything is held as a string (the inputs are text).
+  const [params, setParams] = useState(() => {
+    const out = {};
+    for (const f of fields) {
+      if (f.def !== undefined && f.def !== null) out[f.name] = String(f.def);
+    }
+    for (const [k, v] of Object.entries(seedParams || {})) {
+      if (v !== undefined && v !== null) out[k] = String(v);
+    }
+    return out;
+  });
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [status, setStatus] = useState(null);
+  const [rawData, setRawData] = useState(null);
+
+  const preview = useMemo(() => {
+    if (sel.error) return { url: null, error: sel.error };
+    try {
+      const url =
+        sel.kind === 'flat'
+          ? resolveFlatUrl(sel.def, params, FLAT_HOSTS)
+          : resolveUrl(sel.def, sel.lg, params, endpoints.hosts);
+      return { url, error: null };
+    } catch (e) {
+      return { url: null, error: String(e.message || e) };
+    }
+  }, [sel, params]);
+
+  const method = useMemo(() => {
+    if (sel.error) return '';
+    const m = sel.kind === 'flat' ? flatMethodName(sel.api, sel.short) : espnMethodName(league, sel.short);
+    const entries = Object.entries(params).filter(([, v]) => v !== '' && v != null);
+    if (parsed) entries.push(['parsed', 'true']);
+    if (parsed && section) entries.push(['section', section]);
+    const args = entries
+      .map(([k, v]) => {
+        const isBool = v === 'true' || v === 'false';
+        const isNum = /^-?\d+(\.\d+)?$/.test(v);
+        return `${k}: ${isBool || isNum ? v : `'${v}'`}`;
+      })
+      .join(', ');
+    return `await sdv.${league}.${m}(${args ? `{ ${args} }` : '{}'});`;
+  }, [sel, league, params, parsed, section]);
+
+  // Parse the cached payload client-side, exactly like the playground does.
+  const parsedView = useMemo(() => {
+    if (!parsed || sel.error || rawData == null) return null;
+    try {
+      if (sel.kind === 'espn' && sel.short === 'summary') {
+        const dict = parseEndpoint('espn', 'summary', rawData);
+        const sections = dict && typeof dict === 'object' ? Object.keys(dict) : [];
+        const active = section && sections.includes(section) ? section : sections[0];
+        return { rows: active ? dict[active] : [] };
+      }
+      const key = sel.kind === 'espn' ? sel.short : sel.def.parser;
+      const out = parseEndpoint(sel.kind, key, rawData);
+      if (out == null) return { error: 'No parser registered for this endpoint.' };
+      return { rows: out };
+    } catch (e) {
+      return { error: String(e.message || e) };
+    }
+  }, [parsed, sel, rawData, section]);
+
+  async function run() {
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    setRawData(null);
+    try {
+      const reqBody =
+        sel.kind === 'flat'
+          ? { api: sel.api, endpoint: sel.short, params }
+          : { league, endpoint: sel.short, params };
+      const res = await fetch('/api/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(reqBody),
+      });
+      setStatus(res.status);
+      const text = await res.text();
+      let data = null;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = null; // non-JSON body (CSV/HTML flat families)
+      }
+      setRawData(data);
+      if (!res.ok) setError(`Proxy returned ${res.status}.`);
+    } catch (e) {
+      setError(
+        `Request failed: ${String(e.message || e)} — the live proxy runs on the ` +
+          'deployed site (Vercel); it is unavailable under plain `docusaurus start`.'
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (sel.error) {
+    return (
+      <div className={styles.cell}>
+        <div className={styles.err}>{sel.error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.cell}>
+      {title ? <div className={styles.title}>{title}</div> : null}
+
+      {fields.length > 0 && (
+        <div className={styles.params}>
+          {fields.map((f) => (
+            <label key={f.name} className={styles.field}>
+              <span className={styles.label}>
+                {f.name}
+                {f.required ? <span className={styles.req}>*</span> : null}
+              </span>
+              <input
+                className={styles.input}
+                value={params[f.name] ?? ''}
+                placeholder={f.def != null ? String(f.def) : ''}
+                onChange={(e) => setParams((p) => ({ ...p, [f.name]: e.target.value }))}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+
+      <div className={styles.urlRow}>
+        <span className={styles.urlTag}>GET</span>
+        {preview.error ? (
+          <span className={styles.err}>{preview.error}</span>
+        ) : (
+          <code className={styles.url}>{preview.url}</code>
+        )}
+      </div>
+
+      <div className={styles.runRow}>
+        <button className={styles.runBtn} onClick={run} disabled={loading || !!preview.error}>
+          {loading ? 'Running…' : 'Run ▶'}
+        </button>
+        <code className={styles.method}>{method}</code>
+      </div>
+
+      {error ? <div className={styles.err}>{error}</div> : null}
+
+      {rawData != null && parsed && parsedView ? (
+        parsedView.error ? (
+          <div className={styles.err}>{parsedView.error}</div>
+        ) : (
+          <CompactTable rows={parsedView.rows} />
+        )
+      ) : null}
+
+      {rawData != null && !parsed ? (
+        <pre className={styles.json}>
+          <code>{JSON.stringify(rawData, null, 2).slice(0, 4000)}</code>
+        </pre>
+      ) : null}
+
+      {status != null && rawData == null && !error ? (
+        <div className={styles.empty}>HTTP {status} — no JSON body returned.</div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * <RunCell league="nba" endpoint="espn:scoreboard" parsed /> — an SSR-safe,
+ * single-endpoint live runner for inline use in MDX guides.
+ *
+ * Props:
+ *   - league   (string, required)  league prefix, e.g. "nba"
+ *   - endpoint (string, required)  "espn:<short>" or "flat:<api>:<short>"
+ *   - params   (object)            default param values, e.g. {{ team_id: 13 }}
+ *   - parsed   (bool)              render a tidy table via parseEndpoint
+ *   - section  (string)            sub-frame name for the ESPN summary dispatcher
+ *   - title    (string)            optional heading above the cell
+ */
+export default function RunCell(props) {
+  return (
+    <BrowserOnly fallback={<div className={styles.cell}>Loading live cell…</div>}>
+      {() => <RunCellInner {...props} />}
+    </BrowserOnly>
+  );
+}

--- a/docs/src/components/RunCell/index.jsx
+++ b/docs/src/components/RunCell/index.jsx
@@ -9,19 +9,31 @@ import styles from './styles.module.css';
 // <RunCell> — a compact, single-endpoint live runner, droppable inline in an
 // MDX guide. It is a focused slice of the full <Playground>: one endpoint, a
 // small row of editable param inputs, the resolved GET URL, a Run button, and
-// the result (a tidy table when `parsed`, pretty JSON otherwise).
+// the result (a tidy table when `parsed`, pretty JSON / raw text otherwise).
 //
 // It reuses the playground's own infrastructure verbatim:
 //   - resolve.mjs        — builds the request URL (no network)
 //   - parsers.bundle.mjs — client-side parseEndpoint(kind, key, raw, section)
 //   - /api/run           — the Vercel serverless proxy (ESPN/flat send no CORS)
 //
+// Generalizations over the original PoC:
+//   - works for EVERY endpoint kind: ESPN (incl. `leagueParam` leagues like
+//     soccer, where a `league` slug field is injected) and every flat family
+//     (MLB Stats, NHL ×4, NFL.com, Statcast, odds, CBS/Fox/Yahoo, 247);
+//   - the ESPN `summary` dispatcher gets a live section <select> (mirrors the
+//     Playground) so a reader can flip between the 21 sub-frames after running;
+//   - params are seeded from endpoints.json metadata, and a small curated ENUM
+//     map renders a <select> for well-known closed-set params (season_type,
+//     csv, game_type, …) with a text input fallback everywhere else;
+//   - non-JSON upstreams (Statcast CSV / HTML) keep their raw text and render it
+//     instead of silently showing nothing.
+//
 // Props:
-//   league   (string)  league prefix, e.g. "nba"
+//   league   (string)  league / namespace prefix, e.g. "nba", "soccer", "fox"
 //   endpoint (string)  "espn:<short>" or "flat:<api>:<short>"
 //   params   (object)  default param values, e.g. { team_id: 13 }
 //   parsed   (bool)    run the response through parseEndpoint and show a table
-//   section  (string)  for the ESPN summary dispatcher, pick one sub-frame
+//   section  (string)  for the ESPN summary dispatcher, the initial sub-frame
 //   title    (string)  optional heading above the cell
 // ---------------------------------------------------------------------------
 
@@ -30,6 +42,23 @@ const FLAT_HOSTS = endpoints.flatHosts || {};
 
 const MAX_TABLE_ROWS = 25;
 const MAX_TABLE_COLS = 12;
+
+// Curated closed-set options for well-known params. endpoints.json carries no
+// enum metadata (only name/queryKey/default/required), so this small map lets a
+// reader pick from a dropdown for the handful of params with a real fixed set.
+// Anything not listed here renders as a free-text input. Keyed by param name.
+const ENUM_PARAMS = {
+  season_type: ['REG', 'POST', 'PRE', '1', '2', '3'],
+  game_type: ['2', '1', '3'], // NHL/Statcast: 2 = regular season
+  csv: ['true', 'false'],
+  all: ['true', 'false'],
+  positions: ['forwards', 'defensemen', 'goalies'],
+  roster_type: ['active', 'fullSeason', '40Man', 'depthChart'],
+  player_type: ['pitcher', 'batter'],
+  include_drive_chart: ['true', 'false'],
+  include_replays: ['true', 'false'],
+  include_standings: ['true', 'false'],
+};
 
 /** snake_case -> camelCase (espn_nba_scoreboard -> espnNbaScoreboard). */
 const toCamel = (s) => s.replace(/_([a-z0-9])/g, (_m, c) => c.toUpperCase());
@@ -53,14 +82,34 @@ function resolveSelection(league, endpoint) {
   return { kind: 'espn', def, short, lg };
 }
 
-/** Editable fields for a selection (path + query params), with seeded defaults. */
+/**
+ * Editable fields for a selection (league slug + path + query params), with
+ * seeded defaults. Mirrors the Playground's `fieldsFor`: a `league` field is
+ * injected for ESPN `leagueParam` leagues (soccer) so the reader can pick the
+ * competition slug. Each field carries `options` when it's in ENUM_PARAMS.
+ */
 function fieldsFor(sel) {
   const fields = [];
+  if (sel.kind === 'espn' && sel.lg && sel.lg.leagueParam) {
+    fields.push({ name: 'league', required: false, def: sel.lg.league, kind: 'league' });
+  }
   for (const p of sel.def.pathParams || []) {
-    fields.push({ name: p.name, required: p.required !== false, def: p.default });
+    fields.push({
+      name: p.name,
+      required: p.required !== false,
+      def: p.default,
+      kind: 'path',
+      options: ENUM_PARAMS[p.name],
+    });
   }
   for (const p of sel.def.queryParams || []) {
-    fields.push({ name: p.name, required: false, def: p.default });
+    fields.push({
+      name: p.name,
+      required: false,
+      def: p.default,
+      kind: 'query',
+      options: ENUM_PARAMS[p.name],
+    });
   }
   return fields;
 }
@@ -113,14 +162,14 @@ function CompactTable({ rows }) {
   );
 }
 
-function RunCellInner({ league, endpoint, params: seedParams, parsed, section, title }) {
+function RunCellInner({ league, endpoint, params: seedParams, parsed, section: initialSection, title }) {
   const { useMemo, useState } = React;
 
   const sel = useMemo(() => resolveSelection(league, endpoint), [league, endpoint]);
   const fields = useMemo(() => (sel.error ? [] : fieldsFor(sel)), [sel]);
 
   // Seed params: explicit `params` prop wins, then the endpoint's declared
-  // defaults. Everything is held as a string (the inputs are text).
+  // defaults. Everything is held as a string (the inputs are text/select).
   const [params, setParams] = useState(() => {
     const out = {};
     for (const f of fields) {
@@ -132,10 +181,17 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
     return out;
   });
 
+  // Active summary sub-frame (only meaningful for espn:summary). Seeded from the
+  // `section` prop; the reader can change it live via the dropdown after a run.
+  const [section, setSection] = useState(initialSection || null);
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [status, setStatus] = useState(null);
   const [rawData, setRawData] = useState(null);
+  const [rawText, setRawText] = useState(null);
+
+  const isSummary = sel.kind === 'espn' && sel.short === 'summary';
 
   const preview = useMemo(() => {
     if (sel.error) return { url: null, error: sel.error };
@@ -155,7 +211,7 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
     const m = sel.kind === 'flat' ? flatMethodName(sel.api, sel.short) : espnMethodName(league, sel.short);
     const entries = Object.entries(params).filter(([, v]) => v !== '' && v != null);
     if (parsed) entries.push(['parsed', 'true']);
-    if (parsed && section) entries.push(['section', section]);
+    if (parsed && isSummary && section) entries.push(['section', section]);
     const args = entries
       .map(([k, v]) => {
         const isBool = v === 'true' || v === 'false';
@@ -164,32 +220,39 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
       })
       .join(', ');
     return `await sdv.${league}.${m}(${args ? `{ ${args} }` : '{}'});`;
-  }, [sel, league, params, parsed, section]);
+  }, [sel, league, params, parsed, isSummary, section]);
 
-  // Parse the cached payload client-side, exactly like the playground does.
+  // Parse the cached payload client-side, exactly like the playground does. For
+  // the summary dispatcher we surface the full section list so the dropdown can
+  // flip between sub-frames without a re-run.
   const parsedView = useMemo(() => {
     if (!parsed || sel.error || rawData == null) return null;
     try {
-      if (sel.kind === 'espn' && sel.short === 'summary') {
+      if (isSummary) {
         const dict = parseEndpoint('espn', 'summary', rawData);
         const sections = dict && typeof dict === 'object' ? Object.keys(dict) : [];
         const active = section && sections.includes(section) ? section : sections[0];
-        return { rows: active ? dict[active] : [] };
+        return { kind: 'summary', sections, active, rows: active ? dict[active] : [] };
       }
       const key = sel.kind === 'espn' ? sel.short : sel.def.parser;
+      if (!key) return { error: 'No parser registered for this endpoint.' };
       const out = parseEndpoint(sel.kind, key, rawData);
       if (out == null) return { error: 'No parser registered for this endpoint.' };
-      return { rows: out };
+      return { kind: 'table', rows: out };
     } catch (e) {
       return { error: String(e.message || e) };
     }
-  }, [parsed, sel, rawData, section]);
+  }, [parsed, sel, rawData, section, isSummary]);
+
+  // Does the selected flat endpoint even have a parser? ESPN shorts always do.
+  const hasParser = sel.error ? false : sel.kind === 'flat' ? !!sel.def.parser : true;
 
   async function run() {
     setLoading(true);
     setError(null);
     setStatus(null);
     setRawData(null);
+    setRawText(null);
     try {
       const reqBody =
         sel.kind === 'flat'
@@ -202,14 +265,13 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
       });
       setStatus(res.status);
       const text = await res.text();
-      let data = null;
+      setRawText(text);
       try {
-        data = JSON.parse(text);
+        setRawData(JSON.parse(text));
       } catch {
-        data = null; // non-JSON body (CSV/HTML flat families)
+        setRawData(null); // non-JSON body (CSV/HTML flat families)
       }
-      setRawData(data);
-      if (!res.ok) setError(`Proxy returned ${res.status}.`);
+      if (!res.ok) setError(`Proxy / upstream returned ${res.status}.`);
     } catch (e) {
       setError(
         `Request failed: ${String(e.message || e)} — the live proxy runs on the ` +
@@ -228,6 +290,9 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
     );
   }
 
+  const showParsedTable = parsed && hasParser;
+  const prettyRaw = rawData != null ? JSON.stringify(rawData, null, 2) : rawText;
+
   return (
     <div className={styles.cell}>
       {title ? <div className={styles.title}>{title}</div> : null}
@@ -240,12 +305,27 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
                 {f.name}
                 {f.required ? <span className={styles.req}>*</span> : null}
               </span>
-              <input
-                className={styles.input}
-                value={params[f.name] ?? ''}
-                placeholder={f.def != null ? String(f.def) : ''}
-                onChange={(e) => setParams((p) => ({ ...p, [f.name]: e.target.value }))}
-              />
+              {f.options ? (
+                <select
+                  className={styles.input}
+                  value={params[f.name] ?? ''}
+                  onChange={(e) => setParams((p) => ({ ...p, [f.name]: e.target.value }))}
+                >
+                  <option value="">—</option>
+                  {f.options.map((o) => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  className={styles.input}
+                  value={params[f.name] ?? ''}
+                  placeholder={f.def != null ? String(f.def) : ''}
+                  onChange={(e) => setParams((p) => ({ ...p, [f.name]: e.target.value }))}
+                />
+              )}
             </label>
           ))}
         </div>
@@ -265,11 +345,26 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
           {loading ? 'Running…' : 'Run ▶'}
         </button>
         <code className={styles.method}>{method}</code>
+        {showParsedTable && parsedView?.kind === 'summary' && parsedView.sections?.length > 0 && (
+          <select
+            className={styles.sectionSelect}
+            value={parsedView.active || ''}
+            onChange={(e) => setSection(e.target.value)}
+            title="Pick a summary sub-frame"
+          >
+            {parsedView.sections.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {error ? <div className={styles.err}>{error}</div> : null}
 
-      {rawData != null && parsed && parsedView ? (
+      {/* Parsed → a tidy table (or the parser's "no parser" note). */}
+      {showParsedTable && parsedView ? (
         parsedView.error ? (
           <div className={styles.err}>{parsedView.error}</div>
         ) : (
@@ -277,14 +372,22 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
         )
       ) : null}
 
-      {rawData != null && !parsed ? (
+      {/* Raw JSON (parsed off, or no parser). */}
+      {!showParsedTable && rawData != null ? (
         <pre className={styles.json}>
           <code>{JSON.stringify(rawData, null, 2).slice(0, 4000)}</code>
         </pre>
       ) : null}
 
-      {status != null && rawData == null && !error ? (
-        <div className={styles.empty}>HTTP {status} — no JSON body returned.</div>
+      {/* Non-JSON upstream (Statcast CSV / HTML): show the raw text body. */}
+      {!showParsedTable && rawData == null && rawText ? (
+        <pre className={styles.json}>
+          <code>{rawText.slice(0, 4000)}{rawText.length > 4000 ? '\n… (truncated)' : ''}</code>
+        </pre>
+      ) : null}
+
+      {status != null && rawData == null && !rawText && !error ? (
+        <div className={styles.empty}>HTTP {status} — no body returned.</div>
       ) : null}
     </div>
   );
@@ -295,11 +398,11 @@ function RunCellInner({ league, endpoint, params: seedParams, parsed, section, t
  * single-endpoint live runner for inline use in MDX guides.
  *
  * Props:
- *   - league   (string, required)  league prefix, e.g. "nba"
+ *   - league   (string, required)  league / namespace prefix, e.g. "nba"
  *   - endpoint (string, required)  "espn:<short>" or "flat:<api>:<short>"
  *   - params   (object)            default param values, e.g. {{ team_id: 13 }}
  *   - parsed   (bool)              render a tidy table via parseEndpoint
- *   - section  (string)            sub-frame name for the ESPN summary dispatcher
+ *   - section  (string)            initial sub-frame for the ESPN summary dispatcher
  *   - title    (string)            optional heading above the cell
  */
 export default function RunCell(props) {

--- a/docs/src/components/RunCell/styles.module.css
+++ b/docs/src/components/RunCell/styles.module.css
@@ -1,0 +1,195 @@
+/* RunCell — a compact, single-endpoint live runner for inline use in guides.
+   A deliberately slimmed-down cousin of the full Playground styles. It reuses
+   the same CSS custom properties so it tracks the Docusaurus light/dark theme. */
+
+.cell {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  padding: 1rem;
+  background: var(--ifm-background-surface-color);
+  margin: 1.25rem 0;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-bottom: 0.6rem;
+}
+
+.params {
+  display: grid;
+  gap: 0.6rem 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-bottom: 0.75rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.req {
+  color: var(--ifm-color-danger);
+  font-weight: 700;
+}
+
+.input {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 7px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px var(--ifm-color-primary-lightest);
+}
+
+.runRow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.runBtn {
+  font: inherit;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0.4rem 0.85rem;
+  border-radius: 7px;
+  border: 1px solid var(--ifm-color-primary-dark);
+  background: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.runBtn:hover {
+  background: var(--ifm-color-primary-dark);
+}
+
+.runBtn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.method {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-700);
+  word-break: break-all;
+}
+
+.urlRow {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.urlTag {
+  font-weight: 700;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  color: #fff;
+  background: var(--ifm-color-success);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+  flex: 0 0 auto;
+}
+
+.url {
+  flex: 1 1 280px;
+  min-width: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.72rem;
+  word-break: break-all;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.err {
+  color: var(--ifm-color-danger);
+  font-size: 0.82rem;
+  margin-top: 0.4rem;
+}
+
+.tableWrap {
+  overflow-x: auto;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  margin-top: 0.5rem;
+}
+
+.table {
+  border-collapse: collapse;
+  font-size: 0.76rem;
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+}
+
+.table th,
+.table td {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  padding: 0.3rem 0.55rem;
+  text-align: left;
+  white-space: nowrap;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.table th {
+  background: var(--ifm-color-emphasis-100);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+}
+
+.rowNum {
+  color: var(--ifm-color-emphasis-500);
+  text-align: right;
+}
+
+.meta {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.4rem;
+}
+
+.json {
+  margin-top: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  background: var(--ifm-color-emphasis-100);
+  overflow: auto;
+  max-height: 360px;
+}
+
+.json code {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.76rem;
+  white-space: pre;
+}
+
+.empty {
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.5rem;
+}

--- a/docs/src/components/RunCell/styles.module.css
+++ b/docs/src/components/RunCell/styles.module.css
@@ -95,6 +95,18 @@
   word-break: break-all;
 }
 
+/* Live summary sub-frame picker, shown next to Run for the espn:summary cell. */
+.sectionSelect {
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: 6px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  margin-left: auto;
+}
+
 .urlRow {
   display: flex;
   align-items: baseline;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "docs": "typedoc",
     "codegen": "node tools/codegen/generate.mjs",
     "codegen:check": "node tools/codegen/generate.mjs --check",
-    "bundle:parsers": "esbuild src/parsers/index.ts --bundle --format=esm --platform=browser --legal-comments=eof --outfile=docs/src/playground/parsers.bundle.mjs"
+    "bundle:parsers": "esbuild src/parsers/index.ts --bundle --format=esm --platform=browser --legal-comments=eof --outfile=docs/src/playground/parsers.bundle.mjs",
+    "docs:examples": "node tools/docs/inject-outputs.mjs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "codegen": "node tools/codegen/generate.mjs",
     "codegen:check": "node tools/codegen/generate.mjs --check",
     "bundle:parsers": "esbuild src/parsers/index.ts --bundle --format=esm --platform=browser --legal-comments=eof --outfile=docs/src/playground/parsers.bundle.mjs",
-    "docs:examples": "node tools/docs/inject-outputs.mjs"
+    "docs:examples": "node tools/docs/inject-outputs.mjs",
+    "docs:examples:check": "node tools/docs/inject-outputs.mjs --check"
   },
   "repository": {
     "type": "git",

--- a/test/docs-examples.test.js
+++ b/test/docs-examples.test.js
@@ -1,0 +1,68 @@
+import 'should'; // side-effect: installs the `.should` assertion property
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { EXAMPLES } from '../tools/docs/examples.mjs';
+import * as bundle from '../docs/src/playground/parsers.bundle.mjs';
+
+// No-network guard for the docs output injector (tools/docs/inject-outputs.mjs)
+// + its manifest (tools/docs/examples.mjs). Each example freezes real parser
+// output into a guide between marker comments; this test checks the wiring is
+// internally consistent so a broken manifest entry fails CI before the docs
+// build. It runs the SAME committed parser bundle the injector + playground use.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, '..');
+const FIXTURE_DIRS = {
+  espn: join(REPO, 'test', 'fixtures', 'espn'),
+  tools: join(REPO, 'tools', 'docs', 'fixtures'),
+};
+const GUIDES = join(REPO, 'docs', 'docs', 'guides');
+
+describe('docs output-injector manifest is internally consistent', () => {
+  it('has at least one example per supported family', () => {
+    const families = new Set(EXAMPLES.map((e) => e.family));
+    families.has('espn').should.equal(true);
+    families.has('flat').should.equal(true);
+    families.has('espn-summary').should.equal(true);
+  });
+
+  for (const ex of EXAMPLES) {
+    describe(`example "${ex.id}" (${ex.family} → ${ex.target})`, () => {
+      it('points at a fixture that exists', () => {
+        const dir = FIXTURE_DIRS[ex.fixtureDir];
+        (dir == null).should.equal(false);
+        existsSync(join(dir, ex.fixture)).should.equal(true);
+      });
+
+      it('parses to a non-empty array of rows via the committed bundle', () => {
+        const dir = FIXTURE_DIRS[ex.fixtureDir];
+        const raw = JSON.parse(readFileSync(join(dir, ex.fixture), 'utf8'));
+        let rows;
+        if (ex.family === 'espn') {
+          rows = bundle.parseEndpoint('espn', ex.key, raw);
+        } else if (ex.family === 'flat') {
+          rows = bundle.parseEndpoint('flat', ex.parser, raw);
+        } else if (ex.family === 'espn-summary') {
+          const dict = bundle.parseEndpoint('espn', 'summary', raw);
+          dict.should.be.an.Object();
+          dict.should.have.property(ex.section);
+          rows = dict[ex.section];
+        } else {
+          throw new Error(`unknown family "${ex.family}"`);
+        }
+        rows.should.be.an.Array();
+        rows.length.should.be.above(0);
+      });
+
+      it('has matching inject markers in its target guide', () => {
+        const doc = readFileSync(join(GUIDES, ex.target), 'utf8');
+        const open = `<!-- inject:example:${ex.id} -->`;
+        const close = '<!-- /inject -->';
+        const start = doc.indexOf(open);
+        start.should.be.above(-1);
+        doc.indexOf(close, start).should.be.above(start);
+      });
+    });
+  }
+});

--- a/tools/docs/examples.mjs
+++ b/tools/docs/examples.mjs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------
+// examples.mjs — the manifest the build-time output injector reads.
+//
+// Each entry pairs a committed fixture + a parse target with the guide page +
+// marker id where its frozen table should land. inject-outputs.mjs runs every
+// entry through the SAME parser bundle the playground uses and writes the first
+// few rows × cols as a markdown table between the page's
+//   <!-- inject:example:<id> -->  ...  <!-- /inject -->
+// markers. It is deterministic (fixtures are committed, no network) so CI can
+// reproduce the exact tables and fail on drift (`--check`).
+//
+// Supported `family` kinds:
+//   - "espn"          ESPN array-frame parser: parseEndpoint('espn', key, raw)
+//                     → an array of row objects (scoreboard, standings, roster…).
+//   - "flat"          a flat (non-ESPN) parser: parseEndpoint('flat', parserName,
+//                     raw) → an array of row objects (MLB Stats, NHL ×4, NFL.com,
+//                     Statcast, odds, CBS/Fox/Yahoo, 247).
+//   - "espn-summary"  the ESPN summary dispatcher: parse the whole payload to its
+//                     dict-of-frames, then render ONE chosen `section` sub-frame.
+//
+// Fixture lookup:
+//   - `fixtureDir: "espn"`   → test/fixtures/espn/<fixture>     (committed captures)
+//   - `fixtureDir: "tools"`  → tools/docs/fixtures/<fixture>    (tiny inline samples
+//                              for flat families without a committed capture)
+//
+// `target` is the guide file relative to docs/docs/guides/. Add a new example by
+// dropping a fixture, then adding an entry here + the marker pair in the guide.
+// ---------------------------------------------------------------------------
+
+export const EXAMPLES = [
+  // --- ESPN array frames (quickstart) -------------------------------------
+  {
+    id: 'scoreboard',
+    family: 'espn',
+    fixtureDir: 'espn',
+    fixture: 'scoreboard_nba.json',
+    key: 'scoreboard',
+    target: '01-quickstart.mdx',
+    caption: '`sdv.nba.espnNbaScoreboard({ parsed: true })` — one row per game.',
+  },
+  {
+    id: 'standings',
+    family: 'espn',
+    fixtureDir: 'espn',
+    fixture: 'standings_nba.json',
+    key: 'standings',
+    target: '01-quickstart.mdx',
+    caption: '`sdv.nba.espnNbaStandings({ parsed: true })` — one row per team.',
+  },
+  {
+    id: 'team_roster',
+    family: 'espn',
+    fixtureDir: 'espn',
+    fixture: 'team_roster_nba.json',
+    key: 'team_roster',
+    target: '01-quickstart.mdx',
+    caption:
+      '`sdv.nba.espnNbaTeamRoster({ team_id: 13, parsed: true })` — one row per player.',
+  },
+
+  // --- ESPN summary dict-of-frames (one sub-frame) ------------------------
+  {
+    id: 'summary_leaders',
+    family: 'espn-summary',
+    fixtureDir: 'espn',
+    fixture: 'summary_nba.json',
+    section: 'leaders',
+    target: 'nba.mdx',
+    caption:
+      "`sdv.nba.espnNbaSummary({ event_id, parsed: true, section: 'leaders' })` — " +
+      'the `leaders` sub-frame of the 21-section summary dispatcher.',
+  },
+
+  // --- Flat-API parser frame ----------------------------------------------
+  {
+    id: 'nfl_standings',
+    family: 'flat',
+    fixtureDir: 'tools',
+    fixture: 'nfl_api_standings.json',
+    parser: 'parse_nfl_standings',
+    target: 'nfl.mdx',
+    caption:
+      '`sdv.nfl.nflApiStandings({ season: 2024, parsed: true })` — the native ' +
+      'NFL.com Shield standings, one row per team (sample fixture).',
+  },
+];

--- a/tools/docs/fixtures/nfl_api_standings.json
+++ b/tools/docs/fixtures/nfl_api_standings.json
@@ -1,0 +1,64 @@
+{
+  "_note": "Tiny hand-built sample for the docs output injector. Mirrors the api.nfl.com /football/v2/standings shape (raw.weeks[].standings[]) that parse_nfl_standings consumes. NOT a captured live payload — kept minimal & deterministic so the frozen doc table never drifts. Real data has ~32 teams and many more fields.",
+  "weeks": [
+    {
+      "season": 2024,
+      "seasonType": "REG",
+      "week": 18,
+      "standings": [
+        {
+          "team": { "abbreviation": "KC", "fullName": "Kansas City Chiefs" },
+          "conference": "AFC",
+          "division": "AFC West",
+          "wins": 15,
+          "losses": 2,
+          "ties": 0,
+          "winPct": 0.882,
+          "pointsFor": 372,
+          "pointsAgainst": 326,
+          "divisionRank": 1,
+          "conferenceRank": 1
+        },
+        {
+          "team": { "abbreviation": "BUF", "fullName": "Buffalo Bills" },
+          "conference": "AFC",
+          "division": "AFC East",
+          "wins": 13,
+          "losses": 4,
+          "ties": 0,
+          "winPct": 0.765,
+          "pointsFor": 525,
+          "pointsAgainst": 368,
+          "divisionRank": 1,
+          "conferenceRank": 2
+        },
+        {
+          "team": { "abbreviation": "DET", "fullName": "Detroit Lions" },
+          "conference": "NFC",
+          "division": "NFC North",
+          "wins": 15,
+          "losses": 2,
+          "ties": 0,
+          "winPct": 0.882,
+          "pointsFor": 564,
+          "pointsAgainst": 391,
+          "divisionRank": 1,
+          "conferenceRank": 1
+        },
+        {
+          "team": { "abbreviation": "PHI", "fullName": "Philadelphia Eagles" },
+          "conference": "NFC",
+          "division": "NFC East",
+          "wins": 14,
+          "losses": 3,
+          "ties": 0,
+          "winPct": 0.824,
+          "pointsFor": 433,
+          "pointsAgainst": 303,
+          "divisionRank": 1,
+          "conferenceRank": 2
+        }
+      ]
+    }
+  ]
+}

--- a/tools/docs/inject-outputs.mjs
+++ b/tools/docs/inject-outputs.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// inject-outputs.mjs — build-time "real output" injector (literate docs PoC).
+//
+// Runs a small set of example snippets at BUILD time and freezes their real
+// parsed output into a guide page, between HTML-comment markers. This gives the
+// "literate docs" benefit (the reader sees actual rows the parser produces)
+// without any client runtime — the tables are plain markdown in the committed
+// page.
+//
+// How it works:
+//   1. Each EXAMPLE names a committed ESPN fixture + a parse target (kind/key).
+//   2. We load the fixture and run it through the SAME parser bundle the
+//      playground uses (docs/src/playground/parsers.bundle.mjs, which runs in
+//      Node as-is — it's an esbuild-bundled ESM module).
+//   3. We render the first ~8 rows × ~6 cols as a markdown table (truncation
+//      noted), then inject it into the target guide between markers, e.g.
+//         <!-- inject:example:scoreboard -->  ...  <!-- /inject -->
+//
+// It is idempotent: re-running replaces the content between each marker pair.
+// It is deterministic: fixtures are committed, so there is NO network — CI can
+// reproduce the exact same tables. (The same injector could fetch live instead;
+// the fixture path is the PoC choice for reproducibility.)
+//
+// Usage:  node tools/docs/inject-outputs.mjs
+//         npm run docs:examples
+// ---------------------------------------------------------------------------
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO = join(__dirname, '..', '..');
+
+const FIXTURES = join(REPO, 'test', 'fixtures', 'espn');
+const PARSERS = join(REPO, 'docs', 'src', 'playground', 'parsers.bundle.mjs');
+const TARGET = join(REPO, 'docs', 'docs', 'guides', '01-quickstart.mdx');
+
+const MAX_ROWS = 8;
+const MAX_COLS = 6;
+
+// The PoC example set: id (matches the marker), fixture file, parse kind + key,
+// and a one-line caption rendered above the table.
+const EXAMPLES = [
+  {
+    id: 'scoreboard',
+    fixture: 'scoreboard_nba.json',
+    kind: 'espn',
+    key: 'scoreboard',
+    caption: '`sdv.nba.espnNbaScoreboard({ parsed: true })` — one row per game.',
+  },
+  {
+    id: 'standings',
+    fixture: 'standings_nba.json',
+    kind: 'espn',
+    key: 'standings',
+    caption: '`sdv.nba.espnNbaStandings({ parsed: true })` — one row per team.',
+  },
+  {
+    id: 'team_roster',
+    fixture: 'team_roster_nba.json',
+    kind: 'espn',
+    key: 'team_roster',
+    caption: '`sdv.nba.espnNbaTeamRoster({ team_id: 13, parsed: true })` — one row per player.',
+  },
+];
+
+/** Escape a value for a markdown table cell (no raw pipes/newlines). */
+function cell(v) {
+  if (v == null) return '';
+  let s = typeof v === 'object' ? JSON.stringify(v) : String(v);
+  s = s.replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+  if (s.length > 40) s = s.slice(0, 37) + '…';
+  return s;
+}
+
+/** Render rows -> a markdown table (first MAX_ROWS × MAX_COLS), with a note. */
+function renderTable(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return '_0 rows (empty frame)._';
+  }
+  const allCols = [...new Set(rows.flatMap((r) => Object.keys(r)))];
+  const cols = allCols.slice(0, MAX_COLS);
+  const shown = rows.slice(0, MAX_ROWS);
+
+  const header = `| ${cols.join(' | ')} |`;
+  const divider = `| ${cols.map(() => '---').join(' | ')} |`;
+  const body = shown
+    .map((r) => `| ${cols.map((c) => cell(r[c])).join(' | ')} |`)
+    .join('\n');
+
+  const truncBits = [];
+  if (rows.length > MAX_ROWS) truncBits.push(`${rows.length} rows total — first ${MAX_ROWS} shown`);
+  else truncBits.push(`${rows.length} rows`);
+  if (allCols.length > MAX_COLS) truncBits.push(`${allCols.length} cols total — first ${MAX_COLS} shown`);
+  else truncBits.push(`${allCols.length} cols`);
+
+  return `${header}\n${divider}\n${body}\n\n_${truncBits.join(', ')}._`;
+}
+
+/** Replace the content between `<!-- inject:example:ID -->` and `<!-- /inject -->`. */
+function injectBlock(doc, id, block) {
+  const open = `<!-- inject:example:${id} -->`;
+  const close = '<!-- /inject -->';
+  const start = doc.indexOf(open);
+  if (start === -1) {
+    console.warn(`  ! marker not found for "${id}" — skipped`);
+    return doc;
+  }
+  const end = doc.indexOf(close, start);
+  if (end === -1) {
+    console.warn(`  ! closing marker not found for "${id}" — skipped`);
+    return doc;
+  }
+  const before = doc.slice(0, start + open.length);
+  const after = doc.slice(end);
+  return `${before}\n\n${block}\n\n${after}`;
+}
+
+async function main() {
+  const parsers = await import(`file://${PARSERS.replace(/\\/g, '/')}`);
+  let doc = readFileSync(TARGET, 'utf8');
+
+  for (const ex of EXAMPLES) {
+    const raw = JSON.parse(readFileSync(join(FIXTURES, ex.fixture), 'utf8'));
+    const rows = parsers.parseEndpoint(ex.kind, ex.key, raw);
+    const count = Array.isArray(rows) ? rows.length : 0;
+    const block = `${ex.caption}\n\n${renderTable(rows)}`;
+    doc = injectBlock(doc, ex.id, block);
+    console.log(`  ✓ ${ex.id.padEnd(12)} ${ex.fixture.padEnd(24)} ${count} rows`);
+  }
+
+  writeFileSync(TARGET, doc);
+  console.log(`\nInjected ${EXAMPLES.length} example(s) into ${TARGET}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tools/docs/inject-outputs.mjs
+++ b/tools/docs/inject-outputs.mjs
@@ -1,70 +1,64 @@
 #!/usr/bin/env node
 // ---------------------------------------------------------------------------
-// inject-outputs.mjs — build-time "real output" injector (literate docs PoC).
+// inject-outputs.mjs — build-time "real output" injector (literate docs).
 //
-// Runs a small set of example snippets at BUILD time and freezes their real
-// parsed output into a guide page, between HTML-comment markers. This gives the
-// "literate docs" benefit (the reader sees actual rows the parser produces)
-// without any client runtime — the tables are plain markdown in the committed
-// page.
+// Runs a manifest of example snippets at BUILD time and freezes their real
+// parsed output into the guide pages, between HTML-comment markers. This gives
+// the "literate docs" benefit (the reader sees the actual rows the parser
+// produces) without any client runtime — the tables are plain markdown in the
+// committed page.
 //
 // How it works:
-//   1. Each EXAMPLE names a committed ESPN fixture + a parse target (kind/key).
-//   2. We load the fixture and run it through the SAME parser bundle the
-//      playground uses (docs/src/playground/parsers.bundle.mjs, which runs in
-//      Node as-is — it's an esbuild-bundled ESM module).
+//   1. The example set lives in tools/docs/examples.mjs (the MANIFEST) — each
+//      entry names a committed fixture + a parse target (family/key/parser/
+//      section) + the guide page + marker id where its table should land.
+//   2. We load each fixture and run it through the SAME parser bundle the
+//      playground uses (docs/src/playground/parsers.bundle.mjs, an esbuild
+//      ESM module that runs in Node as-is).
 //   3. We render the first ~8 rows × ~6 cols as a markdown table (truncation
 //      noted), then inject it into the target guide between markers, e.g.
 //         <!-- inject:example:scoreboard -->  ...  <!-- /inject -->
 //
+// Supported families (see examples.mjs for the contract):
+//   - "espn"          ESPN array-frame parser  → array of row objects.
+//   - "flat"          flat (non-ESPN) parser    → array of row objects.
+//   - "espn-summary"  ESPN summary dispatcher   → dict of frames; render one
+//                     chosen `section` sub-frame.
+//
 // It is idempotent: re-running replaces the content between each marker pair.
 // It is deterministic: fixtures are committed, so there is NO network — CI can
-// reproduce the exact same tables. (The same injector could fetch live instead;
-// the fixture path is the PoC choice for reproducibility.)
+// reproduce the exact same tables.
 //
-// Usage:  node tools/docs/inject-outputs.mjs
-//         npm run docs:examples
+// Usage:
+//   node tools/docs/inject-outputs.mjs           # write the frozen tables
+//   node tools/docs/inject-outputs.mjs --check    # CI drift gate: exit 1 if any
+//                                                 # guide is stale vs a fresh run
+//   npm run docs:examples                          # alias for the write mode
+//
+// The `--check` mode is wired into CI (.github/workflows/ci.yml, docs job) so a
+// committed guide whose frozen output no longer matches the parser fails the
+// build instead of silently drifting.
 // ---------------------------------------------------------------------------
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { EXAMPLES } from './examples.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO = join(__dirname, '..', '..');
 
-const FIXTURES = join(REPO, 'test', 'fixtures', 'espn');
+const FIXTURE_DIRS = {
+  espn: join(REPO, 'test', 'fixtures', 'espn'),
+  tools: join(__dirname, 'fixtures'),
+};
 const PARSERS = join(REPO, 'docs', 'src', 'playground', 'parsers.bundle.mjs');
-const TARGET = join(REPO, 'docs', 'docs', 'guides', '01-quickstart.mdx');
+const GUIDES = join(REPO, 'docs', 'docs', 'guides');
 
 const MAX_ROWS = 8;
 const MAX_COLS = 6;
 
-// The PoC example set: id (matches the marker), fixture file, parse kind + key,
-// and a one-line caption rendered above the table.
-const EXAMPLES = [
-  {
-    id: 'scoreboard',
-    fixture: 'scoreboard_nba.json',
-    kind: 'espn',
-    key: 'scoreboard',
-    caption: '`sdv.nba.espnNbaScoreboard({ parsed: true })` — one row per game.',
-  },
-  {
-    id: 'standings',
-    fixture: 'standings_nba.json',
-    kind: 'espn',
-    key: 'standings',
-    caption: '`sdv.nba.espnNbaStandings({ parsed: true })` — one row per team.',
-  },
-  {
-    id: 'team_roster',
-    fixture: 'team_roster_nba.json',
-    kind: 'espn',
-    key: 'team_roster',
-    caption: '`sdv.nba.espnNbaTeamRoster({ team_id: 13, parsed: true })` — one row per player.',
-  },
-];
+const CHECK = process.argv.includes('--check');
 
 /** Escape a value for a markdown table cell (no raw pipes/newlines). */
 function cell(v) {
@@ -99,40 +93,102 @@ function renderTable(rows) {
   return `${header}\n${divider}\n${body}\n\n_${truncBits.join(', ')}._`;
 }
 
+/** Run one manifest entry through the parser bundle → array of rows. */
+function rowsFor(parsers, ex) {
+  const dir = FIXTURE_DIRS[ex.fixtureDir];
+  if (!dir) throw new Error(`example "${ex.id}": unknown fixtureDir "${ex.fixtureDir}"`);
+  const raw = JSON.parse(readFileSync(join(dir, ex.fixture), 'utf8'));
+
+  if (ex.family === 'espn') {
+    return parsers.parseEndpoint('espn', ex.key, raw);
+  }
+  if (ex.family === 'flat') {
+    return parsers.parseEndpoint('flat', ex.parser, raw);
+  }
+  if (ex.family === 'espn-summary') {
+    const dict = parsers.parseEndpoint('espn', 'summary', raw);
+    if (!dict || typeof dict !== 'object') return [];
+    if (!(ex.section in dict)) {
+      throw new Error(`example "${ex.id}": summary section "${ex.section}" not found`);
+    }
+    return dict[ex.section];
+  }
+  throw new Error(`example "${ex.id}": unknown family "${ex.family}"`);
+}
+
+/** Build the full injected block (caption + table) for an entry. */
+function blockFor(parsers, ex) {
+  const rows = rowsFor(parsers, ex);
+  const count = Array.isArray(rows) ? rows.length : 0;
+  return { block: `${ex.caption}\n\n${renderTable(rows)}`, count };
+}
+
 /** Replace the content between `<!-- inject:example:ID -->` and `<!-- /inject -->`. */
 function injectBlock(doc, id, block) {
   const open = `<!-- inject:example:${id} -->`;
   const close = '<!-- /inject -->';
   const start = doc.indexOf(open);
-  if (start === -1) {
-    console.warn(`  ! marker not found for "${id}" — skipped`);
-    return doc;
-  }
+  if (start === -1) return { doc, found: false };
   const end = doc.indexOf(close, start);
-  if (end === -1) {
-    console.warn(`  ! closing marker not found for "${id}" — skipped`);
-    return doc;
-  }
+  if (end === -1) return { doc, found: false };
   const before = doc.slice(0, start + open.length);
   const after = doc.slice(end);
-  return `${before}\n\n${block}\n\n${after}`;
+  return { doc: `${before}\n\n${block}\n\n${after}`, found: true };
 }
 
 async function main() {
   const parsers = await import(`file://${PARSERS.replace(/\\/g, '/')}`);
-  let doc = readFileSync(TARGET, 'utf8');
 
+  // Group examples by target guide so each file is read + written once.
+  const byTarget = new Map();
   for (const ex of EXAMPLES) {
-    const raw = JSON.parse(readFileSync(join(FIXTURES, ex.fixture), 'utf8'));
-    const rows = parsers.parseEndpoint(ex.kind, ex.key, raw);
-    const count = Array.isArray(rows) ? rows.length : 0;
-    const block = `${ex.caption}\n\n${renderTable(rows)}`;
-    doc = injectBlock(doc, ex.id, block);
-    console.log(`  ✓ ${ex.id.padEnd(12)} ${ex.fixture.padEnd(24)} ${count} rows`);
+    if (!byTarget.has(ex.target)) byTarget.set(ex.target, []);
+    byTarget.get(ex.target).push(ex);
   }
 
-  writeFileSync(TARGET, doc);
-  console.log(`\nInjected ${EXAMPLES.length} example(s) into ${TARGET}`);
+  let staleFiles = 0;
+  let injected = 0;
+
+  for (const [target, exs] of byTarget) {
+    const path = join(GUIDES, target);
+    const original = readFileSync(path, 'utf8');
+    let doc = original;
+
+    for (const ex of exs) {
+      const { block, count } = blockFor(parsers, ex);
+      const res = injectBlock(doc, ex.id, block);
+      if (!res.found) {
+        console.warn(`  ! marker not found for "${ex.id}" in ${target} — skipped`);
+        continue;
+      }
+      doc = res.doc;
+      injected += 1;
+      console.log(`  ✓ ${ex.id.padEnd(18)} ${target.padEnd(20)} ${ex.family.padEnd(13)} ${count} rows`);
+    }
+
+    if (doc !== original) {
+      if (CHECK) {
+        staleFiles += 1;
+        console.error(`  ✗ STALE: ${target} — injected output differs from a fresh run`);
+      } else {
+        writeFileSync(path, doc);
+      }
+    }
+  }
+
+  if (CHECK) {
+    if (staleFiles > 0) {
+      console.error(
+        `\n${staleFiles} guide(s) have stale frozen output. ` +
+          'Run `npm run docs:examples` and commit the result.'
+      );
+      process.exit(1);
+    }
+    console.log(`\n✓ All ${injected} injected block(s) across ${byTarget.size} guide(s) are up to date.`);
+    return;
+  }
+
+  console.log(`\nInjected ${injected} example(s) across ${byTarget.size} guide(s).`);
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Live, runnable docs on `proto/live-docs`: an embeddable single-endpoint live runner wired into **every guide**, plus a manifest-driven build-time output injector with a CI drift gate. The package runtime (`src/`) is untouched — `npm test` stays green (1428 passing), and `cd docs && npx docusaurus build` → `[SUCCESS]`.

## A — `<RunCell>` in every guide
`docs/src/components/RunCell/{index.jsx,styles.module.css}` — a compact slice of the full Playground for ONE endpoint, droppable inline in an MDX guide.

- **Props:** `league`, `endpoint` (`"espn:scoreboard"` or `"flat:mlb_api:schedule"`), `params`, `parsed`, `section`, `title`.
- **21 RunCell cells across 9 guides**, every endpoint/param verified against `endpoints.json`:
  - **nba** — scoreboard, roster, summary · **wnba** — scoreboard, standings
  - **nfl** — espn scoreboard + native `flat:nfl_api:standings` · **mlb** — `flat:mlb_api:schedule` + `flat:mlb_statcast:leaderboard_bat_tracking` (CSV)
  - **nhl** — `flat:nhl_api_web:standings_season` + `flat:nhl_api_web:pbp` game feed
  - **cfb** — scoreboard + rankings · **college-basketball** — scoreboard + rankings
  - **soccer** — scoreboard + standings via the `league`-slug param (`leagueParam`)
  - **providers** — odds / cbs / fox / yahoo / 247, one cell each (api_key / headers noted where required)
- The remaining `.md` guides that needed a cell were converted to `.mdx` (cfb, mlb, nfl, wnba, college-basketball, soccer); all existing snippets + "Open in playground" links preserved.

## B — generalized components
**RunCell** now handles every endpoint kind robustly:
- every flat family + the soccer `leagueParam` (injects a `league` slug field);
- a **live section `<select>`** for the `espn:summary` dispatcher (flip between the 21 sub-frames after running, like the Playground);
- a **curated enum `<select>`** for well-known closed-set params (`season_type`, `csv`, `game_type`, `positions`, …) seeded from `endpoints.json` metadata, with a text-input fallback everywhere else; required-param markers retained;
- **graceful errors** — proxy-down under `docusaurus start` is messaged, and non-JSON upstreams (Statcast CSV/HTML) keep + render their raw text instead of showing nothing; stays SSR-safe via `BrowserOnly`.

**Injector** (`tools/docs/inject-outputs.mjs`):
- reads examples from a **manifest** (`tools/docs/examples.mjs`), not a hardcoded array;
- supports three families: ESPN **array frames**, **flat-API** parser frames (runs the flat parser on a fixture), and the ESPN **summary dict-of-frames** (renders one chosen sub-frame). A tiny inline NFL standings fixture lives under `tools/docs/fixtures/` for the flat family; ESPN fixtures reuse `test/fixtures/espn/`;
- frozen blocks now in **3 guides**: quickstart (×3 ESPN), nba (summary `leaders`), nfl (flat `parse_nfl_standings`);
- **`--check` drift mode** (`node tools/docs/inject-outputs.mjs --check`, script `docs:examples:check`) fails (exit 1) if any guide's injected block is stale vs a fresh run;
- **CI drift gate** wired into the existing `.github/workflows/ci.yml` **docs** job (a "Docs example-output drift check" step before the Docusaurus build), so frozen outputs can't silently drift;
- a no-network mocha test (`test/docs-examples.test.js`) validates the manifest ↔ fixture ↔ guide-marker wiring.

## Gates
- `npm run docs:examples` runs clean; `npm run docs:examples:check` passes after regen (and was verified to fail on real drift).
- `cd docs && npx docusaurus build` → `[SUCCESS]` (every `<RunCell>` import resolves; no MDX/broken-link errors).
- `npm test` → 1428 passing.

## Notes / limitations
- Statcast leaderboards stream **CSV**, so their RunCell shows the raw body (the package's `mlbStatcast*` parsers tidy it in Node; the browser cell surfaces it) — this is the intended non-JSON path.
- The Odds API cell needs **your** `api_key` (empty by default → 401 until filled); CBS uses opaque league slugs (`football-nfl`). Both are documented inline.
- RunCell's **Run ▶** needs the Vercel `/api/run` proxy, so it lights up on the deployed site, not under plain `docusaurus start`.
